### PR TITLE
fix travis-ci(#28): use shell script instead of aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ addons:
     - oracle-java8-set-default
 
 before_install:
-- shopt -s expand_aliases
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-- sudo curl -O https://www.antlr.org/download/antlr-4.7.1-complete.jar
+- sudo curl -o /usr/local/lib/antlr-4.7.1-complete.jar https://www.antlr.org/download/antlr-4.7.1-complete.jar
 - export CLASSPATH=".:/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH"
-- alias antlr4='java -jar /usr/local/lib/antlr-4.7.1-complete.jar'
-- alias grun='java org.antlr.v4.gui.TestRig'
+- mkdir $HOME/travis-bin
+- echo -e "#!/bin/bash\njava -jar /usr/local/lib/antlr-4.7.1-complete.jar" > $HOME/travis-bin/antlr4
+- echo -e "#!/bin/bash\njava org.antlr.v4.gui.TestRig" > $HOME/travis-bin/grun
+- chmod +x $HOME/travis-bin/*
+- export PATH=$PATH:$HOME/travis-bin

--- a/pkg/runtime/values/helpers.go
+++ b/pkg/runtime/values/helpers.go
@@ -215,6 +215,8 @@ func Parse(input interface{}) core.Value {
 		return obj
 	case []byte:
 		return NewBinary(input.([]byte))
+    case nil:
+        return None
 	default:
 		v := reflect.ValueOf(input)
 		t := reflect.TypeOf(input)


### PR DESCRIPTION
Fixes issue #28 
With this PR you can see that the [travis build is success here](https://travis-ci.com/krishnakarthik1309/ferret/builds/86870827) for branch `travis-ci`.

**PR Description**
Previously `travis-ci` is failing because its not able to identify aliases for `antlr4` and others. In this PR, aliases are substituted by one line shell script(created by `echo -e "command" > filename`).

Even after this modification the travis-build fails. The error is due to a test case in `pkg/stdlib/strings/json_test.go` where `JsonParse` was not able to parse `none`.
So I fixed that too by parsing value `None` if input is `nil`.