### PR TITLE
fix travis build: send arguments to antlr4 #28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - sudo curl -o /usr/local/lib/antlr-4.7.1-complete.jar https://www.antlr.org/download/antlr-4.7.1-complete.jar
 - export CLASSPATH=".:/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH"
 - mkdir $HOME/travis-bin
-- echo -e "#!/bin/bash\njava -jar /usr/local/lib/antlr-4.7.1-complete.jar" > $HOME/travis-bin/antlr4
-- echo -e "#!/bin/bash\njava org.antlr.v4.gui.TestRig" > $HOME/travis-bin/grun
+- echo -e '#!/bin/bash\njava -jar /usr/local/lib/antlr-4.7.1-complete.jar "$@"' > $HOME/travis-bin/antlr4
+- echo -e '#!/bin/bash\njava org.antlr.v4.gui.TestRig "$@"' > $HOME/travis-bin/grun
 - chmod +x $HOME/travis-bin/*
 - export PATH=$PATH:$HOME/travis-bin


### PR DESCRIPTION
In PR #35 arguments to `antlr4` were not passed. This PR uses `$@` to pass arguments to `antlr4` 