### PR TITLE
Fix race condition in WaitForNavigation

### DIFF
--- a/pkg/html/dynamic/document.go
+++ b/pkg/html/dynamic/document.go
@@ -557,26 +557,20 @@ func (doc *HTMLDocument) WaitForClassAll(selector, class values.String, timeout 
 }
 
 func (doc *HTMLDocument) WaitForNavigation(timeout values.Int) error {
-	timer := time.NewTimer(time.Millisecond * time.Duration(timeout))
-	onEvent := make(chan bool)
+	onEvent := make(chan struct{})
 	listener := func(_ interface{}) {
-		onEvent <- true
+		close(onEvent)
 	}
 
 	defer doc.events.RemoveEventListener("load", listener)
-	defer close(onEvent)
 
 	doc.events.AddEventListener("load", listener)
 
-	for {
-		select {
-		case <-onEvent:
-			timer.Stop()
-
-			return nil
-		case <-timer.C:
-			return core.ErrTimeout
-		}
+	select {
+	case <-onEvent:
+		return nil
+	case <-time.After(time.Millisecond * time.Duration(timeout)):
+		return core.ErrTimeout
 	}
 }
 


### PR DESCRIPTION
I'd been getting the occasional send on closed channel panic and found that there's a race condition where `listener` could be called after `WaitForNavigation` returns. The deferred close of `onEvent` seems to be the culprit. I also removed the unnecessary `for` loop around the `select`. The code should either time out and return an error, or the callback is called and the channel closed, and then the function returns successfully.  If the timeout occurs, the channel will eventually be garbage collected.