### PR TITLE
Adds WAIT_ELEMENT to sample as sometimes WAIT_NAVIGATION isn't sufficient

### DIFF
--- a/examples/input.fql
+++ b/examples/input.fql
@@ -4,6 +4,7 @@ INPUT(google, 'input[name="q"]', "ferret", 25)
 CLICK(google, 'input[name="btnK"]')
 
 WAIT_NAVIGATION(google)
+WAIT_ELEMENT(google, '.g')
 
 FOR result IN ELEMENTS(google, '.g')
     // filter out extra elements like videos and 'People also ask'


### PR DESCRIPTION
The page will often return an empty array because the search results haven't loaded although the navigation has occurred.