### PR TITLE
Add mutex and check if closed prior to closing

### DIFF
--- a/pkg/html/dynamic/document.go
+++ b/pkg/html/dynamic/document.go
@@ -558,8 +558,15 @@ func (doc *HTMLDocument) WaitForClassAll(selector, class values.String, timeout 
 
 func (doc *HTMLDocument) WaitForNavigation(timeout values.Int) error {
 	onEvent := make(chan struct{})
+	closed := false
+	var mu sync.Mutex
 	listener := func(_ interface{}) {
-		close(onEvent)
+		mu.Lock()
+		if !closed {
+			close(onEvent)
+			closed = true
+		}
+		mu.Unlock()
 	}
 
 	defer doc.events.RemoveEventListener("load", listener)

--- a/pkg/html/dynamic/document.go
+++ b/pkg/html/dynamic/document.go
@@ -558,6 +558,11 @@ func (doc *HTMLDocument) WaitForClassAll(selector, class values.String, timeout 
 
 func (doc *HTMLDocument) WaitForNavigation(timeout values.Int) error {
 	onEvent := make(chan struct{})
+
+	// There's an issue where the callback can get called more than once, thus
+	// causing a panic for trying to close a previously closed channel. This
+	// is a little hacky but is meant to prevent panics from attempting to close
+	// the channel again
 	closed := false
 	var mu sync.Mutex
 	listener := func(_ interface{}) {


### PR DESCRIPTION
I thought my previous PR fixed this problem, but it seems that the callback can get called more than once, causing a panic since the channel was already closed on a previous invocation. I haven't been able to figure out how/why, but it shouldn't cause the app to panic, so this is a stopgap until we can figure out what's going on.