### PR TITLE
Feature/#103 navigate back

### DIFF
--- a/examples/navigate_back.fql
+++ b/examples/navigate_back.fql
@@ -1,0 +1,7 @@
+LET origin = "https://github.com/"
+LET doc = DOCUMENT(origin, true)
+
+NAVIGATE(doc, "https://github.com/features")
+NAVIGATE_BACK(doc)
+
+RETURN doc.url == origin

--- a/examples/navigate_back_2.fql
+++ b/examples/navigate_back_2.fql
@@ -1,0 +1,9 @@
+LET origin = "https://github.com/"
+LET doc = DOCUMENT(origin, true)
+
+NAVIGATE(doc, "https://github.com/features")
+NAVIGATE(doc, "https://github.com/business")
+NAVIGATE(doc, "https://github.com/marketplace")
+NAVIGATE_BACK(doc, 3)
+
+RETURN doc.url == origin

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -2099,31 +2099,28 @@ func TestParam(t *testing.T) {
 	})
 }
 
-//func TestHtml(t *testing.T) {
-//	Convey("Should load a document", t, func() {
-//		c := compiler.New()
-//
-//		out, err := c.MustCompile(`
-//LET google = DOCUMENT("https://www.google.com/", true)
-//
-//INPUT(google, 'input[name="q"]', "ferret", 25)
-//CLICK(google, 'input[name="btnK"]')
-//
-//WAIT_NAVIGATION(google)
-//WAIT_ELEMENT(google, '.g', 5000)
-//
-//FOR result IN ELEMENTS(google, '.g')
-//    // filter out extra elements like videos and 'People also ask'
-//    FILTER TRIM(result.attributes.class) == 'g'
-//    RETURN {
-//        title: INNER_TEXT(result, 'h3'),
-//        description: INNER_TEXT(result, '.st'),
-//        url: INNER_TEXT(result, 'cite')
-//    }
-//			`).Run(context.Background())
-//
-//		So(err, ShouldBeNil)
-//
-//		So(string(out), ShouldEqual, `"int"`)
-//	})
-//}
+func TestHtml(t *testing.T) {
+	Convey("Should load a document", t, func() {
+		c := compiler.New()
+
+		out, err := c.MustCompile(`
+LET origin = "https://github.com/"
+LET doc = DOCUMENT(origin, true)
+
+NAVIGATE(doc, "https://github.com/features")
+
+LOG("NAVIGATE", doc.url)
+
+NAVIGATE_BACK(doc)
+
+LOG("NAVIGATE_BACK", doc.url)
+
+RETURN doc.url == origin
+
+			`).Run(context.Background())
+
+		So(err, ShouldBeNil)
+
+		So(string(out), ShouldEqual, `"int"`)
+	})
+}

--- a/pkg/compiler/compiler_test.go
+++ b/pkg/compiler/compiler_test.go
@@ -2099,28 +2099,28 @@ func TestParam(t *testing.T) {
 	})
 }
 
-func TestHtml(t *testing.T) {
-	Convey("Should load a document", t, func() {
-		c := compiler.New()
-
-		out, err := c.MustCompile(`
-LET origin = "https://github.com/"
-LET doc = DOCUMENT(origin, true)
-
-NAVIGATE(doc, "https://github.com/features")
-
-LOG("NAVIGATE", doc.url)
-
-NAVIGATE_BACK(doc)
-
-LOG("NAVIGATE_BACK", doc.url)
-
-RETURN doc.url == origin
-
-			`).Run(context.Background())
-
-		So(err, ShouldBeNil)
-
-		So(string(out), ShouldEqual, `"int"`)
-	})
-}
+//func TestHtml(t *testing.T) {
+//	Convey("Should load a document", t, func() {
+//		c := compiler.New()
+//
+//		out, err := c.MustCompile(`
+//LET origin = "https://github.com/"
+//LET doc = DOCUMENT(origin, true)
+//
+//NAVIGATE(doc, "https://github.com/features")
+//
+//LOG("NAVIGATE", doc.url)
+//
+//NAVIGATE_BACK(doc)
+//
+//LOG("NAVIGATE_BACK", doc.url)
+//
+//RETURN doc.url == origin
+//
+//			`).Run(context.Background())
+//
+//		So(err, ShouldBeNil)
+//
+//		So(string(out), ShouldEqual, `"int"`)
+//	})
+//}

--- a/pkg/html/dynamic/document.go
+++ b/pkg/html/dynamic/document.go
@@ -611,26 +611,23 @@ func (doc *HTMLDocument) NavigateBack(skip values.Int, timeout values.Int) (valu
 		return values.False, err
 	}
 
+	// we are in the beginning
+	if history.CurrentIndex == 0 {
+		return values.False, nil
+	}
+
 	if skip < 1 {
 		skip = 1
 	}
 
-	to := int(skip + 1)
-	length := len(history.Entries)
+	to := history.CurrentIndex - int(skip)
 
-	// no history
-	if length < to {
-		return values.False, nil
-	}
-
-	index := length - to
-
-	if index < 0 {
+	if to < 0 {
 		// TODO: Return error?
 		return values.False, nil
 	}
 
-	prev := history.Entries[length-to]
+	prev := history.Entries[to]
 	err = doc.client.Page.NavigateToHistoryEntry(ctx, page.NewNavigateToHistoryEntryArgs(prev.ID))
 
 	if err != nil {

--- a/pkg/stdlib/html/lib.go
+++ b/pkg/stdlib/html/lib.go
@@ -24,6 +24,7 @@ func NewLib() map[string]core.Function {
 		"CLICK":           Click,
 		"CLICK_ALL":       ClickAll,
 		"NAVIGATE":        Navigate,
+		"NAVIGATE_BACK":   NavigateBack,
 		"INPUT":           Input,
 		"INNER_HTML":      InnerHTML,
 		"INNER_HTML_ALL":  InnerHTMLAll,

--- a/pkg/stdlib/html/navigate_back.go
+++ b/pkg/stdlib/html/navigate_back.go
@@ -1,0 +1,62 @@
+package html
+
+import (
+	"context"
+	"github.com/MontFerret/ferret/pkg/html/dynamic"
+	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values"
+)
+
+/*
+ * Navigates a document back within its navigation history.
+ * The operation blocks the execution until the page gets loaded.
+ * If the history is empty, the function returns FALSE.
+ * @param doc (Document) - Target document.
+ * @param entry (Int, optional) - Optional value indicating how many pages to skip. Default 1.
+ * @param timeout (Int, optional) - Optional timeout. Default is 5000.
+ * @returns (Boolean) - Returns TRUE if history exists and the operation succeeded, otherwise FALSE.
+ */
+func NavigateBack(_ context.Context, args ...core.Value) (core.Value, error) {
+	err := core.ValidateArgs(args, 1, 3)
+
+	if err != nil {
+		return values.False, err
+	}
+
+	err = core.ValidateType(args[0], core.HTMLDocumentType)
+
+	if err != nil {
+		return values.None, err
+	}
+
+	doc, ok := args[0].(*dynamic.HTMLDocument)
+
+	if !ok {
+		return values.False, core.Errors(core.ErrInvalidType, ErrNotDynamic)
+	}
+
+	skip := values.NewInt(1)
+	timeout := values.NewInt(defaultTimeout)
+
+	if len(args) > 1 {
+		err = core.ValidateType(args[1], core.IntType)
+
+		if err != nil {
+			return values.None, err
+		}
+
+		skip = args[1].(values.Int)
+	}
+
+	if len(args) > 2 {
+		err = core.ValidateType(args[2], core.IntType)
+
+		if err != nil {
+			return values.None, err
+		}
+
+		timeout = args[2].(values.Int)
+	}
+
+	return doc.NavigateBack(skip, timeout)
+}


### PR DESCRIPTION
New ``NAVIGATE_BACK([skip, timeout]) -> boolean`` function.

 * Navigates a document back within its navigation history.
 * The operation blocks the execution until the page gets loaded.
 * If the history is empty, the function returns FALSE.
 * @param doc (Document) - Target document.
 * @param entry (Int, optional) - Optional value indicating how many pages to skip. Default 1.
 * @param timeout (Int, optional) - Optional timeout. Default is 5000.
 * @returns (Boolean) - Returns TRUE if history exists and the operation succeeded, otherwise FALSE.