### PR TITLE
Implement DOWNLOAD function

### DIFF
--- a/pkg/stdlib/html/blob.go
+++ b/pkg/stdlib/html/blob.go
@@ -3,6 +3,8 @@ package html
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"regexp"
 
 	"github.com/mafredri/cdp/protocol/page"
@@ -372,4 +374,29 @@ func PDF(ctx context.Context, args ...core.Value) (core.Value, error) {
 	}
 
 	return pdf, nil
+}
+
+// Download a ressource from the given URL.
+// @param URL (String) - URL to download.
+// @returns data (Binary) - Returns a base64 encoded string in binary format.
+func Download(_ context.Context, args ...core.Value) (core.Value, error) {
+	err := core.ValidateArgs(args, 1, 1)
+	if err != nil {
+		return values.None, err
+	}
+
+	arg1 := args[0]
+	err = core.ValidateType(arg1, core.StringType)
+	if err != nil {
+		return values.None, err
+	}
+	resp, err := http.Get(arg1.String())
+	if err != nil {
+		return values.None, err
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return values.None, err
+	}
+	return values.NewBinary(data), nil
 }

--- a/pkg/stdlib/html/lib.go
+++ b/pkg/stdlib/html/lib.go
@@ -34,5 +34,6 @@ func NewLib() map[string]core.Function {
 		"INNER_TEXT_ALL":   InnerTextAll,
 		"SCREENSHOT":       Screenshot,
 		"PDF":              PDF,
+		"DOWNLOAD":         Download,
 	}
 }


### PR DESCRIPTION
As discussed in #14, I have implement only the signature :
```aql
DOWNLOAD(url)
```
Because, as of right now, I think there is no way to detect whether or not a download is done or not with cdp. We should keep an eye on this [issue](https://github.com/GoogleChrome/puppeteer/issues/3360).