### PR TITLE
Fixed use of duplicate variable as a source in FOR IN statement

### DIFF
--- a/pkg/compiler/compiler_let_test.go
+++ b/pkg/compiler/compiler_let_test.go
@@ -197,4 +197,15 @@ func TestLet(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(string(out), ShouldEqual, "[1,2,3]")
 	})
+
+	Convey("Should not compile FOR foo IN foo", t, func() {
+		c := compiler.New()
+
+		_, err := c.Compile(`
+			FOR foo IN foo
+				RETURN foo
+		`)
+
+		So(err, ShouldNotBeNil)
+	})
 }

--- a/pkg/compiler/visitor.go
+++ b/pkg/compiler/visitor.go
@@ -160,23 +160,30 @@ func (v *visitor) doVisitForExpression(ctx *fql.ForExpressionContext, scope *sco
 	var keyVarName string
 
 	parsedClauses := make([]forOption, 0, 10)
-	valVar := ctx.ForExpressionValueVariable()
-	valVarName = valVar.GetText()
 	forInScope := scope.Fork()
-	forInScope.SetVariable(valVarName)
-
-	keyVar := ctx.ForExpressionKeyVariable()
-
-	if keyVar != nil {
-		keyVarName = keyVar.GetText()
-		forInScope.SetVariable(keyVarName)
-	}
 
 	srcCtx := ctx.ForExpressionSource().(*fql.ForExpressionSourceContext)
 	srcExp, err := v.doVisitForExpressionSource(srcCtx, forInScope)
 
 	if err != nil {
 		return nil, err
+	}
+
+	valVar := ctx.ForExpressionValueVariable()
+	valVarName = valVar.GetText()
+
+	if err := forInScope.SetVariable(valVarName); err != nil {
+		return nil, err
+	}
+
+	keyVar := ctx.ForExpressionKeyVariable()
+
+	if keyVar != nil {
+		keyVarName = keyVar.GetText()
+
+		if err := forInScope.SetVariable(keyVarName); err != nil {
+			return nil, err
+		}
 	}
 
 	src, err := expressions.NewDataSource(


### PR DESCRIPTION
Should not compile the following code

```
FOR foo IN foo 
    RETURN foo
```