### PR TITLE
Prevent memory leak

### DIFF
--- a/pkg/stdlib/html/blob.go
+++ b/pkg/stdlib/html/blob.go
@@ -394,6 +394,7 @@ func Download(_ context.Context, args ...core.Value) (core.Value, error) {
 	if err != nil {
 		return values.None, err
 	}
+	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return values.None, err


### PR DESCRIPTION
Not adding `resp.Body.Close()` will cause the TCP packet to leak since `go` expects us to close the query ([source](https://github.com/bradfitz/exp-httpclient/blob/master/problems.md)).