### PR TITLE
Allows simulated clicks to be canceled

### DIFF
--- a/pkg/drivers/cdp/document.go
+++ b/pkg/drivers/cdp/document.go
@@ -386,7 +386,7 @@ func (doc *HTMLDocument) ClickBySelector(selector values.String) (values.Boolean
 				return false;
 			}
 
-			var evt = new window.MouseEvent('click', { bubbles: true });
+			var evt = new window.MouseEvent('click', { bubbles: true, cancelable: true });
 			el.dispatchEvent(evt);
 
 			return true;
@@ -417,7 +417,7 @@ func (doc *HTMLDocument) ClickBySelectorAll(selector values.String) (values.Bool
 			}
 
 			elements.forEach((el) => {
-				var evt = new window.MouseEvent('click', { bubbles: true });
+				var evt = new window.MouseEvent('click', { bubbles: true, cancelable: true });
 				el.dispatchEvent(evt);	
 			});
 


### PR DESCRIPTION
User-generated mouse clicks are cancelable (and thus preventDefault() works), but the simulated MouseEvents were not cancelable.  This led to some sites to have different behavior between user-generated and simulated clicks.

See https://developer.mozilla.org/en-US/docs/Web/Events/click.