### PR TITLE
return the *FqlCompiler customed replace default

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -28,9 +28,7 @@ func New(setters ...Option) *FqlCompiler {
 		c.funcs = make(map[string]core.Function)
 	}
 
-	return &FqlCompiler{
-		stdlib.NewLib(),
-	}
+	return c
 }
 
 func (c *FqlCompiler) RegisterFunction(name string, fun core.Function) error {


### PR DESCRIPTION
I suppose you want to return the c, not the default with 'stdlib.NewLib'  which make the work done before meanless