### PR TITLE
Fixes WaitForNavigation race condition in #125

### DIFF
--- a/pkg/drivers/cdp/document.go
+++ b/pkg/drivers/cdp/document.go
@@ -707,8 +707,11 @@ func (doc *HTMLDocument) WaitForClassBySelectorAll(ctx context.Context, selector
 
 func (doc *HTMLDocument) WaitForNavigation(ctx context.Context) error {
 	onEvent := make(chan struct{})
+	var once sync.Once
 	listener := func(_ context.Context, _ interface{}) {
-		close(onEvent)
+		once.Do(func() {
+			close(onEvent)
+		})
 	}
 
 	defer doc.events.RemoveEventListener(events.EventLoad, listener)


### PR DESCRIPTION
When multiple redirects happen very quickly, sometimes the event handler will not be removed before the next page is loaded, so it will call the handler twice and panic because it's attempting to close a previously-closed channel.

Closes #125 