### PR TITLE
Added errors to ClickX methods and added existence check

### DIFF
--- a/pkg/drivers/cdp/document.go
+++ b/pkg/drivers/cdp/document.go
@@ -263,7 +263,7 @@ func (doc *HTMLDocument) CountBySelector(ctx context.Context, selector values.St
 	return doc.element.CountBySelector(ctx, selector)
 }
 
-func (doc *HTMLDocument) ExistsBySelector(ctx context.Context, selector values.String) values.Boolean {
+func (doc *HTMLDocument) ExistsBySelector(ctx context.Context, selector values.String) (values.Boolean, error) {
 	return doc.element.ExistsBySelector(ctx, selector)
 }
 
@@ -317,28 +317,16 @@ func (doc *HTMLDocument) GetURL() values.String {
 	return values.NewString(doc.frames.Frame.URL)
 }
 
-func (doc *HTMLDocument) ClickBySelector(ctx context.Context, selector values.String) (values.Boolean, error) {
-	if err := doc.input.ClickBySelector(ctx, doc.element.id.nodeID, selector); err != nil {
-		return values.False, err
-	}
-
-	return values.True, nil
+func (doc *HTMLDocument) ClickBySelector(ctx context.Context, selector values.String) error {
+	return doc.input.ClickBySelector(ctx, doc.element.id.nodeID, selector)
 }
 
-func (doc *HTMLDocument) ClickBySelectorAll(ctx context.Context, selector values.String) (values.Boolean, error) {
-	if err := doc.input.ClickBySelectorAll(ctx, doc.element.id.nodeID, selector); err != nil {
-		return values.False, err
-	}
-
-	return values.True, nil
+func (doc *HTMLDocument) ClickBySelectorAll(ctx context.Context, selector values.String) error {
+	return doc.input.ClickBySelectorAll(ctx, doc.element.id.nodeID, selector)
 }
 
-func (doc *HTMLDocument) InputBySelector(ctx context.Context, selector values.String, value core.Value, delay values.Int) (values.Boolean, error) {
-	if err := doc.input.TypeBySelector(ctx, doc.element.id.nodeID, selector, value, delay); err != nil {
-		return values.False, err
-	}
-
-	return values.True, nil
+func (doc *HTMLDocument) InputBySelector(ctx context.Context, selector values.String, value core.Value, delay values.Int) error {
+	return doc.input.TypeBySelector(ctx, doc.element.id.nodeID, selector, value, delay)
 }
 
 func (doc *HTMLDocument) SelectBySelector(ctx context.Context, selector values.String, value *values.Array) (*values.Array, error) {

--- a/pkg/drivers/http/document.go
+++ b/pkg/drivers/http/document.go
@@ -169,7 +169,7 @@ func (doc *HTMLDocument) CountBySelector(ctx context.Context, selector values.St
 	return doc.element.CountBySelector(ctx, selector)
 }
 
-func (doc *HTMLDocument) ExistsBySelector(ctx context.Context, selector values.String) values.Boolean {
+func (doc *HTMLDocument) ExistsBySelector(ctx context.Context, selector values.String) (values.Boolean, error) {
 	return doc.element.ExistsBySelector(ctx, selector)
 }
 
@@ -207,16 +207,16 @@ func (doc *HTMLDocument) GetParentDocument() drivers.HTMLDocument {
 	return doc.parent
 }
 
-func (doc *HTMLDocument) ClickBySelector(_ context.Context, _ values.String) (values.Boolean, error) {
-	return false, core.ErrNotSupported
+func (doc *HTMLDocument) ClickBySelector(_ context.Context, _ values.String) error {
+	return core.ErrNotSupported
 }
 
-func (doc *HTMLDocument) ClickBySelectorAll(_ context.Context, _ values.String) (values.Boolean, error) {
-	return false, core.ErrNotSupported
+func (doc *HTMLDocument) ClickBySelectorAll(_ context.Context, _ values.String) error {
+	return core.ErrNotSupported
 }
 
-func (doc *HTMLDocument) InputBySelector(_ context.Context, _ values.String, _ core.Value, _ values.Int) (values.Boolean, error) {
-	return false, core.ErrNotSupported
+func (doc *HTMLDocument) InputBySelector(_ context.Context, _ values.String, _ core.Value, _ values.Int) error {
+	return core.ErrNotSupported
 }
 
 func (doc *HTMLDocument) SelectBySelector(_ context.Context, _ values.String, _ *values.Array) (*values.Array, error) {

--- a/pkg/drivers/http/element.go
+++ b/pkg/drivers/http/element.go
@@ -467,14 +467,14 @@ func (el *HTMLElement) CountBySelector(_ context.Context, selector values.String
 	return values.NewInt(selection.Size())
 }
 
-func (el *HTMLElement) ExistsBySelector(_ context.Context, selector values.String) values.Boolean {
+func (el *HTMLElement) ExistsBySelector(_ context.Context, selector values.String) (values.Boolean, error) {
 	selection := el.selection.Closest(selector.String())
 
 	if selection == nil {
-		return values.False
+		return values.False, nil
 	}
 
-	return values.True
+	return values.True, nil
 }
 
 func (el *HTMLElement) GetIn(ctx context.Context, path []core.Value) (core.Value, error) {
@@ -489,8 +489,8 @@ func (el *HTMLElement) Iterate(_ context.Context) (core.Iterator, error) {
 	return common.NewIterator(el)
 }
 
-func (el *HTMLElement) Click(_ context.Context) (values.Boolean, error) {
-	return false, core.ErrNotSupported
+func (el *HTMLElement) Click(_ context.Context) error {
+	return core.ErrNotSupported
 }
 
 func (el *HTMLElement) Input(_ context.Context, _ core.Value, _ values.Int) error {

--- a/pkg/drivers/value.go
+++ b/pkg/drivers/value.go
@@ -40,7 +40,7 @@ type (
 
 		CountBySelector(ctx context.Context, selector values.String) values.Int
 
-		ExistsBySelector(ctx context.Context, selector values.String) values.Boolean
+		ExistsBySelector(ctx context.Context, selector values.String) (values.Boolean, error)
 
 		XPath(ctx context.Context, expression values.String) (core.Value, error)
 	}
@@ -93,7 +93,7 @@ type (
 
 		GetInnerTextBySelectorAll(ctx context.Context, selector values.String) (*values.Array, error)
 
-		Click(ctx context.Context) (values.Boolean, error)
+		Click(ctx context.Context) error
 
 		Input(ctx context.Context, value core.Value, delay values.Int) error
 
@@ -127,11 +127,11 @@ type (
 
 		GetChildDocuments(ctx context.Context) (*values.Array, error)
 
-		ClickBySelector(ctx context.Context, selector values.String) (values.Boolean, error)
+		ClickBySelector(ctx context.Context, selector values.String) error
 
-		ClickBySelectorAll(ctx context.Context, selector values.String) (values.Boolean, error)
+		ClickBySelectorAll(ctx context.Context, selector values.String) error
 
-		InputBySelector(ctx context.Context, selector values.String, value core.Value, delay values.Int) (values.Boolean, error)
+		InputBySelector(ctx context.Context, selector values.String, value core.Value, delay values.Int) error
 
 		SelectBySelector(ctx context.Context, selector values.String, value *values.Array) (*values.Array, error)
 

--- a/pkg/stdlib/html/click.go
+++ b/pkg/stdlib/html/click.go
@@ -26,7 +26,7 @@ func Click(ctx context.Context, args ...core.Value) (core.Value, error) {
 			return values.False, err
 		}
 
-		return el.Click(ctx)
+		return values.True, el.Click(ctx)
 	}
 
 	// CLICK(doc, selector)
@@ -36,7 +36,16 @@ func Click(ctx context.Context, args ...core.Value) (core.Value, error) {
 		return values.False, err
 	}
 
-	selector := args[1].String()
+	selector := values.ToString(args[1])
+	exists, err := doc.ExistsBySelector(ctx, selector)
 
-	return doc.ClickBySelector(ctx, values.NewString(selector))
+	if err != nil {
+		return values.False, err
+	}
+
+	if !exists {
+		return exists, nil
+	}
+
+	return exists, doc.ClickBySelector(ctx, selector)
 }

--- a/pkg/stdlib/html/click_all.go
+++ b/pkg/stdlib/html/click_all.go
@@ -25,7 +25,17 @@ func ClickAll(ctx context.Context, args ...core.Value) (core.Value, error) {
 		return values.None, err
 	}
 
-	selector := args[1].String()
+	selector := values.ToString(args[1])
 
-	return doc.ClickBySelectorAll(ctx, values.NewString(selector))
+	exists, err := doc.ExistsBySelector(ctx, selector)
+
+	if err != nil {
+		return values.False, err
+	}
+
+	if !exists {
+		return values.False, nil
+	}
+
+	return values.True, doc.ClickBySelectorAll(ctx, selector)
 }

--- a/pkg/stdlib/html/element_exists.go
+++ b/pkg/stdlib/html/element_exists.go
@@ -18,5 +18,5 @@ func ElementExists(ctx context.Context, args ...core.Value) (core.Value, error) 
 		return values.None, err
 	}
 
-	return el.ExistsBySelector(ctx, selector), nil
+	return el.ExistsBySelector(ctx, selector)
 }

--- a/pkg/stdlib/html/input.go
+++ b/pkg/stdlib/html/input.go
@@ -44,6 +44,7 @@ func Input(ctx context.Context, args ...core.Value) (core.Value, error) {
 			return values.False, err
 		}
 
+		selector := values.ToString(arg2)
 		delay := values.Int(0)
 
 		if len(args) == 4 {
@@ -55,10 +56,20 @@ func Input(ctx context.Context, args ...core.Value) (core.Value, error) {
 				return values.False, err
 			}
 
-			delay = arg4.(values.Int)
+			delay = values.ToInt(arg4)
 		}
 
-		return doc.InputBySelector(ctx, arg2.(values.String), args[2], delay)
+		exists, err := doc.ExistsBySelector(ctx, selector)
+
+		if err != nil {
+			return values.False, err
+		}
+
+		if !exists {
+			return values.False, nil
+		}
+
+		return values.True, doc.InputBySelector(ctx, selector, args[2], delay)
 	}
 
 	el, err := drivers.ToElement(arg1)

--- a/pkg/stdlib/html/pagination.go
+++ b/pkg/stdlib/html/pagination.go
@@ -95,11 +95,11 @@ func (i *PagingIterator) Next(ctx context.Context) (core.Value, core.Value, erro
 	exists, err := i.document.ExistsBySelector(ctx, i.selector)
 
 	if err != nil {
-		return values.ZeroInt, values.ZeroInt, err
+		return values.None, values.None, err
 	}
 
 	if !exists {
-		return values.ZeroInt, values.ZeroInt, core.ErrNoMoreData
+		return values.None, values.None, core.ErrNoMoreData
 	}
 
 	err = i.document.ClickBySelector(ctx, i.selector)

--- a/pkg/stdlib/html/pagination.go
+++ b/pkg/stdlib/html/pagination.go
@@ -92,11 +92,17 @@ func (i *PagingIterator) Next(ctx context.Context) (core.Value, core.Value, erro
 		return values.ZeroInt, values.ZeroInt, nil
 	}
 
-	if !i.document.ExistsBySelector(ctx, i.selector) {
+	exists, err := i.document.ExistsBySelector(ctx, i.selector)
+
+	if err != nil {
+		return values.ZeroInt, values.ZeroInt, err
+	}
+
+	if !exists {
 		return values.ZeroInt, values.ZeroInt, core.ErrNoMoreData
 	}
 
-	_, err := i.document.ClickBySelector(ctx, i.selector)
+	err = i.document.ClickBySelector(ctx, i.selector)
 
 	if err != nil {
 		return values.None, values.None, err


### PR DESCRIPTION
In 0.7 ``CLICK`` and ``CLICK_ALL`` was doing a check before clicking and was returning a boolean value indicating whether a target element was clicked.
In 0.8 this logic got broken and the check is not performed.