### PR TITLE
replace oracle-java to openjdk in travis #344

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ go:
 addons:
   apt:
     packages:
-    - oracle-java9-set-default
+    - openjdk-9-jre-headless
   chrome: stable
 
 install:


### PR DESCRIPTION
fixes #344 
I replaced oracle-java to openjdk, then I checked that is fine in travis-ci.
