### PR TITLE
 Load HTML pages from memory #385 

### DIFF
--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -2,8 +2,9 @@ package drivers
 
 import (
 	"context"
-	"github.com/MontFerret/ferret/pkg/runtime/core"
 	"io"
+
+	"github.com/MontFerret/ferret/pkg/runtime/core"
 )
 
 type (
@@ -18,6 +19,7 @@ type (
 		io.Closer
 		Name() string
 		Open(ctx context.Context, params Params) (HTMLPage, error)
+		Parse(ctx context.Context, content []byte) (HTMLPage, error)
 	}
 )
 

--- a/pkg/drivers/http/driver.go
+++ b/pkg/drivers/http/driver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/MontFerret/ferret/pkg/drivers"
 	"github.com/MontFerret/ferret/pkg/drivers/common"
 	"github.com/MontFerret/ferret/pkg/runtime/logging"
-	"github.com/MontFerret/ferret/pkg/runtime/values"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/pkg/errors"
 	"github.com/sethgrid/pester"
@@ -178,8 +177,8 @@ func (drv *Driver) Open(ctx context.Context, params drivers.Params) (drivers.HTM
 	return NewHTMLPage(doc, params.URL, &r, cookies)
 }
 
-func (drv *Driver) Parse(_ context.Context, str values.String) (drivers.HTMLPage, error) {
-	buf := bytes.NewBuffer([]byte(str))
+func (drv *Driver) Parse(_ context.Context, content []byte) (drivers.HTMLPage, error) {
+	buf := bytes.NewBuffer(content)
 
 	doc, err := goquery.NewDocumentFromReader(buf)
 

--- a/pkg/stdlib/html/html_parse.go
+++ b/pkg/stdlib/html/html_parse.go
@@ -1,0 +1,59 @@
+package html
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/MontFerret/ferret/pkg/drivers"
+	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values"
+	"github.com/MontFerret/ferret/pkg/runtime/values/types"
+)
+
+type HtmlParseParams struct {
+	FileName string
+	Driver   string
+}
+
+// HTML_PARSE loads an HTML page from a local file
+// By default, loads a page by http call - resulted page does not support any interactions.
+// @param params (Object) - Optional, An object containing the following properties :
+// 		driver (String) - Optional, driver name.
+// @returns (HTMLPage) - Returns loaded HTML page.
+func HTMLParse(ctx context.Context, args ...core.Value) (core.Value, error) {
+	err := core.ValidateArgs(args, 1, 2)
+
+	if err != nil {
+		return values.None, err
+	}
+
+	err = core.ValidateType(args[0], types.String)
+
+	if err != nil {
+		return values.None, err
+	}
+
+	var params PageLoadParams
+
+	if len(args) > 1 {
+		p, err := newPageLoadParams("about:blank", args[1])
+
+		if err != nil {
+			return values.None, err
+		}
+
+		params = p
+	}
+
+	b, err := ioutil.ReadFile(args[0].String())
+	if err != nil {
+		return values.None, err
+	}
+
+	drv, err := drivers.FromContext(ctx, params.Driver)
+	if err != nil {
+		return values.None, err
+	}
+
+	return drv.Parse(ctx, b)
+}

--- a/pkg/stdlib/html/lib.go
+++ b/pkg/stdlib/html/lib.go
@@ -28,6 +28,7 @@ func RegisterLib(ns core.Namespace) error {
 		"ELEMENTS":          Elements,
 		"ELEMENTS_COUNT":    ElementsCount,
 		"FOCUS":             Focus,
+		"HTML_PARSE":        HTMLParse,
 		"HOVER":             Hover,
 		"INNER_HTML":        GetInnerHTML,
 		"INNER_HTML_SET":    SetInnerHTML,


### PR DESCRIPTION
For https://github.com/MontFerret/ferret/issues/385

The http version is tested and works with examples/static-page.fql.

The cdp version has the problem that the default write buffer size is 4096 so SetDocumentContent cannot load files larger than that (it returns the error: "cdp.Page: SetDocumentContent: cdp.Target: SendMessageToTarget: rpcc: message too large...").

This can be fixed by setting the buffer size in Driver.init(...), but I have not looked into it further.

The cdp version has been tested with the following simple example:
```
<!DOCTYPE html>
<html>
<body>Test</body>
</html>
```
```
LET doc = HTML_PARSE("test.html", {driver:"cdp"})
LET str = ELEMENT(doc, "body")
RETURN str
```