### PR TITLE
Event broker performance improvement

### DIFF
--- a/pkg/drivers/cdp/events/broker.go
+++ b/pkg/drivers/cdp/events/broker.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/mafredri/cdp/protocol/dom"
 	"github.com/mafredri/cdp/protocol/page"
 
-	"github.com/MontFerret/ferret/pkg/drivers"
 	"github.com/MontFerret/ferret/pkg/runtime/core"
 )
 
@@ -282,11 +280,7 @@ func (broker *EventBroker) emit(ctx context.Context, event Event, message interf
 		case <-ctx.Done():
 			return
 		default:
-			ctx2, fn := context.WithTimeout(ctx, time.Duration(drivers.DefaultTimeout)*time.Millisecond)
-
-			listener(ctx2, message)
-
-			fn()
+			listener(ctx, message)
 		}
 	}
 }


### PR DESCRIPTION
I removed the somewhat arbitrary `WithTimeout()` call in the `emit()` function.

As far as I can see, this serves no real purpose. It doesn't matter if event callbacks "expire" after 30 seconds or not, because the callbacks will get canceled regardless:

1) when the user wants to close a `cdp.Page`, event broker's context gets canceled, which means all event callbacks get canceled as well.
2) a cdp-related error occurs, in which case the event callbacks themselves will process the error.

This timeout context served as a "just in case" measure that isn't necessary and is detrimental to performance.

Some sites require you to create a huge amount of elements (1000+ per second). During 15 minutes of scraping, because of this `WithTimeout()` call, my app allocated over 4.5M contexts which require 4.5M of allocations, mutex acquisitons, and goroutine creations each. 

This change improved the performance of my sites by 1-2 orders of magnitude.