### PR TITLE
Bugfix for changes in PR #402

### DIFF
--- a/pkg/drivers/cdp/events/broker.go
+++ b/pkg/drivers/cdp/events/broker.go
@@ -191,6 +191,9 @@ func (broker *EventBroker) StopAndClose() error {
 func (broker *EventBroker) runLoop(ctx context.Context) {
 	for {
 		select {
+		case <-ctx.Done():
+			return
+
 		case <-broker.onLoad.Ready():
 			if ctxDone(ctx) {
 				return


### PR DESCRIPTION
This PR fixes a bug where runLoop would never end in some cases.

If a cdp connection is terminated due to network errors its event clients might not get closed properly (this might even be a bug in the cdp library, because this doesn't happen every time).

Adding a case which checks if the context has been canceled fixes this. I forgot to add this case in my initial PR. Sorry for that!