### PR TITLE
Fix REPL welcome text

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ ferret
 
 ```shell
 Welcome to Ferret REPL
-Please use `Ctrl-D` to exit this program.
+Please use `exit` or `Ctrl-D` to exit this program.
 >%
 >LET doc = DOCUMENT('https://news.ycombinator.com/')
 >FOR post IN ELEMENTS(doc, '.storylink')


### PR DESCRIPTION
Small fix to match the current REPL welcome

<img width="583" alt="ferrer-repl" src="https://user-images.githubusercontent.com/418747/79759949-ae264a00-8362-11ea-961a-1bcdc1bcc802.png">
