### PR TITLE
Added fuzzer

### DIFF
--- a/pkg/compiler/fuzz/fuzz.go
+++ b/pkg/compiler/fuzz/fuzz.go
@@ -4,11 +4,14 @@ import (
 	"github.com/MontFerret/ferret/pkg/compiler"
 )
 
-// This function is our fuzzer
+// Below function is our fuzzer.
+// The fuzzer is run on oss-fuzz.
+// Link to the project on oss-fuzz
+// will be added once the project is up.
 func Fuzz(data []byte) int {
 	c := compiler.New()
 	p, err := c.Compile(string(data))
-	if err != nil || p == nil{
+	if err != nil || p == nil {
 		return 0
 	}
 	return 1

--- a/pkg/compiler/fuzz/fuzz.go
+++ b/pkg/compiler/fuzz/fuzz.go
@@ -4,7 +4,7 @@ import (
 	"github.com/MontFerret/ferret/pkg/compiler"
 )
 
-// Below function is our fuzzer.
+// Fuzz is our fuzzer.
 // The fuzzer is run on oss-fuzz.
 // Link to the project on oss-fuzz
 // will be added once the project is up.

--- a/pkg/compiler/fuzz/fuzz.go
+++ b/pkg/compiler/fuzz/fuzz.go
@@ -1,0 +1,14 @@
+package compiler_test
+
+import (
+	"github.com/MontFerret/ferret/pkg/compiler"
+)
+
+func Fuzz(data []byte) int {
+	c := compiler.New()
+	p, err := c.Compile(string(data))
+	if err!=nil || p==nil{
+		return 0
+	}
+	return 1
+}

--- a/pkg/compiler/fuzz/fuzz.go
+++ b/pkg/compiler/fuzz/fuzz.go
@@ -4,10 +4,11 @@ import (
 	"github.com/MontFerret/ferret/pkg/compiler"
 )
 
+// This function is our fuzzer
 func Fuzz(data []byte) int {
 	c := compiler.New()
 	p, err := c.Compile(string(data))
-	if err!=nil || p==nil{
+	if err != nil || p == nil{
 		return 0
 	}
 	return 1


### PR DESCRIPTION
This PR adds a fuzzer that targets `Compile()`

I managed to get the fuzzer running on oss-fuzz's platform as well, and I propose setting ferret up on in oss-fuzz. This will allow oss-fuzz to run this fuzzer as well as future fuzzers continuously. If a bug is discovered, oss-fuzz sends a bug report via email to all maintainers on their contact list.
It doesn't cost anything to be a part of oss-fuzz, but the bugs do need to get fixed.

If you would like to setup ferret on oss-fuzz, I need a primary contact email address and the email addresses of all maintainers to add to the email list. This can be updated at anytime.

Google might ask about the userbase of ferret in order to accept the project, so if you have any information about any companies or other packages using ferret, it would help with getting ferret accepted.