### PR TITLE
Fix an emoji error in the string.

### DIFF
--- a/pkg/drivers/cdp/eval/helpers.go
+++ b/pkg/drivers/cdp/eval/helpers.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
 	"github.com/MontFerret/ferret/pkg/runtime/values"

--- a/pkg/drivers/cdp/eval/helpers.go
+++ b/pkg/drivers/cdp/eval/helpers.go
@@ -19,14 +19,6 @@ func Unmarshal(obj *runtime.RemoteObject) (core.Value, error) {
 	}
 
 	switch obj.Type {
-	case "string":
-		str, err := strconv.Unquote(string(obj.Value))
-
-		if err != nil {
-			return values.None, err
-		}
-
-		return values.NewString(str), nil
 	case "undefined", "null":
 		return values.None, nil
 	default:


### PR DESCRIPTION
strconv.Unquote will cause garbled code when the string contains emoticons and should be left to the default json.Unmarshal to handle