### PR TITLE
fix SCREENSHOT() param type check

### DIFF
--- a/pkg/stdlib/html/screenshot.go
+++ b/pkg/stdlib/html/screenshot.go
@@ -29,7 +29,7 @@ func Screenshot(ctx context.Context, args ...core.Value) (core.Value, error) {
 
 	arg1 := args[0]
 
-	err = core.ValidateType(arg1, drivers.HTMLDocumentType, types.String)
+	err = core.ValidateType(arg1, drivers.HTMLPageType, types.String)
 
 	if err != nil {
 		return values.None, err


### PR DESCRIPTION
The function requires a `HTMLPageType`.

Fixes #542 