### PR TITLE
JSON encoding with no HTML escaping

### DIFF
--- a/pkg/runtime/values/array.go
+++ b/pkg/runtime/values/array.go
@@ -3,11 +3,11 @@ package values
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"hash/fnv"
 	"sort"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -30,7 +30,7 @@ func NewArrayWith(values ...core.Value) *Array {
 }
 
 func (t *Array) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.items)
+	return encoder.EncodeJSON(t.items)
 }
 
 func (t *Array) Type() core.Type {

--- a/pkg/runtime/values/boolean.go
+++ b/pkg/runtime/values/boolean.go
@@ -1,11 +1,11 @@
 package values
 
 import (
-	"encoding/json"
 	"hash/fnv"
 	"strings"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -51,7 +51,7 @@ func MustParseBoolean(input interface{}) Boolean {
 }
 
 func (t Boolean) MarshalJSON() ([]byte, error) {
-	return json.Marshal(bool(t))
+	return encoder.EncodeJSON(bool(t))
 }
 
 func (t Boolean) Type() core.Type {

--- a/pkg/runtime/values/encoder/json.go
+++ b/pkg/runtime/values/encoder/json.go
@@ -1,0 +1,25 @@
+package encoder
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+var b bytes.Buffer
+var jsonEnc *json.Encoder
+
+func init() {
+	jsonEnc = json.NewEncoder(&b)
+	jsonEnc.SetEscapeHTML(false)
+}
+
+func EncodeJSON(v interface{}) ([]byte, error) {
+	err := jsonEnc.Encode(v)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	bs := bytes.TrimSuffix(b.Bytes(), []byte{'\n'})
+	b.Reset()
+	return bs, nil
+}

--- a/pkg/runtime/values/encoder/json_test.go
+++ b/pkg/runtime/values/encoder/json_test.go
@@ -1,0 +1,19 @@
+package encoder_test
+
+import (
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	Convey(".EncodeJSON", t, func() {
+		Convey("Should not HTML escape", func() {
+			expectedValue := []byte(`"name=Jane&age=38"`)
+
+			marshalled, err := encoder.EncodeJSON("name=Jane&age=38")
+			So(err, ShouldBeNil)
+			So(string(marshalled), ShouldEqual, string(expectedValue))
+		})
+	})
+}

--- a/pkg/runtime/values/float.go
+++ b/pkg/runtime/values/float.go
@@ -2,13 +2,13 @@ package values
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"math"
 	"strconv"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -74,7 +74,7 @@ func IsInf(input Float, sign Int) Boolean {
 }
 
 func (t Float) MarshalJSON() ([]byte, error) {
-	return json.Marshal(float64(t))
+	return encoder.EncodeJSON(float64(t))
 }
 
 func (t Float) Type() core.Type {

--- a/pkg/runtime/values/int.go
+++ b/pkg/runtime/values/int.go
@@ -2,11 +2,11 @@ package values
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"hash/fnv"
 	"strconv"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -62,7 +62,7 @@ func MustParseInt(input interface{}) Int {
 }
 
 func (t Int) MarshalJSON() ([]byte, error) {
-	return json.Marshal(int64(t))
+	return encoder.EncodeJSON(int64(t))
 }
 
 func (t Int) Type() core.Type {

--- a/pkg/runtime/values/object.go
+++ b/pkg/runtime/values/object.go
@@ -3,11 +3,11 @@ package values
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"hash/fnv"
 	"sort"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -43,7 +43,7 @@ func NewObjectWith(props ...*ObjectProperty) *Object {
 }
 
 func (t *Object) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.value)
+	return encoder.EncodeJSON(t.value)
 }
 
 func (t *Object) Type() core.Type {

--- a/pkg/runtime/values/string.go
+++ b/pkg/runtime/values/string.go
@@ -1,12 +1,12 @@
 package values
 
 import (
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"strings"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 	"github.com/MontFerret/ferret/pkg/runtime/values/types"
 )
 
@@ -68,7 +68,7 @@ func MustParseString(input interface{}) String {
 }
 
 func (t String) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(t))
+	return encoder.EncodeJSON(string(t))
 }
 
 func (t String) Type() core.Type {

--- a/pkg/runtime/values/string_test.go
+++ b/pkg/runtime/values/string_test.go
@@ -34,4 +34,15 @@ func TestString(t *testing.T) {
 			So(str.Length(), ShouldEqual, 7)
 		})
 	})
+
+	Convey(".MarshalJSON", t, func() {
+		Convey("Should not HTML escape", func() {
+			str := values.NewString("name=Jane&age=38")
+			expectedValue := []byte(`"name=Jane&age=38"`)
+
+			marshalled, err := str.MarshalJSON()
+			So(err, ShouldBeNil)
+			So(string(marshalled), ShouldEqual, string(expectedValue))
+		})
+	})
 }

--- a/pkg/stdlib/strings/json.go
+++ b/pkg/stdlib/strings/json.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
 	"github.com/MontFerret/ferret/pkg/runtime/values"
+	"github.com/MontFerret/ferret/pkg/runtime/values/encoder"
 )
 
 // JSON_PARSE returns a value described by the JSON-encoded input string.
@@ -39,7 +40,7 @@ func JSONStringify(_ context.Context, args ...core.Value) (core.Value, error) {
 		return values.EmptyString, err
 	}
 
-	out, err := json.Marshal(args[0])
+	out, err := encoder.EncodeJSON(args[0])
 
 	if err != nil {
 		return values.EmptyString, err


### PR DESCRIPTION
Hi,
As far as I know the problem is that we are encoding as JSON the final result 
https://github.com/MontFerret/ferret/blob/master/pkg/runtime/program.go#L103
So that, being the HTML special chars escaping enabled by default in the `encoding/json` package it encoded HTML escaped characters as `"&"` to `"\\u0026"` (notice the double `\`, as they are 6 runes, instead of 1)

So that, my suggestion is not to escape HTML characters.

For that, I've created an encoder package and updated all the calls to `json.Marshall` in `runtime/values` to use the new encoder package.

I have not much experience in Go, I've tried to mimic the project structure for adding the new package but maybe you could suggest a better place/names for that. 


Fixes #550 and #488 