### PR TITLE
Add rand seed in RAND(min, max) #578

### DIFF
--- a/pkg/runtime/core/helpers.go
+++ b/pkg/runtime/core/helpers.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"time"
 )
 
 func IsNil(input interface{}) bool {
@@ -46,6 +47,7 @@ func NumberLowerBoundary(input float64) float64 {
 }
 
 func Random(max float64, min float64) float64 {
+	rand.Seed(time.Now().UnixNano())
 	r := rand.Float64()
 	i := r * (max - min + 1)
 	out := math.Floor(i) + min


### PR DESCRIPTION
Fixes #578 
It had returned the same value for same reason as #483.
Because Random in pkg/runtime/core/helpers.go didn't change rand.Seed every time.