### PR TITLE
custom http transport

### DIFF
--- a/pkg/compiler/compiler_param_test.go
+++ b/pkg/compiler/compiler_param_test.go
@@ -2,10 +2,11 @@ package compiler_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/MontFerret/ferret/pkg/compiler"
 	"github.com/MontFerret/ferret/pkg/runtime"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestParam(t *testing.T) {
@@ -145,4 +146,29 @@ func TestParam(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "subattr")
 	})
+
+	Convey("Should be possible to use in struct with nested struct which nil", t, func() {
+		type Some2 struct {
+		}
+		type Some struct {
+			Some2 *Some2
+		}
+
+		someObj := &Some{}
+		prog := compiler.New().
+			MustCompile(`
+
+			RETURN null
+		`)
+
+		panics := func() {
+			_, _ = prog.Run(
+				context.Background(),
+				runtime.WithParam("struct", someObj),
+			)
+		}
+
+		So(panics, ShouldNotPanic)
+	})
+
 }

--- a/pkg/drivers/http/driver.go
+++ b/pkg/drivers/http/driver.go
@@ -26,18 +26,7 @@ func NewDriver(opts ...Option) *Driver {
 	drv := new(Driver)
 	drv.options = newOptions(opts)
 
-	if drv.options.Proxy == "" {
-		drv.client = pester.New()
-	} else {
-		client, err := newClientWithProxy(drv.options)
-
-		if err != nil {
-			drv.client = pester.New()
-		} else {
-			drv.client = pester.NewExtendedClient(client)
-		}
-	}
-
+	drv.client = newHttpClient(drv.options)
 	drv.client.Concurrency = drv.options.Concurrency
 	drv.client.MaxRetries = drv.options.MaxRetries
 	drv.client.Backoff = drv.options.Backoff
@@ -45,17 +34,47 @@ func NewDriver(opts ...Option) *Driver {
 	return drv
 }
 
-func newClientWithProxy(options *Options) (*http.Client, error) {
-	proxyURL, err := url.Parse(options.Proxy)
+func newHttpClient(options *Options) (httpClient *pester.Client) {
+	httpClient = pester.New()
 
+	if options.HttpTransport != nil {
+		httpClient.Transport = options.HttpTransport
+	}
+
+	if options.Proxy == "" {
+		return
+	}
+
+	if err := addProxy(httpClient, options.Proxy); err != nil {
+		return
+	}
+
+	httpClient = pester.NewExtendedClient(&http.Client{Transport: httpClient.Transport})
+
+	return
+}
+
+func addProxy(httpClient *pester.Client, proxyStr string) error {
+	if proxyStr == "" {
+		return nil
+	}
+
+	proxyURL, err := url.Parse(proxyStr)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	proxy := http.ProxyURL(proxyURL)
-	tr := &http.Transport{Proxy: proxy}
 
-	return &http.Client{Transport: tr}, nil
+	if httpClient.Transport != nil {
+		httpClient.Transport.(*http.Transport).Proxy = proxy
+
+		return nil
+	}
+
+	httpClient.Transport = &http.Transport{Proxy: proxy}
+
+	return nil
 }
 
 func (drv *Driver) Name() string {

--- a/pkg/drivers/http/driver_test.go
+++ b/pkg/drivers/http/driver_test.go
@@ -1,0 +1,101 @@
+package http
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func Test_newHttpClientWithTransport(t *testing.T) {
+	httpTransport := (http.DefaultTransport).(*http.Transport)
+	httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	type args struct {
+		options *Options
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "check transport exist with pester.New()",
+			args: args{options: &Options{
+				Proxy:         "http://0.0.0.|",
+				HttpTransport: httpTransport,
+			}},
+		},
+		{
+			name: "check transport exist with pester.NewExtendedClient()",
+			args: args{options: &Options{
+				Proxy:         "http://0.0.0.0",
+				HttpTransport: httpTransport,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convey.Convey(tt.name, t, func() {
+				var (
+					transport *http.Transport
+					client    = newHttpClient(tt.args.options)
+					rValue    = reflect.ValueOf(client).Elem()
+					rField    = rValue.Field(0)
+				)
+
+				rField = reflect.NewAt(rField.Type(), unsafe.Pointer(rField.UnsafeAddr())).Elem()
+				hc := rField.Interface().(*http.Client)
+
+				if hc != nil {
+					transport = hc.Transport.(*http.Transport)
+				} else {
+					transport = client.Transport.(*http.Transport)
+				}
+
+				verify := transport.TLSClientConfig.InsecureSkipVerify
+
+				convey.So(verify, convey.ShouldBeTrue)
+			})
+		})
+	}
+}
+
+func Test_newHttpClient(t *testing.T) {
+
+	convey.Convey("pester.New()", t, func() {
+		var (
+			client = newHttpClient(&Options{
+				Proxy: "http://0.0.0.|",
+			})
+
+			rValue = reflect.ValueOf(client).Elem()
+			rField = rValue.Field(0)
+		)
+
+		rField = reflect.NewAt(rField.Type(), unsafe.Pointer(rField.UnsafeAddr())).Elem()
+		hc := rField.Interface().(*http.Client)
+
+		convey.So(hc, convey.ShouldBeNil)
+	})
+
+	convey.Convey("pester.NewExtend()", t, func() {
+		var (
+			client = newHttpClient(&Options{
+				Proxy: "http://0.0.0.0",
+			})
+
+			rValue = reflect.ValueOf(client).Elem()
+			rField = rValue.Field(0)
+		)
+
+		rField = reflect.NewAt(rField.Type(), unsafe.Pointer(rField.UnsafeAddr())).Elem()
+		hc := rField.Interface().(*http.Client)
+
+		convey.So(hc, convey.ShouldNotBeNil)
+	})
+
+}

--- a/pkg/drivers/http/options.go
+++ b/pkg/drivers/http/options.go
@@ -20,6 +20,7 @@ type (
 		Headers          drivers.HTTPHeaders
 		Cookies          drivers.HTTPCookies
 		AllowedHTTPCodes map[int]struct{}
+		HttpTransport    *stdhttp.Transport
 	}
 )
 
@@ -141,5 +142,11 @@ func WithAllowedHTTPCodes(httpCodes []int) Option {
 		for _, code := range httpCodes {
 			opts.AllowedHTTPCodes[code] = struct{}{}
 		}
+	}
+}
+
+func WithCustomTransport(transport *stdhttp.Transport) Option {
+	return func(opts *Options) {
+		opts.HttpTransport = transport
 	}
 }

--- a/pkg/runtime/values/helpers.go
+++ b/pkg/runtime/values/helpers.go
@@ -148,7 +148,13 @@ func Parse(input interface{}) core.Value {
 		kind := t.Kind()
 
 		if kind == reflect.Ptr {
-			return Parse(v.Elem().Interface())
+			el := v.Elem()
+
+			if el.Kind() == 0 {
+				return None
+			}
+
+			return Parse(el.Interface())
 		}
 
 		if kind == reflect.Slice || kind == reflect.Array {


### PR DESCRIPTION
I added option WithCustomTransport for http driver and  did refactoring code which create pester.Client. 

Added WithCustomTransport was necessary for control flag InsecureSkipVerify in section TLSClientConfig inside http.Transport.