### PR TITLE
Check Kind() by 0

### DIFF
--- a/pkg/compiler/compiler_param_test.go
+++ b/pkg/compiler/compiler_param_test.go
@@ -145,4 +145,28 @@ func TestParam(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "subattr")
 	})
+
+	Convey("Should be possible to use in struct with nested struct which nil", t, func() {
+		type Some2 struct {
+		}
+		type Some struct {
+			Some2 *Some2
+		}
+
+		someObj := &Some{}
+		prog := compiler.New().
+			MustCompile(`
+
+			RETURN null
+		`)
+
+		panics := func() {
+			_, _ = prog.Run(
+				context.Background(),
+				runtime.WithParam("struct", someObj),
+			)
+		}
+
+		So(panics, ShouldNotPanic)
+	})
 }

--- a/pkg/runtime/values/helpers.go
+++ b/pkg/runtime/values/helpers.go
@@ -148,7 +148,13 @@ func Parse(input interface{}) core.Value {
 		kind := t.Kind()
 
 		if kind == reflect.Ptr {
-			return Parse(v.Elem().Interface())
+			el := v.Elem()
+
+			if el.Kind() == 0 {
+				return None
+			}
+
+			return Parse(el.Interface())
 		}
 
 		if kind == reflect.Slice || kind == reflect.Array {


### PR DESCRIPTION
In `pkg/runtime/values/helpers.go` added Kind check to 0.
Otherwise, passing parameters with a nested nil structure leads to panic.