### PR TITLE
setting Input charset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,6 @@ require (
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/text v0.3.2
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )

--- a/pkg/drivers/http/driver_test.go
+++ b/pkg/drivers/http/driver_test.go
@@ -1,12 +1,17 @@
 package http
 
 import (
+	"bytes"
 	"crypto/tls"
 	"github.com/MontFerret/ferret/pkg/drivers"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
 	"unsafe"
+
+	"golang.org/x/text/encoding/charmap"
 
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -106,5 +111,61 @@ func Test_newHTTPClient(t *testing.T) {
 
 		convey.So(hc, convey.ShouldNotBeNil)
 	})
+}
 
+func TestDriver_convertToUTF8(t *testing.T) {
+	type args struct {
+		inputData  string
+		srcCharset string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantData io.Reader
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "should convert to expected state",
+			args: args{
+				inputData:  `<!DOCTYPE html><html><head><meta charset="windows-1251"/></head><body>феррет</body></html>`,
+				srcCharset: "windows-1251",
+			},
+			wantErr:  false,
+			expected: `<!DOCTYPE html><html><head><meta charset="windows-1251"/></head><body>феррет</body></html>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			drv := &Driver{}
+
+			convey.Convey(tt.name, t, func() {
+
+				data, err := ioutil.ReadAll(bytes.NewBufferString(tt.args.inputData))
+				if err != nil {
+					panic(err)
+				}
+
+				encodedData := make([]byte, len(data)*2)
+
+				dec := charmap.Windows1251.NewEncoder()
+				nDst, _, err := dec.Transform(encodedData, data, false)
+				if err != nil {
+					panic(err)
+				}
+
+				encodedData = encodedData[:nDst]
+
+				gotData, err := drv.convertToUTF8(bytes.NewReader(encodedData), tt.args.srcCharset)
+				convey.So(err, convey.ShouldBeNil)
+
+				outData, err := ioutil.ReadAll(gotData)
+				convey.So(err, convey.ShouldBeNil)
+
+				convey.So(string(outData), convey.ShouldEqual, tt.expected)
+
+			})
+
+		})
+	}
 }

--- a/pkg/drivers/params.go
+++ b/pkg/drivers/params.go
@@ -31,6 +31,7 @@ type (
 		Cookies     *HTTPCookies
 		Headers     *HTTPHeaders
 		Viewport    *Viewport
+		Charset     string
 		Ignore      *Ignore
 	}
 

--- a/pkg/stdlib/html/document.go
+++ b/pkg/stdlib/html/document.go
@@ -50,6 +50,7 @@ type PageLoadParams struct {
 // @param {Float} [params.viewport.scaleFactor] - Viewport scale factor.
 // @param {Boolean} [params.viewport.mobile] - Value that indicates whether to emulate mobile device.
 // @param {Boolean} [params.viewport.landscape] - Value that indicates whether to render a page in landscape position.
+// @param {String} [params.charset] - (only HTTPDriver) Source charset content to convert UTF-8.
 // @return {HTMLPage} - Loaded HTML page.
 func Open(ctx context.Context, args ...core.Value) (core.Value, error) {
 	err := core.ValidateArgs(args, 1, 2)
@@ -214,6 +215,16 @@ func newPageLoadParams(url values.String, arg core.Value) (PageLoadParams, error
 			}
 
 			res.Ignore = ignore
+		}
+
+		charset, exists := obj.Get(values.NewString("charset"))
+
+		if exists {
+			if err := core.ValidateType(charset, types.String); err != nil {
+				return res, err
+			}
+
+			res.Charset = charset.String()
 		}
 	case types.String:
 		res.Driver = arg.(values.String).String()


### PR DESCRIPTION
I am doing scraping in Russian segment. And i ran into a problem with encoding some pages at some sites. The pages have not only < meta charset="windows-1251"/> but also content have encoding at winfows-1251.
But goquery decoding page to utf-8 without own content encoding and the output i'm getting unreadable content. 
So, I added param “charset” (may by this need to other name – to reviewer notice) to document params and function decoding to utf-8 with given the “charset”.