### PR TITLE
Update cdp driver to work with latest cdp protocol

### DIFF
--- a/pkg/drivers/cdp/helpers.go
+++ b/pkg/drivers/cdp/helpers.go
@@ -3,6 +3,7 @@ package cdp
 import (
 	"context"
 	"github.com/MontFerret/ferret/pkg/runtime/events"
+	"github.com/mafredri/cdp/protocol/dom"
 
 	"github.com/mafredri/cdp"
 	"github.com/mafredri/cdp/protocol/emulation"
@@ -65,7 +66,9 @@ func enableFeatures(ctx context.Context, client *cdp.Client, params drivers.Para
 		},
 
 		func() error {
-			return client.DOM.Enable(ctx)
+			var args dom.EnableArgs
+			args.IncludeWhitespace = params.IncludeWhitespace
+			return client.DOM.Enable(ctx, &args)
 		},
 
 		func() error {

--- a/pkg/drivers/cdp/page.go
+++ b/pkg/drivers/cdp/page.go
@@ -392,7 +392,6 @@ func (p *HTMLPage) PrintToPDF(ctx context.Context, params drivers.PDFParams) (va
 		SetLandscape(bool(params.Landscape)).
 		SetDisplayHeaderFooter(bool(params.DisplayHeaderFooter)).
 		SetPrintBackground(bool(params.PrintBackground)).
-		SetIgnoreInvalidPageRanges(bool(params.IgnoreInvalidPageRanges)).
 		SetPreferCSSPageSize(bool(params.PreferCSSPageSize))
 
 	if params.Scale > 0 {

--- a/pkg/drivers/params.go
+++ b/pkg/drivers/params.go
@@ -25,14 +25,15 @@ type (
 	}
 
 	Params struct {
-		URL         string
-		UserAgent   string
-		KeepCookies bool
-		Cookies     *HTTPCookies
-		Headers     *HTTPHeaders
-		Viewport    *Viewport
-		Charset     string
-		Ignore      *Ignore
+		URL               string
+		UserAgent         string
+		KeepCookies       bool
+		Cookies           *HTTPCookies
+		Headers           *HTTPHeaders
+		Viewport          *Viewport
+		Charset           string
+		Ignore            *Ignore
+		IncludeWhitespace *string //Values: "none", "all".
 	}
 
 	ParseParams struct {


### PR DESCRIPTION
In commit d0c159af4b8f9066cc6c90cce5970bb0289e0c01 in https://github.com/mafredri/cdp it looks like a couple of changes were made that are not backwards compatible with the implementation in ferret so these changes should fix that.
it looks like they:
- removed the SetignoreInvalidPageRanges function
- added arguments to the dom.enable for including white space

 I got these errors immediately after cloning the repository and was unable to build/run without fixing them.