### PR TITLE
return all submatches in RegexMatch instead of the first

### DIFF
--- a/pkg/stdlib/strings/regex.go
+++ b/pkg/stdlib/strings/regex.go
@@ -43,8 +43,8 @@ func RegexMatch(_ context.Context, args ...core.Value) (core.Value, error) {
 		return res, nil
 	}
 
-	for _, m := range matches[0] {
-		res.Push(values.NewString(m))
+	for _, m := range matches {
+		res.Push(values.NewString(m[0]))
 	}
 
 	return res, nil


### PR DESCRIPTION
test string: "39.59% annually and 0.04% monthly"

previously regex_match would only return [39.59] for a regex of "\d+[.]\d+" or [39.59,35.59] for a regex of "(\d+[.]\d+)"

this pull request fixes that and returns [39.59,0.04] for a regex of "\d+[.]\d+" and [[39.59,39.59],[0.04,0.04]] for a regex of "(\d+[.]\d+)"