### PR TITLE
refactor: remove io/ioutil

### DIFF
--- a/e2e/cli.go
+++ b/e2e/cli.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -337,7 +336,7 @@ func execFiles(ctx context.Context, engine *ferret.Instance, opts []runtime.Opti
 		if info.IsDir() {
 			log.Debug().Msg("path points to a directory. retrieving list of files...")
 
-			fileInfos, err := ioutil.ReadDir(path)
+			fileInfos, err := os.ReadDir(path)
 
 			if err != nil {
 				log.Debug().Err(err).Msg("failed to retrieve list of files")
@@ -373,7 +372,7 @@ func execFiles(ctx context.Context, engine *ferret.Instance, opts []runtime.Opti
 
 		log.Debug().Msg("path points to a file. starting to read content")
 
-		out, err := ioutil.ReadFile(path)
+		out, err := os.ReadFile(path)
 
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to read content")

--- a/pkg/stdlib/io/fs/read.go
+++ b/pkg/stdlib/io/fs/read.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	"github.com/MontFerret/ferret/pkg/runtime/core"
 	"github.com/MontFerret/ferret/pkg/runtime/values"
@@ -27,7 +27,7 @@ func Read(_ context.Context, args ...core.Value) (core.Value, error) {
 
 	path := args[0].String()
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 
 	if err != nil {
 		return values.None, core.Error(err, "read file")

--- a/pkg/stdlib/io/fs/util_test.go
+++ b/pkg/stdlib/io/fs/util_test.go
@@ -1,14 +1,13 @@
 package fs_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func tempFile() (*os.File, func()) {
-	file, err := ioutil.TempFile("", "fstest")
+	file, err := os.CreateTemp("", "fstest")
 	So(err, ShouldBeNil)
 
 	fn := func() {


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16
https://pkg.go.dev/io/ioutil