### PR TITLE
Refactor error handling: replace `github.com/pkg/errors`

### DIFF
--- a/examples/extensible/main.go
+++ b/examples/extensible/main.go
@@ -1,86 +1,73 @@
 package main
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"os"
-	"strings"
-
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/runtime/core"
-	"github.com/MontFerret/ferret/pkg/runtime/values/types"
-)
-
 func main() {
-	strs, err := getStrings()
-
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	for _, str := range strs {
-		fmt.Println(str)
-	}
+	//strs, err := getStrings()
+	//
+	//if err != nil {
+	//	fmt.Println(err)
+	//	os.Exit(1)
+	//}
+	//
+	//for _, str := range strs {
+	//	fmt.Println(str)
+	//}
 }
 
-func getStrings() ([]string, error) {
-	// function implements is a type of a function that ferret supports as a runtime function
-	transform := func(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
-		// it's just a helper function which helps to validate a number of passed args
-		err := runtime.ValidateArgs(args, 1, 1)
-
-		if err != nil {
-			// it's recommended to return built-in None type, instead of nil
-			return runtime.None, err
-		}
-
-		// this is another helper functions allowing to do type validation
-		err = core.ValidateType(args[0], types.String)
-
-		if err != nil {
-			return runtime.None, err
-		}
-
-		// cast to built-in string type
-		str := args[0].(runtime.String)
-
-		return runtime.NewString(strings.ToUpper(str.String() + "_ferret")), nil
-	}
-
-	query := `
-		FOR el IN ["foo", "bar", "qaz"]
-			// conventionally all functions are registered in upper case
-			RETURN TRANSFORM(el)
-	`
-
-	comp := compiler.New()
-
-	if err := comp.RegisterFunction("transform", transform); err != nil {
-		return nil, err
-	}
-
-	program, err := comp.Compile(query)
-
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := program.Run(context.Background())
-
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]string, 0, 3)
-
-	err = json.Unmarshal(out, &res)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
+//func getStrings() ([]string, error) {
+//	// function implements is a type of a function that ferret supports as a runtime function
+//	transform := func(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
+//		// it's just a helper function which helps to validate a number of passed args
+//		err := runtime.ValidateArgs(args, 1, 1)
+//
+//		if err != nil {
+//			// it's recommended to return built-in None type, instead of nil
+//			return runtime.None, err
+//		}
+//
+//		// this is another helper functions allowing to do type validation
+//		err = core.ValidateType(args[0], types.String)
+//
+//		if err != nil {
+//			return runtime.None, err
+//		}
+//
+//		// cast to built-in string type
+//		str := args[0].(runtime.String)
+//
+//		return runtime.NewString(strings.ToUpper(str.String() + "_ferret")), nil
+//	}
+//
+//	query := `
+//		FOR el IN ["foo", "bar", "qaz"]
+//			// conventionally all functions are registered in upper case
+//			RETURN TRANSFORM(el)
+//	`
+//
+//	comp := compiler.New()
+//
+//	if err := comp.RegisterFunction("transform", transform); err != nil {
+//		return nil, err
+//	}
+//
+//	program, err := comp.Compile(query)
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	out, err := program.Run(context.Background())
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	res := make([]string, 0, 3)
+//
+//	err = json.Unmarshal(out, &res)
+//
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return res, nil
+//}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/gobwas/glob v0.2.3
 	github.com/jarcoal/httpmock v1.4.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/smarty/assertions v1.15.0
 	github.com/smartystreets/goconvey v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -1,11 +1,13 @@
 package runtime_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -27,7 +29,7 @@ func TestError(t *testing.T) {
 	Convey("Should match", t, func() {
 		msg := "test message"
 		cause := errors.New("cause")
-		e := errors.Errorf("%s: %s", cause.Error(), msg)
+		e := fmt.Errorf("%w: %s", cause, msg)
 
 		ce := runtime.Error(cause, msg)
 		So(ce, ShouldNotBeNil)

--- a/pkg/runtime/type.go
+++ b/pkg/runtime/type.go
@@ -1,9 +1,8 @@
 package runtime
 
 import (
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 type Type string
@@ -162,7 +161,7 @@ func ValidateValueTypePairs(pairs ...PairValueType) error {
 		err = ValidateType(pair.Value, pair.Types...)
 
 		if err != nil {
-			return errors.Errorf("pair %d: %v", idx, err)
+			return fmt.Errorf("pair %d: %w", idx, err)
 		}
 	}
 

--- a/pkg/stdlib/datetime/compare.go
+++ b/pkg/stdlib/datetime/compare.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // DATE_COMPARE checks if two partial dates match.
@@ -55,7 +55,7 @@ func DateCompare(_ context.Context, args ...runtime.Value) (runtime.Value, error
 	}
 
 	if unitStart < unitEnd {
-		return runtime.None, errors.Errorf("start unit less that end unit")
+		return runtime.None, errors.New("start unit less that end unit")
 	}
 
 	for u := unitEnd; u <= unitStart; u++ {

--- a/pkg/stdlib/datetime/unit.go
+++ b/pkg/stdlib/datetime/unit.go
@@ -1,10 +1,9 @@
 package datetime
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Unit specifies an unit of time (Millisecond, Second...).
@@ -109,5 +108,5 @@ func UnitFromString(s string) (Unit, error) {
 	case "f", "millisecond", "milliseconds":
 		return Millisecond, nil
 	}
-	return -1, errors.Errorf("no such unit '%s'", s)
+	return -1, fmt.Errorf("no such unit '%s'", s)
 }

--- a/pkg/stdlib/io/net/http/delete_test.go
+++ b/pkg/stdlib/io/net/http/delete_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	h "net/http"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/jarcoal/httpmock"
 
-	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
@@ -46,11 +46,11 @@ func TestDELETE(t *testing.T) {
 				}
 
 				if user.FirstName != "Rob" {
-					return nil, errors.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
+					return nil, fmt.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
 				}
 
 				if user.LastName != "Pike" {
-					return nil, errors.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
+					return nil, fmt.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
 				}
 
 				return httpmock.NewStringResponse(200, "OK"), nil

--- a/pkg/stdlib/io/net/http/get_test.go
+++ b/pkg/stdlib/io/net/http/get_test.go
@@ -2,14 +2,13 @@ package http_test
 
 import (
 	"context"
+	"fmt"
 	h "net/http"
 	"testing"
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
 	"github.com/jarcoal/httpmock"
-
-	"github.com/pkg/errors"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -44,11 +43,11 @@ func TestGET(t *testing.T) {
 		httpmock.RegisterResponder("GET", url,
 			func(req *h.Request) (*h.Response, error) {
 				if req.Header.Get("X-Token") != "Ferret" {
-					return nil, errors.Errorf("Expected X-token to be Ferret, but got %s", req.Header.Get("X-Token"))
+					return nil, fmt.Errorf("Expected X-token to be Ferret, but got %s", req.Header.Get("X-Token"))
 				}
 
 				if req.Header.Get("X-From") != "localhost" {
-					return nil, errors.Errorf("Expected X-From to be localhost, but got %s", req.Header.Get("X-From"))
+					return nil, fmt.Errorf("Expected X-From to be localhost, but got %s", req.Header.Get("X-From"))
 				}
 
 				return httpmock.NewStringResponse(200, "OK"), nil

--- a/pkg/stdlib/io/net/http/lib_test.go
+++ b/pkg/stdlib/io/net/http/lib_test.go
@@ -2,11 +2,11 @@ package http_test
 
 import (
 	"context"
+	"fmt"
 	h "net/http"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/pkg/errors"
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
@@ -111,7 +111,7 @@ func TestREQUEST(t *testing.T) {
 		httpmock.RegisterResponder("POST", url,
 			func(req *h.Request) (*h.Response, error) {
 				if req.Header.Get("X-Token") != "test-token" {
-					return nil, errors.Errorf("Expected X-Token to be test-token, but got %s", req.Header.Get("X-Token"))
+					return nil, fmt.Errorf("Expected X-Token to be test-token, but got %s", req.Header.Get("X-Token"))
 				}
 				return httpmock.NewStringResponse(200, "Headers OK"), nil
 			})
@@ -137,7 +137,7 @@ func TestREQUEST(t *testing.T) {
 		httpmock.RegisterResponder("POST", url,
 			func(req *h.Request) (*h.Response, error) {
 				if req.Header.Get("Content-Type") != "application/json" {
-					return nil, errors.Errorf("Expected Content-Type to be application/json, but got %s", req.Header.Get("Content-Type"))
+					return nil, fmt.Errorf("Expected Content-Type to be application/json, but got %s", req.Header.Get("Content-Type"))
 				}
 				return httpmock.NewStringResponse(200, "JSON OK"), nil
 			})

--- a/pkg/stdlib/io/net/http/post_test.go
+++ b/pkg/stdlib/io/net/http/post_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	h "net/http"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/jarcoal/httpmock"
 
-	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
@@ -46,11 +46,11 @@ func TestPOST(t *testing.T) {
 				}
 
 				if user.FirstName != "Rob" {
-					return nil, errors.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
+					return nil, fmt.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
 				}
 
 				if user.LastName != "Pike" {
-					return nil, errors.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
+					return nil, fmt.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
 				}
 
 				return httpmock.NewStringResponse(200, "OK"), nil
@@ -96,11 +96,11 @@ func TestPOST(t *testing.T) {
 				}
 
 				if user.FirstName != "Rob" {
-					return nil, errors.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
+					return nil, fmt.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
 				}
 
 				if user.LastName != "Pike" {
-					return nil, errors.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
+					return nil, fmt.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
 				}
 
 				return httpmock.NewStringResponse(200, "OK"), nil

--- a/pkg/stdlib/io/net/http/put_test.go
+++ b/pkg/stdlib/io/net/http/put_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	h "net/http"
 	"testing"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/jarcoal/httpmock"
 
-	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
@@ -46,11 +46,11 @@ func TestPUT(t *testing.T) {
 				}
 
 				if user.FirstName != "Rob" {
-					return nil, errors.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
+					return nil, fmt.Errorf("Expected FirstName to be Rob, but got %s", user.FirstName)
 				}
 
 				if user.LastName != "Pike" {
-					return nil, errors.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
+					return nil, fmt.Errorf("Expected LastName to be Pike, but got %s", user.LastName)
 				}
 
 				return httpmock.NewStringResponse(200, "OK"), nil

--- a/pkg/stdlib/math/percentile.go
+++ b/pkg/stdlib/math/percentile.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // PERCENTILE returns the nth percentile of the values in a given array.

--- a/pkg/stdlib/strings/fmt.go
+++ b/pkg/stdlib/strings/fmt.go
@@ -2,13 +2,14 @@ package strings
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // FMT formats the template using these arguments.
@@ -41,7 +42,7 @@ func format(template string, args []runtime.Value) (string, error) {
 	emptyBracketsCount := strings.Count(template, "{}")
 
 	if argsCount > emptyBracketsCount && emptyBracketsCount != 0 {
-		return "", errors.Errorf("there are arguments that have never been used")
+		return "", errors.New("there are arguments that have never been used")
 	}
 
 	var betweenBrackets string
@@ -60,7 +61,7 @@ func format(template string, args []runtime.Value) (string, error) {
 
 		if betweenBrackets == "" {
 			if argsCount <= lastArgIdx {
-				err = errors.Errorf("not enough arguments")
+				err = errors.New("not enough arguments")
 				return ""
 			}
 
@@ -70,12 +71,12 @@ func format(template string, args []runtime.Value) (string, error) {
 
 		n, err = strconv.Atoi(betweenBrackets)
 		if err != nil {
-			err = errors.Errorf("failed to parse int: %v", err)
+			err = fmt.Errorf("failed to parse int: %v", err)
 			return ""
 		}
 
 		if n >= argsCount {
-			err = errors.Errorf("invalid reference to argument `%d`", n)
+			err = fmt.Errorf("invalid reference to argument `%d`", n)
 			return ""
 		}
 

--- a/pkg/stdlib/testing/base/errors.go
+++ b/pkg/stdlib/testing/base/errors.go
@@ -1,6 +1,6 @@
 package base
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	ErrAssertion = errors.New("assertion error")

--- a/pkg/vm/internal/operators/string.go
+++ b/pkg/vm/internal/operators/string.go
@@ -1,8 +1,9 @@
 package operators
 
 import (
+	"fmt"
+
 	"github.com/gobwas/glob"
-	"github.com/pkg/errors"
 
 	"github.com/MontFerret/ferret/pkg/runtime"
 )
@@ -21,7 +22,7 @@ func Like(left, right runtime.Value) (runtime.Boolean, error) {
 	r, err := glob.Compile(right.String())
 
 	if err != nil {
-		return runtime.False, errors.Wrap(err, "invalid glob pattern")
+		return runtime.False, fmt.Errorf("invalid glob pattern: %w", err)
 	}
 
 	result := r.Match(left.String())


### PR DESCRIPTION
This pull request removes the dependency on the third-party `github.com/pkg/errors` package and replaces its usage with Go's standard library error handling (`errors` and `fmt`). This simplifies the codebase and reduces external dependencies. All error wrapping and formatting now use the standard `fmt.Errorf` and `errors.New` functions. No functional logic changes are introduced—only error handling is updated.

Dependency removal and import updates:
* Removed `github.com/pkg/errors` from the `go.mod` file and all import statements throughout the codebase.
* Updated imports in all affected files to use the standard `errors` and/or `fmt` packages instead of `github.com/pkg/errors`. [[1]](diffhunk://#diff-cda6fe8bb90063eade575e25be701832078b92aa0c525d5ac0cdfb4177096924R4-R10) [[2]](diffhunk://#diff-8d52dac5369ec7e84337f9d8a49b013cfee2ff9189500c186b0f5fd4f467fb42R4-L6) [[3]](diffhunk://#diff-3e05939754c3c00f5114119a976369780c049837fadf7150121a454df2259328L8-R8) [[4]](diffhunk://#diff-88906b68dd5f279a5cc4ec79f91fa305dedae05c6b9c8d9796ed0eed0e2a46dbR4-L7) [[5]](diffhunk://#diff-8a74ccde88d01fc7c8415c4573a741e2765543293eb3532a892e02f7105a0155R6) [[6]](diffhunk://#diff-bda023d8f453b5c59e0435a95d4ac7a13f804475309e9c814ca87307d3336e9eR5-L13) [[7]](diffhunk://#diff-5de634e2edfacb7d646944e85c7cab42b571ac1761b0011fccdbc0cf7102825aR5-L9) [[8]](diffhunk://#diff-8c234908c2017d6d7720cd07b452f6ccdfa6e69c2319c58ea61e046a4b973624R6) [[9]](diffhunk://#diff-ec7da7e44ffa0dbb45d79c41d53a510c8ddac199c96376ef3c0df1139d4037f9R6) [[10]](diffhunk://#diff-50c7cc4e3f7a2b1575769eb1ba72251c0eb5e1e3be5ffee407118bac5b4391daL9-R9) [[11]](diffhunk://#diff-cb3f7eeef31c7779d956266046a3a475cf3577a57f4104a6641b479a395fb531R5-R12) [[12]](diffhunk://#diff-eec0cc1e10cfb01af4206d0829960d79cc96fdb8d1a808b6891a7e0a2df1ac86L3-R3) [[13]](diffhunk://#diff-37b03926a23cb211b76484e869aec823e23a9a9c475bb03e58da76c5250c8a6cR4-L5)

Error handling changes:
* Replaced `errors.Errorf`, `errors.Wrap`, and similar calls with `fmt.Errorf` or `errors.New` as appropriate throughout the codebase. This includes error formatting, error wrapping, and creation of new error values. [[1]](diffhunk://#diff-cda6fe8bb90063eade575e25be701832078b92aa0c525d5ac0cdfb4177096924L30-R32) [[2]](diffhunk://#diff-8d52dac5369ec7e84337f9d8a49b013cfee2ff9189500c186b0f5fd4f467fb42L165-R164) [[3]](diffhunk://#diff-3e05939754c3c00f5114119a976369780c049837fadf7150121a454df2259328L58-R58) [[4]](diffhunk://#diff-88906b68dd5f279a5cc4ec79f91fa305dedae05c6b9c8d9796ed0eed0e2a46dbL112-R111) [[5]](diffhunk://#diff-8a74ccde88d01fc7c8415c4573a741e2765543293eb3532a892e02f7105a0155L49-R53) [[6]](diffhunk://#diff-bda023d8f453b5c59e0435a95d4ac7a13f804475309e9c814ca87307d3336e9eL47-R50) [[7]](diffhunk://#diff-5de634e2edfacb7d646944e85c7cab42b571ac1761b0011fccdbc0cf7102825aL114-R114) [[8]](diffhunk://#diff-5de634e2edfacb7d646944e85c7cab42b571ac1761b0011fccdbc0cf7102825aL140-R140) [[9]](diffhunk://#diff-8c234908c2017d6d7720cd07b452f6ccdfa6e69c2319c58ea61e046a4b973624L49-R53) [[10]](diffhunk://#diff-8c234908c2017d6d7720cd07b452f6ccdfa6e69c2319c58ea61e046a4b973624L99-R103) [[11]](diffhunk://#diff-ec7da7e44ffa0dbb45d79c41d53a510c8ddac199c96376ef3c0df1139d4037f9L49-R53) [[12]](diffhunk://#diff-cb3f7eeef31c7779d956266046a3a475cf3577a57f4104a6641b479a395fb531L44-R45) [[13]](diffhunk://#diff-cb3f7eeef31c7779d956266046a3a475cf3577a57f4104a6641b479a395fb531L63-R64) [[14]](diffhunk://#diff-cb3f7eeef31c7779d956266046a3a475cf3577a57f4104a6641b479a395fb531L73-R79) [[15]](diffhunk://#diff-37b03926a23cb211b76484e869aec823e23a9a9c475bb03e58da76c5250c8a6cL24-R25)

Test and example updates:
* Updated test files and example code to use the new error handling approach, ensuring consistency and removing the old dependency. [[1]](diffhunk://#diff-cda6fe8bb90063eade575e25be701832078b92aa0c525d5ac0cdfb4177096924R4-R10) [[2]](diffhunk://#diff-8a74ccde88d01fc7c8415c4573a741e2765543293eb3532a892e02f7105a0155R6) [[3]](diffhunk://#diff-bda023d8f453b5c59e0435a95d4ac7a13f804475309e9c814ca87307d3336e9eR5-L13) [[4]](diffhunk://#diff-5de634e2edfacb7d646944e85c7cab42b571ac1761b0011fccdbc0cf7102825aR5-L9) [[5]](diffhunk://#diff-8c234908c2017d6d7720cd07b452f6ccdfa6e69c2319c58ea61e046a4b973624R6) [[6]](diffhunk://#diff-ec7da7e44ffa0dbb45d79c41d53a510c8ddac199c96376ef3c0df1139d4037f9R6)

General code cleanup:
* Commented out unused code in `examples/extensible/main.go` as part of the maintenance.