### PR TITLE
docs: add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ It is extremely portable, extensible, and fast.
 * Embeddable
 * Extensible
 
+## Installation
+
+### CLI
+
+Install the Ferret CLI using Go:
+
+```bash
+go install github.com/MontFerret/cli/ferret@latest
+```
+
+Make sure your `$GOPATH/bin` is in your `PATH`.
+
+### As a Library
+
+Add Ferret to your Go project:
+
+```bash
+go get github.com/MontFerret/ferret
+```
+
+## Documentation
+
 Documentation is available [at our website](https://www.montferret.dev/docs/introduction/).
 
 ### Different languages


### PR DESCRIPTION
## Summary
Added clear installation instructions to the README.

## Problem
Issue #735 reported that users couldn't find working installation instructions. The README previously didn't include any installation guidance, and users had to discover the correct command through trial and error.

## Solution
Added an Installation section with:
- **CLI installation**: `go install github.com/MontFerret/cli/ferret@latest`
- **Library installation**: `go get github.com/MontFerret/ferret`
- Note about adding `$GOPATH/bin` to PATH

This gives users immediate, working installation commands directly in the README.

Fixes #735