### PR TITLE
chore: complete Apache license boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018-2025 MontFerret
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Fills in the copyright placeholder in the Apache 2.0 license file.

## Problem
Issue #506 noted that the Apache license boilerplate was incomplete, with placeholder values:
```
Copyright [yyyy] [name of copyright owner]
```

The license requires these to be filled in to be valid.

## Solution
Completed the boilerplate with:
- **Year**: 2018-2025 (the project's initial release was October 13, 2018)
- **Copyright owner**: MontFerret

Fixes #506