### PR TITLE
chore: add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Go source files
+*.go text eol=lf
+
+# FQL query files
+*.fql text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# Configuration
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Windows batch files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Makefiles
+Makefile text eol=lf
+
+# Ignore generated files in diff
+*_gen.go -diff linguist-generated=true
+
+# Mark vendored files as such
+vendor/** linguist-vendored
+
+# Images are binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
## Summary
Added a `.gitattributes` file to ensure consistent file handling across different operating systems.

## Contents

The file configures:
- **Line endings**: LF for all text files (except Windows batch files)
- **File types**:
  - Go source files (`.go`)
  - FQL query files (`.fql`)
  - Documentation (`.md`, `.txt`)
  - Configuration files (`.json`, `.yaml`, `.toml`)
  - Shell scripts (`.sh`)
- **Generated files**: Excluded from diffs (`*_gen.go`)
- **Binary files**: Images marked as binary

## Benefits

- Prevents line ending issues when contributors work across Windows, macOS, and Linux
- Cleaner git diffs (no whitespace-only changes)
- Proper linguist detection for GitHub statistics
- Better handling of generated/vendored code