### PR TITLE
Update import paths to v2 for runtime and vm packages

### DIFF
--- a/examples/embedded/main.go
+++ b/examples/embedded/main.go
@@ -6,10 +6,10 @@ package main
 //	"fmt"
 //	"os"
 //
-//	"github.com/MontFerret/ferret/pkg/compiler"
-//	"github.com/MontFerret/ferret/pkg/drivers"
-//	"github.com/MontFerret/ferret/pkg/drivers/cdp"
-//	"github.com/MontFerret/ferret/pkg/drivers/http"
+//	"github.com/MontFerret/ferret/v2/pkg/compiler"
+//	"github.com/MontFerret/ferret/v2/pkg/drivers"
+//	"github.com/MontFerret/ferret/v2/pkg/drivers/cdp"
+//	"github.com/MontFerret/ferret/v2/pkg/drivers/http"
 //)
 //
 //type Topic struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MontFerret/ferret
+module github.com/MontFerret/ferret/v2
 
 go 1.23
 

--- a/lib.go
+++ b/lib.go
@@ -1,10 +1,10 @@
 package ferret
 
 import (
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/engine"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/engine"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type Engine = engine.Engine

--- a/pkg/asm/assembler.go
+++ b/pkg/asm/assembler.go
@@ -1,6 +1,6 @@
 package asm
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 // TODO: Implement the assembler that converts FASM (Ferret Assembly) code into a Ferret VM program.
 func Assemble(fasm string) (*vm.Program, error) {

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // Disassemble returns a human-readable disassembly of the given program.

--- a/pkg/asm/formatter.go
+++ b/pkg/asm/formatter.go
@@ -3,8 +3,8 @@ package asm
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // labelOrAddr returns a label name if one exists for the given address; otherwise just the number.

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -3,16 +3,16 @@ package compiler
 import (
 	goruntime "runtime"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
-	"github.com/MontFerret/ferret/pkg/compiler/internal/optimization"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/optimization"
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
-	"github.com/MontFerret/ferret/pkg/parser"
+	"github.com/MontFerret/ferret/v2/pkg/parser"
 )
 
 type Compiler struct {

--- a/pkg/compiler/error.go
+++ b/pkg/compiler/error.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
 )
 
 type CompilationError = diagnostics.CompilationError

--- a/pkg/compiler/internal/context.go
+++ b/pkg/compiler/internal/context.go
@@ -1,9 +1,9 @@
 package internal
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 // CompilerContext holds the context for the compilation process, including various compilers and allocators.

--- a/pkg/compiler/internal/core/catch.go
+++ b/pkg/compiler/internal/core/catch.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type CatchStack struct {

--- a/pkg/compiler/internal/core/collect_selector.go
+++ b/pkg/compiler/internal/core/collect_selector.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type CollectSelector struct {

--- a/pkg/compiler/internal/core/collector.go
+++ b/pkg/compiler/internal/core/collector.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 type (
 	CollectorType int

--- a/pkg/compiler/internal/core/collector_aggregation.go
+++ b/pkg/compiler/internal/core/collector_aggregation.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type (

--- a/pkg/compiler/internal/core/constants.go
+++ b/pkg/compiler/internal/core/constants.go
@@ -3,8 +3,8 @@ package core
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // ConstantPool stores and deduplicates constants

--- a/pkg/compiler/internal/core/emitter.go
+++ b/pkg/compiler/internal/core/emitter.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type Emitter struct {

--- a/pkg/compiler/internal/core/emitter_extension.go
+++ b/pkg/compiler/internal/core/emitter_extension.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // Emitter Helpers - Common opcode shortcut methods

--- a/pkg/compiler/internal/core/kv.go
+++ b/pkg/compiler/internal/core/kv.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 type KV struct {
 	Key   vm.Operand

--- a/pkg/compiler/internal/core/loop.go
+++ b/pkg/compiler/internal/core/loop.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type LoopType int

--- a/pkg/compiler/internal/core/loops.go
+++ b/pkg/compiler/internal/core/loops.go
@@ -3,7 +3,7 @@ package core
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type LoopTable struct {

--- a/pkg/compiler/internal/core/registers.go
+++ b/pkg/compiler/internal/core/registers.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type (

--- a/pkg/compiler/internal/core/scope.go
+++ b/pkg/compiler/internal/core/scope.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type ScopeProjection struct {

--- a/pkg/compiler/internal/core/symbols.go
+++ b/pkg/compiler/internal/core/symbols.go
@@ -3,8 +3,8 @@ package core
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const (

--- a/pkg/compiler/internal/core/type_tracker.go
+++ b/pkg/compiler/internal/core/type_tracker.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 type TypeTracker struct {
 	regs map[vm.Operand]ValueType

--- a/pkg/compiler/internal/diagnostics/error_analyzer.go
+++ b/pkg/compiler/internal/diagnostics/error_analyzer.go
@@ -1,7 +1,7 @@
 package diagnostics
 
 import (
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 type SyntaxErrorMatcher func(src *file.Source, err *CompilationError, offending *TokenNode) bool

--- a/pkg/compiler/internal/diagnostics/error_analyzer_test.go
+++ b/pkg/compiler/internal/diagnostics/error_analyzer_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestAnalyzeSyntaxError(t *testing.T) {

--- a/pkg/compiler/internal/diagnostics/error_listener.go
+++ b/pkg/compiler/internal/diagnostics/error_listener.go
@@ -3,9 +3,9 @@ package diagnostics
 import (
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 type ErrorListener struct {

--- a/pkg/compiler/internal/diagnostics/error_set.go
+++ b/pkg/compiler/internal/diagnostics/error_set.go
@@ -1,7 +1,7 @@
 package diagnostics
 
 import (
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 )
 
 type CompilationErrorSet struct {

--- a/pkg/compiler/internal/diagnostics/error_test.go
+++ b/pkg/compiler/internal/diagnostics/error_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestCompilationError(t *testing.T) {

--- a/pkg/compiler/internal/diagnostics/errors.go
+++ b/pkg/compiler/internal/diagnostics/errors.go
@@ -1,8 +1,8 @@
 package diagnostics
 
 import (
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 const (

--- a/pkg/compiler/internal/diagnostics/errors_test.go
+++ b/pkg/compiler/internal/diagnostics/errors_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestErrorConstructors(t *testing.T) {

--- a/pkg/compiler/internal/diagnostics/handler.go
+++ b/pkg/compiler/internal/diagnostics/handler.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 type ErrorHandler struct {

--- a/pkg/compiler/internal/diagnostics/handler_test.go
+++ b/pkg/compiler/internal/diagnostics/handler_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 // Simple handler tests without complex ANTLR dependencies

--- a/pkg/compiler/internal/diagnostics/helpers.go
+++ b/pkg/compiler/internal/diagnostics/helpers.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func SpanFromRuleContext(ctx antlr.ParserRuleContext) file.Span {

--- a/pkg/compiler/internal/diagnostics/helpers_test.go
+++ b/pkg/compiler/internal/diagnostics/helpers_test.go
@@ -3,7 +3,7 @@ package diagnostics
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestHas(t *testing.T) {

--- a/pkg/compiler/internal/diagnostics/match_error_assignment.go
+++ b/pkg/compiler/internal/diagnostics/match_error_assignment.go
@@ -3,8 +3,8 @@ package diagnostics
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func matchMissingAssignmentValue(src *file.Source, err *CompilationError, offending *TokenNode) bool {

--- a/pkg/compiler/internal/diagnostics/match_error_common.go
+++ b/pkg/compiler/internal/diagnostics/match_error_common.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func matchCommonErrors(src *file.Source, err *CompilationError, offending *TokenNode) bool {

--- a/pkg/compiler/internal/diagnostics/match_error_for_loop.go
+++ b/pkg/compiler/internal/diagnostics/match_error_for_loop.go
@@ -3,8 +3,8 @@ package diagnostics
 import (
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func matchForLoopErrors(src *file.Source, err *CompilationError, offending *TokenNode) bool {

--- a/pkg/compiler/internal/diagnostics/match_error_literals.go
+++ b/pkg/compiler/internal/diagnostics/match_error_literals.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func isComputedPropertyPrefix(node *TokenNode) bool {

--- a/pkg/compiler/internal/diagnostics/match_error_return.go
+++ b/pkg/compiler/internal/diagnostics/match_error_return.go
@@ -3,8 +3,8 @@ package diagnostics
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func matchMissingReturnValue(src *file.Source, err *CompilationError, offending *TokenNode) bool {

--- a/pkg/compiler/internal/diagnostics/match_error_step_loop.go
+++ b/pkg/compiler/internal/diagnostics/match_error_step_loop.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func matchStepLoopErrors(src *file.Source, err *CompilationError, offending *TokenNode) bool {

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // Runtime functions

--- a/pkg/compiler/internal/helpers.go
+++ b/pkg/compiler/internal/helpers.go
@@ -3,13 +3,13 @@ package internal
 import (
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func loadConstant(ctx *CompilerContext, value runtime.Value) vm.Operand {

--- a/pkg/compiler/internal/literal.go
+++ b/pkg/compiler/internal/literal.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // LiteralCompiler handles the compilation of literal values in FQL queries.

--- a/pkg/compiler/internal/loop.go
+++ b/pkg/compiler/internal/loop.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // LoopCompiler handles the compilation of FOR loop expressions in FQL queries.

--- a/pkg/compiler/internal/loop_collect.go
+++ b/pkg/compiler/internal/loop_collect.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // LoopCollectCompiler handles the compilation of COLLECT clauses in FQL queries.

--- a/pkg/compiler/internal/loop_collect_agg.go
+++ b/pkg/compiler/internal/loop_collect_agg.go
@@ -3,10 +3,10 @@ package internal
 import (
 	"strconv"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // initializeAggregation processes the aggregation selectors from the COLLECT clause.

--- a/pkg/compiler/internal/loop_collect_grp.go
+++ b/pkg/compiler/internal/loop_collect_grp.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // initializeGrouping creates the KeyValue pair for collection, handling both grouping and value setup.

--- a/pkg/compiler/internal/loop_collect_prj.go
+++ b/pkg/compiler/internal/loop_collect_prj.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // initializeProjection handles the projection setup for group variables and counters.

--- a/pkg/compiler/internal/loop_sort.go
+++ b/pkg/compiler/internal/loop_sort.go
@@ -1,10 +1,10 @@
 package internal
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // LoopSortCompiler handles compilation of SORT clauses within loops.

--- a/pkg/compiler/internal/optimization/analysis_test.go
+++ b/pkg/compiler/internal/optimization/analysis_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestAnalyzer_FindReachableBlocks(t *testing.T) {

--- a/pkg/compiler/internal/optimization/builder.go
+++ b/pkg/compiler/internal/optimization/builder.go
@@ -1,6 +1,6 @@
 package optimization
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 // Builder constructs a control flow graph from bytecode
 type Builder struct {

--- a/pkg/compiler/internal/optimization/cfg.go
+++ b/pkg/compiler/internal/optimization/cfg.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // BasicBlock represents a sequence of instructions with a single entry and exit point

--- a/pkg/compiler/internal/optimization/cfg_test.go
+++ b/pkg/compiler/internal/optimization/cfg_test.go
@@ -3,7 +3,7 @@ package optimization
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestBuildCFG_EmptyProgram(t *testing.T) {

--- a/pkg/compiler/internal/optimization/pass.go
+++ b/pkg/compiler/internal/optimization/pass.go
@@ -1,6 +1,6 @@
 package optimization
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 type (
 	// PassResult contains the result of running a pass

--- a/pkg/compiler/internal/optimization/pass_constant_propagation.go
+++ b/pkg/compiler/internal/optimization/pass_constant_propagation.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const ConstantPropagationPassName = "constant-propagation"

--- a/pkg/compiler/internal/optimization/pass_liveness.go
+++ b/pkg/compiler/internal/optimization/pass_liveness.go
@@ -1,7 +1,7 @@
 package optimization
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const (

--- a/pkg/compiler/internal/optimization/pass_register_coalescing.go
+++ b/pkg/compiler/internal/optimization/pass_register_coalescing.go
@@ -3,7 +3,7 @@ package optimization
 import (
 	"sort"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const RegisterCoalescingPassName = "register-coalescing"

--- a/pkg/compiler/internal/optimization/pass_register_coalescing_test.go
+++ b/pkg/compiler/internal/optimization/pass_register_coalescing_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestRegisterCoalescing_CoalescesWhenSrcDies(t *testing.T) {

--- a/pkg/compiler/internal/optimization/pipeline.go
+++ b/pkg/compiler/internal/optimization/pipeline.go
@@ -3,7 +3,7 @@ package optimization
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type (

--- a/pkg/compiler/internal/stmt.go
+++ b/pkg/compiler/internal/stmt.go
@@ -1,9 +1,9 @@
 package internal
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // StmtCompiler handles the compilation of FQL statements.

--- a/pkg/compiler/internal/type_inference.go
+++ b/pkg/compiler/internal/type_inference.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func valueTypeFromRuntime(value runtime.Value) core.ValueType {

--- a/pkg/compiler/internal/wait.go
+++ b/pkg/compiler/internal/wait.go
@@ -3,11 +3,11 @@ package internal
 import (
 	"github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 // WaitCompiler handles the compilation of WAIT FOR expressions in FQL queries.

--- a/pkg/compiler/options.go
+++ b/pkg/compiler/options.go
@@ -1,6 +1,6 @@
 package compiler
 
-import "github.com/MontFerret/ferret/pkg/compiler/internal/optimization"
+import "github.com/MontFerret/ferret/v2/pkg/compiler/internal/optimization"
 
 const (
 	// O0 represents no optimization level, where the compiler performs minimal or no optimizations.

--- a/pkg/compiler/visitor.go
+++ b/pkg/compiler/visitor.go
@@ -1,10 +1,10 @@
 package compiler
 
 import (
-	"github.com/MontFerret/ferret/pkg/compiler/internal"
-	"github.com/MontFerret/ferret/pkg/compiler/internal/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 )
 
 type Visitor struct {

--- a/pkg/diagnostics/diagnostic.go
+++ b/pkg/diagnostics/diagnostic.go
@@ -3,7 +3,7 @@ package diagnostics
 import (
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 // Diagnostic represents a structured diagnostic error with optional source context and spans.

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestMultiCompilationError(t *testing.T) {

--- a/pkg/diagnostics/error_span.go
+++ b/pkg/diagnostics/error_span.go
@@ -1,6 +1,6 @@
 package diagnostics
 
-import "github.com/MontFerret/ferret/pkg/file"
+import "github.com/MontFerret/ferret/v2/pkg/file"
 
 type ErrorSpan struct {
 	Span  file.Span

--- a/pkg/diagnostics/error_span_test.go
+++ b/pkg/diagnostics/error_span_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestErrorSpan(t *testing.T) {

--- a/pkg/diagnostics/formatter.go
+++ b/pkg/diagnostics/formatter.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func FormatDiagnostic(out io.Writer, e *Diagnostic, indent int) {

--- a/pkg/diagnostics/formatter_test.go
+++ b/pkg/diagnostics/formatter_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 func TestFormatError_Basic(t *testing.T) {

--- a/pkg/diagnostics/render.go
+++ b/pkg/diagnostics/render.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 )
 
 // SpanRenderer renders a source span with line numbers and a caret marker.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -3,10 +3,10 @@ package engine
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type Engine struct {

--- a/pkg/engine/engine_options.go
+++ b/pkg/engine/engine_options.go
@@ -4,9 +4,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 )
 
 type (

--- a/pkg/engine/helpers.go
+++ b/pkg/engine/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func IsScalar(result Result) bool {

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -1,6 +1,6 @@
 package engine
 
-import "github.com/MontFerret/ferret/pkg/vm"
+import "github.com/MontFerret/ferret/v2/pkg/vm"
 
 type Plan struct {
 	prog *vm.Program

--- a/pkg/engine/result.go
+++ b/pkg/engine/result.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type (

--- a/pkg/engine/session.go
+++ b/pkg/engine/session.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type Session struct {

--- a/pkg/engine/session_options.go
+++ b/pkg/engine/session_options.go
@@ -1,7 +1,7 @@
 package engine
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type SessionOption = vm.EnvironmentOption

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -4,7 +4,7 @@ package parser
 import (
 	antlr "github.com/antlr4-go/antlr/v4"
 
-	"github.com/MontFerret/ferret/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 )
 
 type Parser struct {

--- a/pkg/runtime/array_iter_test.go
+++ b/pkg/runtime/array_iter_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/array_test.go
+++ b/pkg/runtime/array_test.go
@@ -6,7 +6,7 @@ import (
 
 	c "context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/assertions_test.go
+++ b/pkg/runtime/assertions_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func TestAssertions(t *testing.T) {

--- a/pkg/runtime/binary_test.go
+++ b/pkg/runtime/binary_test.go
@@ -8,7 +8,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func TestBinary(t *testing.T) {

--- a/pkg/runtime/boolean_test.go
+++ b/pkg/runtime/boolean_test.go
@@ -3,7 +3,7 @@ package runtime_test
 import (
 	"testing"
 
-	. "github.com/MontFerret/ferret/pkg/runtime"
+	. "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/casting_test.go
+++ b/pkg/runtime/casting_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func TestCasting(t *testing.T) {

--- a/pkg/runtime/date_time_test.go
+++ b/pkg/runtime/date_time_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"errors"
 

--- a/pkg/runtime/float_test.go
+++ b/pkg/runtime/float_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/helpers_test.go
+++ b/pkg/runtime/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/int_test.go
+++ b/pkg/runtime/int_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/object_iter_test.go
+++ b/pkg/runtime/object_iter_test.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"testing"
 
-	. "github.com/MontFerret/ferret/pkg/runtime"
+	. "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/object_test.go
+++ b/pkg/runtime/object_test.go
@@ -4,7 +4,7 @@ import (
 	c "context"
 	"testing"
 
-	. "github.com/MontFerret/ferret/pkg/runtime"
+	. "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/runtime/sortable_test.go
+++ b/pkg/runtime/sortable_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func TestSortList(t *testing.T) {

--- a/pkg/runtime/string_test.go
+++ b/pkg/runtime/string_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/arrays/append.go
+++ b/pkg/stdlib/arrays/append.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // APPEND appends a new item to an array and returns a new array with a given element.

--- a/pkg/stdlib/arrays/append_test.go
+++ b/pkg/stdlib/arrays/append_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestAppend(t *testing.T) {

--- a/pkg/stdlib/arrays/first.go
+++ b/pkg/stdlib/arrays/first.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // FIRST returns a first element from a given array.

--- a/pkg/stdlib/arrays/first_test.go
+++ b/pkg/stdlib/arrays/first_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestFirst(t *testing.T) {

--- a/pkg/stdlib/arrays/flatten.go
+++ b/pkg/stdlib/arrays/flatten.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // FLATTEN turns an array of arrays into a flat array.

--- a/pkg/stdlib/arrays/flatten_test.go
+++ b/pkg/stdlib/arrays/flatten_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestFlatten_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/intersection.go
+++ b/pkg/stdlib/arrays/intersection.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // INTERSECTION return the intersection of all arrays specified.

--- a/pkg/stdlib/arrays/intersection_test.go
+++ b/pkg/stdlib/arrays/intersection_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestIntersection_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/last.go
+++ b/pkg/stdlib/arrays/last.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // LAST returns the last element of an array.

--- a/pkg/stdlib/arrays/last_test.go
+++ b/pkg/stdlib/arrays/last_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestLast_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/lib.go
+++ b/pkg/stdlib/arrays/lib.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/arrays/lib_test.go
+++ b/pkg/stdlib/arrays/lib_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestToUniqueList(t *testing.T) {

--- a/pkg/stdlib/arrays/minus.go
+++ b/pkg/stdlib/arrays/minus.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MINUS return the difference of all arrays specified.

--- a/pkg/stdlib/arrays/minus_test.go
+++ b/pkg/stdlib/arrays/minus_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestMinus(t *testing.T) {

--- a/pkg/stdlib/arrays/nth.go
+++ b/pkg/stdlib/arrays/nth.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // NTH returns the element of an array at a given position.

--- a/pkg/stdlib/arrays/nth_test.go
+++ b/pkg/stdlib/arrays/nth_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestNth_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/outersection.go
+++ b/pkg/stdlib/arrays/outersection.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // OUTERSECTION return the values that occur only once across all arrays specified.

--- a/pkg/stdlib/arrays/outersection_test.go
+++ b/pkg/stdlib/arrays/outersection_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestOutersection(t *testing.T) {

--- a/pkg/stdlib/arrays/pop.go
+++ b/pkg/stdlib/arrays/pop.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // POP returns a new array without last element.

--- a/pkg/stdlib/arrays/pop_test.go
+++ b/pkg/stdlib/arrays/pop_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestPop(t *testing.T) {

--- a/pkg/stdlib/arrays/position.go
+++ b/pkg/stdlib/arrays/position.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // POSITION returns a value indicating whether an element is contained in array. Optionally returns its position.

--- a/pkg/stdlib/arrays/position_test.go
+++ b/pkg/stdlib/arrays/position_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestPosition_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/push.go
+++ b/pkg/stdlib/arrays/push.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // PUSH create a new array with appended value.

--- a/pkg/stdlib/arrays/push_test.go
+++ b/pkg/stdlib/arrays/push_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestPush(t *testing.T) {

--- a/pkg/stdlib/arrays/remove_nth.go
+++ b/pkg/stdlib/arrays/remove_nth.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // REMOVE_NTH returns a new array without an element by a given position.

--- a/pkg/stdlib/arrays/remove_nth_test.go
+++ b/pkg/stdlib/arrays/remove_nth_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestRemoveNth(t *testing.T) {

--- a/pkg/stdlib/arrays/remove_value.go
+++ b/pkg/stdlib/arrays/remove_value.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // REMOVE_VALUE returns a new array with removed all occurrences of value in a given array.

--- a/pkg/stdlib/arrays/remove_value_test.go
+++ b/pkg/stdlib/arrays/remove_value_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestRemoveValue_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/remove_values.go
+++ b/pkg/stdlib/arrays/remove_values.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // REMOVE_VALUES returns a new array with removed all occurrences of values in a given array.

--- a/pkg/stdlib/arrays/remove_values_test.go
+++ b/pkg/stdlib/arrays/remove_values_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestRemoveValues(t *testing.T) {

--- a/pkg/stdlib/arrays/shift.go
+++ b/pkg/stdlib/arrays/shift.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SHIFT returns a new array without the first element.

--- a/pkg/stdlib/arrays/shift_test.go
+++ b/pkg/stdlib/arrays/shift_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestShift(t *testing.T) {

--- a/pkg/stdlib/arrays/slice.go
+++ b/pkg/stdlib/arrays/slice.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SLICE returns a new sliced array.

--- a/pkg/stdlib/arrays/slice_test.go
+++ b/pkg/stdlib/arrays/slice_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestSlice_Basic(t *testing.T) {

--- a/pkg/stdlib/arrays/sorted.go
+++ b/pkg/stdlib/arrays/sorted.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SORTED sorts all elements in the given list.

--- a/pkg/stdlib/arrays/sorted_test.go
+++ b/pkg/stdlib/arrays/sorted_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestSorted(t *testing.T) {

--- a/pkg/stdlib/arrays/sorted_unique.go
+++ b/pkg/stdlib/arrays/sorted_unique.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SORTED_UNIQUE sorts all elements in a array.

--- a/pkg/stdlib/arrays/sorted_unique_test.go
+++ b/pkg/stdlib/arrays/sorted_unique_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestSortedUnique(t *testing.T) {

--- a/pkg/stdlib/arrays/union.go
+++ b/pkg/stdlib/arrays/union.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // UNION returns the union of all passed arrays.

--- a/pkg/stdlib/arrays/union_distinct.go
+++ b/pkg/stdlib/arrays/union_distinct.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // UNION_DISTINCT returns the union of all passed arrays with unique values.

--- a/pkg/stdlib/arrays/union_distinct_test.go
+++ b/pkg/stdlib/arrays/union_distinct_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestUnionDistinct(t *testing.T) {

--- a/pkg/stdlib/arrays/union_test.go
+++ b/pkg/stdlib/arrays/union_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 // TestUnion_Basic returns the union of distinct values of all passed arrays.

--- a/pkg/stdlib/arrays/unique.go
+++ b/pkg/stdlib/arrays/unique.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // UNIQUE returns all unique elements from a given array.

--- a/pkg/stdlib/arrays/unique_test.go
+++ b/pkg/stdlib/arrays/unique_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestUnique(t *testing.T) {

--- a/pkg/stdlib/arrays/unshift.go
+++ b/pkg/stdlib/arrays/unshift.go
@@ -3,7 +3,7 @@ package arrays
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // UNSHIFT prepends value to a given array.

--- a/pkg/stdlib/arrays/unshift_test.go
+++ b/pkg/stdlib/arrays/unshift_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
 func TestUnshift(t *testing.T) {

--- a/pkg/stdlib/collections/count.go
+++ b/pkg/stdlib/collections/count.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // COUNT computes the number of distinct elements in the given collection and returns the count as an integer.

--- a/pkg/stdlib/collections/count_distinct.go
+++ b/pkg/stdlib/collections/count_distinct.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // COUNT_DISTINCT computes the number of distinct elements in the given collection and returns the count as an integer.

--- a/pkg/stdlib/collections/count_distinct_test.go
+++ b/pkg/stdlib/collections/count_distinct_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
 )
 
 func TestCountDistinct(t *testing.T) {

--- a/pkg/stdlib/collections/count_test.go
+++ b/pkg/stdlib/collections/count_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
 )
 
 func TestCount(t *testing.T) {

--- a/pkg/stdlib/collections/include.go
+++ b/pkg/stdlib/collections/include.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // INCLUDES checks whether a container includes a given value.

--- a/pkg/stdlib/collections/includes_test.go
+++ b/pkg/stdlib/collections/includes_test.go
@@ -6,8 +6,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
 )
 
 func TestIncludes(t *testing.T) {

--- a/pkg/stdlib/collections/lib.go
+++ b/pkg/stdlib/collections/lib.go
@@ -1,7 +1,7 @@
 package collections
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/collections/lib_test.go
+++ b/pkg/stdlib/collections/lib_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
 )
 
 func TestLib(t *testing.T) {

--- a/pkg/stdlib/collections/reverse.go
+++ b/pkg/stdlib/collections/reverse.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // REVERSE returns the reverse of a given string or array value.

--- a/pkg/stdlib/collections/reverse_test.go
+++ b/pkg/stdlib/collections/reverse_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
 )
 
 func TestReverse(t *testing.T) {

--- a/pkg/stdlib/datetime/add_subtract.go
+++ b/pkg/stdlib/datetime/add_subtract.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 var (

--- a/pkg/stdlib/datetime/add_subtract_test.go
+++ b/pkg/stdlib/datetime/add_subtract_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 var (

--- a/pkg/stdlib/datetime/compare.go
+++ b/pkg/stdlib/datetime/compare.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"errors"
 )

--- a/pkg/stdlib/datetime/compare_test.go
+++ b/pkg/stdlib/datetime/compare_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateCompare(t *testing.T) {

--- a/pkg/stdlib/datetime/date.go
+++ b/pkg/stdlib/datetime/date.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE parses a formatted string and returns DateTime object it represents.

--- a/pkg/stdlib/datetime/date_test.go
+++ b/pkg/stdlib/datetime/date_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDate(t *testing.T) {

--- a/pkg/stdlib/datetime/day.go
+++ b/pkg/stdlib/datetime/day.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_DAY returns the day of date as a number.

--- a/pkg/stdlib/datetime/day_test.go
+++ b/pkg/stdlib/datetime/day_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateDay(t *testing.T) {

--- a/pkg/stdlib/datetime/dayofweek.go
+++ b/pkg/stdlib/datetime/dayofweek.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_DAYOFWEEK returns number of the weekday from the date. Sunday is the 0th day of week.

--- a/pkg/stdlib/datetime/dayofweek_test.go
+++ b/pkg/stdlib/datetime/dayofweek_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateDayOfWeek(t *testing.T) {

--- a/pkg/stdlib/datetime/dayofyear.go
+++ b/pkg/stdlib/datetime/dayofyear.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_DAYOFYEAR returns the day of year number of date.

--- a/pkg/stdlib/datetime/dayofyear_test.go
+++ b/pkg/stdlib/datetime/dayofyear_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateDayOfYear(t *testing.T) {

--- a/pkg/stdlib/datetime/daysinmonth.go
+++ b/pkg/stdlib/datetime/daysinmonth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 var daysCount = map[time.Month]int{

--- a/pkg/stdlib/datetime/daysinmonth_test.go
+++ b/pkg/stdlib/datetime/daysinmonth_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateDateDaysInMonth(t *testing.T) {

--- a/pkg/stdlib/datetime/diff.go
+++ b/pkg/stdlib/datetime/diff.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_DIFF returns the difference between two dates in given time unit.

--- a/pkg/stdlib/datetime/diff_test.go
+++ b/pkg/stdlib/datetime/diff_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 var (

--- a/pkg/stdlib/datetime/format.go
+++ b/pkg/stdlib/datetime/format.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_FORMAT format date according to the given format string.

--- a/pkg/stdlib/datetime/format_test.go
+++ b/pkg/stdlib/datetime/format_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateFormat(t *testing.T) {

--- a/pkg/stdlib/datetime/helpers_test.go
+++ b/pkg/stdlib/datetime/helpers_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type testCase struct {

--- a/pkg/stdlib/datetime/hour.go
+++ b/pkg/stdlib/datetime/hour.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_HOUR returns the hour of date as a number.

--- a/pkg/stdlib/datetime/hour_test.go
+++ b/pkg/stdlib/datetime/hour_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateHour(t *testing.T) {

--- a/pkg/stdlib/datetime/leapyear.go
+++ b/pkg/stdlib/datetime/leapyear.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_LEAPYEAR returns true if date is in a leap year else false.

--- a/pkg/stdlib/datetime/leapyear_test.go
+++ b/pkg/stdlib/datetime/leapyear_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateLeapYear(t *testing.T) {

--- a/pkg/stdlib/datetime/lib.go
+++ b/pkg/stdlib/datetime/lib.go
@@ -1,7 +1,7 @@
 package datetime
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/datetime/lib_test.go
+++ b/pkg/stdlib/datetime/lib_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestRegisterLib(t *testing.T) {

--- a/pkg/stdlib/datetime/millisecond.go
+++ b/pkg/stdlib/datetime/millisecond.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_MILLISECOND returns the millisecond of date as a number.

--- a/pkg/stdlib/datetime/millisecond_test.go
+++ b/pkg/stdlib/datetime/millisecond_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateMillisecond(t *testing.T) {

--- a/pkg/stdlib/datetime/minute.go
+++ b/pkg/stdlib/datetime/minute.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_MINUTE returns the minute of date as a number.

--- a/pkg/stdlib/datetime/minute_test.go
+++ b/pkg/stdlib/datetime/minute_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateMinute(t *testing.T) {

--- a/pkg/stdlib/datetime/month.go
+++ b/pkg/stdlib/datetime/month.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_MONTH returns the month of date as a number.

--- a/pkg/stdlib/datetime/month_test.go
+++ b/pkg/stdlib/datetime/month_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateMonth(t *testing.T) {

--- a/pkg/stdlib/datetime/now.go
+++ b/pkg/stdlib/datetime/now.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // NOW returns new DateTime object with Time equal to time.Now().

--- a/pkg/stdlib/datetime/now_test.go
+++ b/pkg/stdlib/datetime/now_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestNow(t *testing.T) {

--- a/pkg/stdlib/datetime/quarter.go
+++ b/pkg/stdlib/datetime/quarter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_QUARTER returns which quarter date belongs to.

--- a/pkg/stdlib/datetime/quarter_test.go
+++ b/pkg/stdlib/datetime/quarter_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateQuarter(t *testing.T) {

--- a/pkg/stdlib/datetime/second.go
+++ b/pkg/stdlib/datetime/second.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_SECOND returns the second of date as a number.

--- a/pkg/stdlib/datetime/second_test.go
+++ b/pkg/stdlib/datetime/second_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateSecond(t *testing.T) {

--- a/pkg/stdlib/datetime/unit_test.go
+++ b/pkg/stdlib/datetime/unit_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 // Test UnitFromString function which is exported

--- a/pkg/stdlib/datetime/week_comparison_test.go
+++ b/pkg/stdlib/datetime/week_comparison_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestWeekComparisonBugFix(t *testing.T) {

--- a/pkg/stdlib/datetime/year.go
+++ b/pkg/stdlib/datetime/year.go
@@ -3,7 +3,7 @@ package datetime
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DATE_YEAR returns the year extracted from the given date.

--- a/pkg/stdlib/datetime/year_test.go
+++ b/pkg/stdlib/datetime/year_test.go
@@ -3,8 +3,8 @@ package datetime_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
 )
 
 func TestDateYear(t *testing.T) {

--- a/pkg/stdlib/io/fs/lib.go
+++ b/pkg/stdlib/io/fs/lib.go
@@ -1,7 +1,7 @@
 package fs
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // RegisterLib register `FS` namespace functions.

--- a/pkg/stdlib/io/fs/lib_test.go
+++ b/pkg/stdlib/io/fs/lib_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/fs"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/fs"
 )
 
 func TestRegisterLib(t *testing.T) {

--- a/pkg/stdlib/io/fs/read.go
+++ b/pkg/stdlib/io/fs/read.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // READ reads from a given file.

--- a/pkg/stdlib/io/fs/read_test.go
+++ b/pkg/stdlib/io/fs/read_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/fs"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/fs"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/io/fs/write.go
+++ b/pkg/stdlib/io/fs/write.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // WRITE writes the given data into the file.

--- a/pkg/stdlib/io/fs/write_test.go
+++ b/pkg/stdlib/io/fs/write_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/fs"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/fs"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/io/lib.go
+++ b/pkg/stdlib/io/lib.go
@@ -1,9 +1,9 @@
 package io
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/fs"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/fs"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net"
 )
 
 // RegisterLib register `IO` namespace functions.

--- a/pkg/stdlib/io/lib_test.go
+++ b/pkg/stdlib/io/lib_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io"
 )
 
 func TestRegisterLib(t *testing.T) {

--- a/pkg/stdlib/io/net/http/delete.go
+++ b/pkg/stdlib/io/net/http/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	h "net/http"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DELETE makes a DELETE request.

--- a/pkg/stdlib/io/net/http/delete_test.go
+++ b/pkg/stdlib/io/net/http/delete_test.go
@@ -8,13 +8,13 @@ import (
 	h "net/http"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/jarcoal/httpmock"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 func TestDELETE(t *testing.T) {

--- a/pkg/stdlib/io/net/http/get.go
+++ b/pkg/stdlib/io/net/http/get.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	h "net/http"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // GET makes a GET request.

--- a/pkg/stdlib/io/net/http/get_test.go
+++ b/pkg/stdlib/io/net/http/get_test.go
@@ -6,13 +6,13 @@ import (
 	h "net/http"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/jarcoal/httpmock"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 func TestGET(t *testing.T) {

--- a/pkg/stdlib/io/net/http/lib.go
+++ b/pkg/stdlib/io/net/http/lib.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // RegisterLib register `HTTP` namespace functions.

--- a/pkg/stdlib/io/net/http/lib_test.go
+++ b/pkg/stdlib/io/net/http/lib_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/jarcoal/httpmock"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 func TestRegisterLib(t *testing.T) {

--- a/pkg/stdlib/io/net/http/post.go
+++ b/pkg/stdlib/io/net/http/post.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	h "net/http"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // POST makes a POST request.

--- a/pkg/stdlib/io/net/http/post_test.go
+++ b/pkg/stdlib/io/net/http/post_test.go
@@ -8,13 +8,13 @@ import (
 	h "net/http"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/jarcoal/httpmock"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 func TestPOST(t *testing.T) {

--- a/pkg/stdlib/io/net/http/put.go
+++ b/pkg/stdlib/io/net/http/put.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	h "net/http"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // PUT makes a PUT HTTP request.

--- a/pkg/stdlib/io/net/http/put_test.go
+++ b/pkg/stdlib/io/net/http/put_test.go
@@ -8,13 +8,13 @@ import (
 	h "net/http"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/jarcoal/httpmock"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 func TestPUT(t *testing.T) {

--- a/pkg/stdlib/io/net/http/request.go
+++ b/pkg/stdlib/io/net/http/request.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	h "net/http"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type Params struct {

--- a/pkg/stdlib/io/net/lib.go
+++ b/pkg/stdlib/io/net/lib.go
@@ -1,8 +1,8 @@
 package net
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net/http"
 )
 
 // RegisterLib register `NET` namespace functions.

--- a/pkg/stdlib/io/net/lib_test.go
+++ b/pkg/stdlib/io/net/lib_test.go
@@ -5,8 +5,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io/net"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net"
 )
 
 func TestRegisterLib(t *testing.T) {

--- a/pkg/stdlib/lib.go
+++ b/pkg/stdlib/lib.go
@@ -1,18 +1,18 @@
 package stdlib
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/arrays"
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
-	"github.com/MontFerret/ferret/pkg/stdlib/datetime"
-	"github.com/MontFerret/ferret/pkg/stdlib/io"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/types"
-	"github.com/MontFerret/ferret/pkg/stdlib/utils"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/types"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/utils"
 )
 
 func New() runtime.Functions {

--- a/pkg/stdlib/math/abs.go
+++ b/pkg/stdlib/math/abs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ABS returns the absolute value of a given number.

--- a/pkg/stdlib/math/abs_test.go
+++ b/pkg/stdlib/math/abs_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/acos.go
+++ b/pkg/stdlib/math/acos.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ACOS returns the arccosine, in radians, of a given number.

--- a/pkg/stdlib/math/acos_test.go
+++ b/pkg/stdlib/math/acos_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/asin.go
+++ b/pkg/stdlib/math/asin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ASIN returns the arcsine, in radians, of a given number.

--- a/pkg/stdlib/math/asin_test.go
+++ b/pkg/stdlib/math/asin_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/atan.go
+++ b/pkg/stdlib/math/atan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ATAN returns the arctangent, in radians, of a given number.

--- a/pkg/stdlib/math/atan2.go
+++ b/pkg/stdlib/math/atan2.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ATAN2 returns the arc tangent of y/x, using the signs of the two to determine the quadrant of the return value.

--- a/pkg/stdlib/math/atan2_test.go
+++ b/pkg/stdlib/math/atan2_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/atan_test.go
+++ b/pkg/stdlib/math/atan_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/average.go
+++ b/pkg/stdlib/math/average.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // AVERAGE Returns the average (arithmetic mean) of the values in array.

--- a/pkg/stdlib/math/average_test.go
+++ b/pkg/stdlib/math/average_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/ceil.go
+++ b/pkg/stdlib/math/ceil.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // CEIL returns the least integer value greater than or equal to a given value.

--- a/pkg/stdlib/math/ceil_test.go
+++ b/pkg/stdlib/math/ceil_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/cos.go
+++ b/pkg/stdlib/math/cos.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // COS returns the cosine of a given number.

--- a/pkg/stdlib/math/cos_test.go
+++ b/pkg/stdlib/math/cos_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/degrees.go
+++ b/pkg/stdlib/math/degrees.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DEGREES returns the angle converted from radians to degrees.

--- a/pkg/stdlib/math/degrees_test.go
+++ b/pkg/stdlib/math/degrees_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/exp.go
+++ b/pkg/stdlib/math/exp.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // EXP returns Euler's constant (2.71828...) raised to the power of value.

--- a/pkg/stdlib/math/exp2.go
+++ b/pkg/stdlib/math/exp2.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // EXP2 returns 2 raised to the power of value.

--- a/pkg/stdlib/math/exp2_test.go
+++ b/pkg/stdlib/math/exp2_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/exp_test.go
+++ b/pkg/stdlib/math/exp_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/floor.go
+++ b/pkg/stdlib/math/floor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // FLOOR returns the greatest integer value less than or equal to a given value.

--- a/pkg/stdlib/math/floor_test.go
+++ b/pkg/stdlib/math/floor_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/lib.go
+++ b/pkg/stdlib/math/lib.go
@@ -3,7 +3,7 @@ package math
 import (
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 const (

--- a/pkg/stdlib/math/log.go
+++ b/pkg/stdlib/math/log.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // LOG returns the natural logarithm of a given value.

--- a/pkg/stdlib/math/log10.go
+++ b/pkg/stdlib/math/log10.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // LOG10 returns the decimal logarithm of a given value.

--- a/pkg/stdlib/math/log10_test.go
+++ b/pkg/stdlib/math/log10_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/log2.go
+++ b/pkg/stdlib/math/log2.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // LOG2 returns the binary logarithm of a given value.

--- a/pkg/stdlib/math/log2_test.go
+++ b/pkg/stdlib/math/log2_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/log_test.go
+++ b/pkg/stdlib/math/log_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/max.go
+++ b/pkg/stdlib/math/max.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MAX returns the greatest (arithmetic mean) of the values in array.

--- a/pkg/stdlib/math/max_test.go
+++ b/pkg/stdlib/math/max_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/mean.go
+++ b/pkg/stdlib/math/mean.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func mean(ctx context.Context, input runtime.List) (runtime.Float, error) {

--- a/pkg/stdlib/math/median.go
+++ b/pkg/stdlib/math/median.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MEDIAN returns the median of the values in array.

--- a/pkg/stdlib/math/median_test.go
+++ b/pkg/stdlib/math/median_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/min.go
+++ b/pkg/stdlib/math/min.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MIN returns the smallest (arithmetic mean) of the values in array.

--- a/pkg/stdlib/math/min_test.go
+++ b/pkg/stdlib/math/min_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/percentile.go
+++ b/pkg/stdlib/math/percentile.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"errors"
 )

--- a/pkg/stdlib/math/percentile_test.go
+++ b/pkg/stdlib/math/percentile_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/pi.go
+++ b/pkg/stdlib/math/pi.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // PI returns Pi value.

--- a/pkg/stdlib/math/pi_test.go
+++ b/pkg/stdlib/math/pi_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 )
 
 func TestPi(t *testing.T) {

--- a/pkg/stdlib/math/pow.go
+++ b/pkg/stdlib/math/pow.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // POW returns the base to the exponent value.

--- a/pkg/stdlib/math/pow_test.go
+++ b/pkg/stdlib/math/pow_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/radians.go
+++ b/pkg/stdlib/math/radians.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // RADIANS returns the angle converted from degrees to radians.

--- a/pkg/stdlib/math/radians_test.go
+++ b/pkg/stdlib/math/radians_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/rand.go
+++ b/pkg/stdlib/math/rand.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // RAND return a pseudo-random number between 0 and 1.

--- a/pkg/stdlib/math/rand_test.go
+++ b/pkg/stdlib/math/rand_test.go
@@ -6,7 +6,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 )
 
 func TestRand(t *testing.T) {

--- a/pkg/stdlib/math/range.go
+++ b/pkg/stdlib/math/range.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // RANGE returns an array of numbers in the specified range, optionally with increments other than 1.

--- a/pkg/stdlib/math/range_test.go
+++ b/pkg/stdlib/math/range_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/round.go
+++ b/pkg/stdlib/math/round.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ROUND returns the nearest integer, rounding half away from zero.

--- a/pkg/stdlib/math/round_test.go
+++ b/pkg/stdlib/math/round_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/sin.go
+++ b/pkg/stdlib/math/sin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SIN returns the sine of the radian argument.

--- a/pkg/stdlib/math/sin_test.go
+++ b/pkg/stdlib/math/sin_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/sqrt.go
+++ b/pkg/stdlib/math/sqrt.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SQRT returns the square root of a given number.

--- a/pkg/stdlib/math/sqrt_test.go
+++ b/pkg/stdlib/math/sqrt_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/stddev_population.go
+++ b/pkg/stdlib/math/stddev_population.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // STDDEV_POPULATION returns the population standard deviation of the values in a given array.

--- a/pkg/stdlib/math/stddev_population_test.go
+++ b/pkg/stdlib/math/stddev_population_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/stddev_sample.go
+++ b/pkg/stdlib/math/stddev_sample.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // STDDEV_SAMPLE returns the sample standard deviation of the values in a given array.

--- a/pkg/stdlib/math/stddev_sample_test.go
+++ b/pkg/stdlib/math/stddev_sample_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/sum.go
+++ b/pkg/stdlib/math/sum.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SUM returns the sum of the values in a given array.

--- a/pkg/stdlib/math/sum_test.go
+++ b/pkg/stdlib/math/sum_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/tan.go
+++ b/pkg/stdlib/math/tan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TAN returns the tangent of a given number.

--- a/pkg/stdlib/math/tan_test.go
+++ b/pkg/stdlib/math/tan_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/variance.go
+++ b/pkg/stdlib/math/variance.go
@@ -3,7 +3,7 @@ package math
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func variance(ctx context.Context, input runtime.List, sample runtime.Int) (runtime.Float, error) {

--- a/pkg/stdlib/math/variance_population.go
+++ b/pkg/stdlib/math/variance_population.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // VARIANCE_POPULATION returns the population variance of the values in a given array.

--- a/pkg/stdlib/math/variance_population_test.go
+++ b/pkg/stdlib/math/variance_population_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/math/variance_sample.go
+++ b/pkg/stdlib/math/variance_sample.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // VARIANCE_SAMPLE returns the sample variance of the values in a given array.

--- a/pkg/stdlib/math/variance_sample_test.go
+++ b/pkg/stdlib/math/variance_sample_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/has.go
+++ b/pkg/stdlib/objects/has.go
@@ -3,7 +3,7 @@ package objects
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // HAS returns the value stored by the given key.

--- a/pkg/stdlib/objects/has_test.go
+++ b/pkg/stdlib/objects/has_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/keep_keys.go
+++ b/pkg/stdlib/objects/keep_keys.go
@@ -3,7 +3,7 @@ package objects
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // KEEP_KEYS returns a new object with only given keys.

--- a/pkg/stdlib/objects/keep_keys_test.go
+++ b/pkg/stdlib/objects/keep_keys_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 )
 
 // TODO: Fix tests

--- a/pkg/stdlib/objects/keys.go
+++ b/pkg/stdlib/objects/keys.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // KEYS returns string array of object's keys

--- a/pkg/stdlib/objects/keys_test.go
+++ b/pkg/stdlib/objects/keys_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/lib.go
+++ b/pkg/stdlib/objects/lib.go
@@ -1,6 +1,6 @@
 package objects
 
-import "github.com/MontFerret/ferret/pkg/runtime"
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 func RegisterLib(ns runtime.Namespace) error {
 	ns.Functions().

--- a/pkg/stdlib/objects/merge.go
+++ b/pkg/stdlib/objects/merge.go
@@ -3,7 +3,7 @@ package objects
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MERGE merge the given objects into a single object.

--- a/pkg/stdlib/objects/merge_recursive.go
+++ b/pkg/stdlib/objects/merge_recursive.go
@@ -3,7 +3,7 @@ package objects
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MERGE_RECURSIVE recursively merge the given objects into a single object.

--- a/pkg/stdlib/objects/merge_recursive_test.go
+++ b/pkg/stdlib/objects/merge_recursive_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/merge_test.go
+++ b/pkg/stdlib/objects/merge_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/values.go
+++ b/pkg/stdlib/objects/values.go
@@ -3,7 +3,7 @@ package objects
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // VALUES return the attribute values of the object as an array.

--- a/pkg/stdlib/objects/values_test.go
+++ b/pkg/stdlib/objects/values_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/objects/zip.go
+++ b/pkg/stdlib/objects/zip.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ZIP returns an object assembled from the separate parameters keys and values.

--- a/pkg/stdlib/objects/zip_test.go
+++ b/pkg/stdlib/objects/zip_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/path/base.go
+++ b/pkg/stdlib/path/base.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // BASE returns the last component of the path or the path itself if it does not contain any directory separators.

--- a/pkg/stdlib/path/base_test.go
+++ b/pkg/stdlib/path/base_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestBase(t *testing.T) {

--- a/pkg/stdlib/path/clean.go
+++ b/pkg/stdlib/path/clean.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // CLEAN returns the shortest path name equivalent to path.

--- a/pkg/stdlib/path/clean_test.go
+++ b/pkg/stdlib/path/clean_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestClean(t *testing.T) {

--- a/pkg/stdlib/path/dir.go
+++ b/pkg/stdlib/path/dir.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // DIR returns the directory component of path.

--- a/pkg/stdlib/path/dir_test.go
+++ b/pkg/stdlib/path/dir_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestDir(t *testing.T) {

--- a/pkg/stdlib/path/ext.go
+++ b/pkg/stdlib/path/ext.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // EXT returns the extension of the last component of path.

--- a/pkg/stdlib/path/ext_test.go
+++ b/pkg/stdlib/path/ext_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestExt(t *testing.T) {

--- a/pkg/stdlib/path/is_abs.go
+++ b/pkg/stdlib/path/is_abs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_ABS reports whether the path is absolute.

--- a/pkg/stdlib/path/is_abs_test.go
+++ b/pkg/stdlib/path/is_abs_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestIsAbs(t *testing.T) {

--- a/pkg/stdlib/path/join.go
+++ b/pkg/stdlib/path/join.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // JOIN joins any number of path elements into a single path, separating them with slashes.

--- a/pkg/stdlib/path/join_test.go
+++ b/pkg/stdlib/path/join_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestJoin(t *testing.T) {

--- a/pkg/stdlib/path/lib.go
+++ b/pkg/stdlib/path/lib.go
@@ -1,6 +1,6 @@
 package path
 
-import "github.com/MontFerret/ferret/pkg/runtime"
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 // RegisterLib register `PATH` namespace functions.
 // @namespace PATH

--- a/pkg/stdlib/path/match.go
+++ b/pkg/stdlib/path/match.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // MATCH reports whether name matches the pattern.

--- a/pkg/stdlib/path/match_test.go
+++ b/pkg/stdlib/path/match_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestMatch(t *testing.T) {

--- a/pkg/stdlib/path/separate.go
+++ b/pkg/stdlib/path/separate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SEPARATE separates the path into a directory and filename component.

--- a/pkg/stdlib/path/separate_test.go
+++ b/pkg/stdlib/path/separate_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/path"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
 )
 
 func TestSeparate(t *testing.T) {

--- a/pkg/stdlib/strings/case.go
+++ b/pkg/stdlib/strings/case.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // LOWER converts strings to their lower-case counterparts. All other characters are returned unchanged.

--- a/pkg/stdlib/strings/case_test.go
+++ b/pkg/stdlib/strings/case_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestLower(t *testing.T) {

--- a/pkg/stdlib/strings/concat.go
+++ b/pkg/stdlib/strings/concat.go
@@ -3,7 +3,7 @@ package strings
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // CONCAT concatenates one or more instances of String, or an arrayList.

--- a/pkg/stdlib/strings/concat_test.go
+++ b/pkg/stdlib/strings/concat_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestConcat(t *testing.T) {

--- a/pkg/stdlib/strings/contains.go
+++ b/pkg/stdlib/strings/contains.go
@@ -3,7 +3,7 @@ package strings
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // CONTAINS returns a value indicating whether a specified substring occurs within a string.

--- a/pkg/stdlib/strings/contains_test.go
+++ b/pkg/stdlib/strings/contains_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestContains(t *testing.T) {

--- a/pkg/stdlib/strings/decode.go
+++ b/pkg/stdlib/strings/decode.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // FROM_BASE64 returns the value of a base64 representation.

--- a/pkg/stdlib/strings/decode_test.go
+++ b/pkg/stdlib/strings/decode_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/strings/encode.go
+++ b/pkg/stdlib/strings/encode.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"net/url"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ENCODE_URI_COMPONENT returns the encoded String of uri.

--- a/pkg/stdlib/strings/encode_test.go
+++ b/pkg/stdlib/strings/encode_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestEncodedURIComponent(t *testing.T) {

--- a/pkg/stdlib/strings/escape.go
+++ b/pkg/stdlib/strings/escape.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"html"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ESCAPE_HTML escapes special characters like "<" to become "&lt;". It

--- a/pkg/stdlib/strings/escape_test.go
+++ b/pkg/stdlib/strings/escape_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/strings/find.go
+++ b/pkg/stdlib/strings/find.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // FIND_FIRST returns the position of the first occurrence of the string search inside the string text. Positions start at 0.

--- a/pkg/stdlib/strings/find_test.go
+++ b/pkg/stdlib/strings/find_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestFindFirst(t *testing.T) {

--- a/pkg/stdlib/strings/fmt.go
+++ b/pkg/stdlib/strings/fmt.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"errors"
 )

--- a/pkg/stdlib/strings/fmt_test.go
+++ b/pkg/stdlib/strings/fmt_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 type testCase struct {

--- a/pkg/stdlib/strings/json.go
+++ b/pkg/stdlib/strings/json.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/wI2L/jettison"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // JSON_PARSE returns a value described by the JSON-encoded input string.

--- a/pkg/stdlib/strings/json_test.go
+++ b/pkg/stdlib/strings/json_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 // TODO: Fix the tests

--- a/pkg/stdlib/strings/lib.go
+++ b/pkg/stdlib/strings/lib.go
@@ -1,7 +1,7 @@
 package strings
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/strings/like.go
+++ b/pkg/stdlib/strings/like.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/gobwas/glob"
 )

--- a/pkg/stdlib/strings/like_test.go
+++ b/pkg/stdlib/strings/like_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestLike(t *testing.T) {

--- a/pkg/stdlib/strings/random.go
+++ b/pkg/stdlib/strings/random.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 const (

--- a/pkg/stdlib/strings/random_test.go
+++ b/pkg/stdlib/strings/random_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestRandomToken(t *testing.T) {

--- a/pkg/stdlib/strings/regex.go
+++ b/pkg/stdlib/strings/regex.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // REGEX_MATCH returns the matches in the given string text, using the regex.

--- a/pkg/stdlib/strings/regex_test.go
+++ b/pkg/stdlib/strings/regex_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestRegexMatch(t *testing.T) {

--- a/pkg/stdlib/strings/split.go
+++ b/pkg/stdlib/strings/split.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SPLIT splits the given string value into a list of strings, using the separator.

--- a/pkg/stdlib/strings/split_test.go
+++ b/pkg/stdlib/strings/split_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestSplit(t *testing.T) {

--- a/pkg/stdlib/strings/substitute.go
+++ b/pkg/stdlib/strings/substitute.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SUBSTITUTE replaces search values in the string value.

--- a/pkg/stdlib/strings/substitute_test.go
+++ b/pkg/stdlib/strings/substitute_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestSubstitute(t *testing.T) {

--- a/pkg/stdlib/strings/substr.go
+++ b/pkg/stdlib/strings/substr.go
@@ -3,7 +3,7 @@ package strings
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // SUBSTRING returns a substring of value.

--- a/pkg/stdlib/strings/substr_test.go
+++ b/pkg/stdlib/strings/substr_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestSubstring(t *testing.T) {

--- a/pkg/stdlib/strings/trim.go
+++ b/pkg/stdlib/strings/trim.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TRIM returns the string value with whitespace stripped from the start and/or end.

--- a/pkg/stdlib/strings/trim_test.go
+++ b/pkg/stdlib/strings/trim_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
 func TestLTrim(t *testing.T) {

--- a/pkg/stdlib/strings/unescape.go
+++ b/pkg/stdlib/strings/unescape.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"html"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // UNESCAPE_HTML unescapes entities like "&lt;" to become "<". It unescapes a

--- a/pkg/stdlib/strings/unescape_test.go
+++ b/pkg/stdlib/strings/unescape_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/stdlib/testing/array.go
+++ b/pkg/stdlib/testing/array.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // ARRAY asserts that value is a array type.

--- a/pkg/stdlib/testing/array_test.go
+++ b/pkg/stdlib/testing/array_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestArray(t *t.T) {

--- a/pkg/stdlib/testing/base/assertion.go
+++ b/pkg/stdlib/testing/base/assertion.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type AssertionFn func(ctx context.Context, args []runtime.Value) (bool, error)

--- a/pkg/stdlib/testing/base/compare.go
+++ b/pkg/stdlib/testing/base/compare.go
@@ -1,7 +1,7 @@
 package base
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type CompareOperator int

--- a/pkg/stdlib/testing/base/format.go
+++ b/pkg/stdlib/testing/base/format.go
@@ -3,7 +3,7 @@ package base
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func FormatValue(val runtime.Value) string {

--- a/pkg/stdlib/testing/binary.go
+++ b/pkg/stdlib/testing/binary.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // BINARY asserts that value is a binary type.

--- a/pkg/stdlib/testing/binary_test.go
+++ b/pkg/stdlib/testing/binary_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestBinary(t *t.T) {

--- a/pkg/stdlib/testing/datetime.go
+++ b/pkg/stdlib/testing/datetime.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // DATETIME asserts that value is a datetime type.

--- a/pkg/stdlib/testing/datetime_test.go
+++ b/pkg/stdlib/testing/datetime_test.go
@@ -7,9 +7,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestDateTime(t *t.T) {

--- a/pkg/stdlib/testing/empty.go
+++ b/pkg/stdlib/testing/empty.go
@@ -3,8 +3,8 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // EMPTY asserts that the target does not contain any values.

--- a/pkg/stdlib/testing/empty_test.go
+++ b/pkg/stdlib/testing/empty_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestEmpty(t *t.T) {

--- a/pkg/stdlib/testing/equal.go
+++ b/pkg/stdlib/testing/equal.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // EQUAL asserts equality of actual and expected values.

--- a/pkg/stdlib/testing/equal_test.go
+++ b/pkg/stdlib/testing/equal_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestEqual(t *t.T) {

--- a/pkg/stdlib/testing/fail.go
+++ b/pkg/stdlib/testing/fail.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // FAIL returns an error.

--- a/pkg/stdlib/testing/fail_test.go
+++ b/pkg/stdlib/testing/fail_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestFail(t *t.T) {

--- a/pkg/stdlib/testing/false.go
+++ b/pkg/stdlib/testing/false.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // FALSE asserts that value is false.

--- a/pkg/stdlib/testing/false_test.go
+++ b/pkg/stdlib/testing/false_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestFalse(t *t.T) {

--- a/pkg/stdlib/testing/float.go
+++ b/pkg/stdlib/testing/float.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // FLOAT asserts that value is a float type.

--- a/pkg/stdlib/testing/float_test.go
+++ b/pkg/stdlib/testing/float_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestFloat(t *t.T) {

--- a/pkg/stdlib/testing/gt.go
+++ b/pkg/stdlib/testing/gt.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // GT asserts that an actual value is greater than an expected one.

--- a/pkg/stdlib/testing/gt_test.go
+++ b/pkg/stdlib/testing/gt_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestGt(t *t.T) {

--- a/pkg/stdlib/testing/gte.go
+++ b/pkg/stdlib/testing/gte.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // GTE asserts that an actual value is greater than or equal to an expected one.

--- a/pkg/stdlib/testing/gte_test.go
+++ b/pkg/stdlib/testing/gte_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestGte(t *t.T) {

--- a/pkg/stdlib/testing/include.go
+++ b/pkg/stdlib/testing/include.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/collections"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // INCLUDE asserts that haystack includes needle.

--- a/pkg/stdlib/testing/include_test.go
+++ b/pkg/stdlib/testing/include_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestInclude(t *t.T) {

--- a/pkg/stdlib/testing/int.go
+++ b/pkg/stdlib/testing/int.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // INT asserts that value is a int type.

--- a/pkg/stdlib/testing/int_test.go
+++ b/pkg/stdlib/testing/int_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestInt(t *t.T) {

--- a/pkg/stdlib/testing/len.go
+++ b/pkg/stdlib/testing/len.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // LEN asserts that a measurable value has a length or size with the expected value.

--- a/pkg/stdlib/testing/len_test.go
+++ b/pkg/stdlib/testing/len_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
 )
 
 func TestLen(t *t.T) {

--- a/pkg/stdlib/testing/lib.go
+++ b/pkg/stdlib/testing/lib.go
@@ -1,8 +1,8 @@
 package testing
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // @namespace T

--- a/pkg/stdlib/testing/lt.go
+++ b/pkg/stdlib/testing/lt.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // LT asserts that an actual value is lesser than an expected one.

--- a/pkg/stdlib/testing/lt_test.go
+++ b/pkg/stdlib/testing/lt_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestLt(t *t.T) {

--- a/pkg/stdlib/testing/lte.go
+++ b/pkg/stdlib/testing/lte.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // LTE asserts that an actual value is lesser than or equal to an expected one.

--- a/pkg/stdlib/testing/lte_test.go
+++ b/pkg/stdlib/testing/lte_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestLte(t *t.T) {

--- a/pkg/stdlib/testing/match.go
+++ b/pkg/stdlib/testing/match.go
@@ -3,10 +3,10 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/strings"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // MATCH asserts that value matches the regular expression.

--- a/pkg/stdlib/testing/match_test.go
+++ b/pkg/stdlib/testing/match_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestMatch(t *t.T) {

--- a/pkg/stdlib/testing/none.go
+++ b/pkg/stdlib/testing/none.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // NONE asserts that value is none.

--- a/pkg/stdlib/testing/none_test.go
+++ b/pkg/stdlib/testing/none_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
 )
 
 func TestNone(t *t.T) {

--- a/pkg/stdlib/testing/object.go
+++ b/pkg/stdlib/testing/object.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // OBJECT asserts that value is a object type.

--- a/pkg/stdlib/testing/object_test.go
+++ b/pkg/stdlib/testing/object_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestObject(t *t.T) {

--- a/pkg/stdlib/testing/string.go
+++ b/pkg/stdlib/testing/string.go
@@ -3,9 +3,9 @@ package testing
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // STRING asserts that value is a string type.

--- a/pkg/stdlib/testing/string_test.go
+++ b/pkg/stdlib/testing/string_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestString(t *t.T) {

--- a/pkg/stdlib/testing/true.go
+++ b/pkg/stdlib/testing/true.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // TRUE asserts that value is true.

--- a/pkg/stdlib/testing/true_test.go
+++ b/pkg/stdlib/testing/true_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	t "testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/pkg/stdlib/testing/base"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 func TestTrue(t *t.T) {

--- a/pkg/stdlib/types/is_array.go
+++ b/pkg/stdlib/types/is_array.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_ARRAY checks whether value is an array value.

--- a/pkg/stdlib/types/is_binary.go
+++ b/pkg/stdlib/types/is_binary.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_BINARY checks whether value is a binary value.

--- a/pkg/stdlib/types/is_boolean.go
+++ b/pkg/stdlib/types/is_boolean.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_BOOL checks whether value is a boolean value.

--- a/pkg/stdlib/types/is_date_time.go
+++ b/pkg/stdlib/types/is_date_time.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_DATETIME checks whether value is a date time value.

--- a/pkg/stdlib/types/is_float.go
+++ b/pkg/stdlib/types/is_float.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_FLOAT checks whether value is a float value.

--- a/pkg/stdlib/types/is_html_document.go
+++ b/pkg/stdlib/types/is_html_document.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_HTML_DOCUMENT checks whether value is a HTMLDocument value.

--- a/pkg/stdlib/types/is_html_element.go
+++ b/pkg/stdlib/types/is_html_element.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_HTML_ELEMENT checks whether value is a HTMLElement value.

--- a/pkg/stdlib/types/is_int.go
+++ b/pkg/stdlib/types/is_int.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_INT checks whether value is a int value.

--- a/pkg/stdlib/types/is_list.go
+++ b/pkg/stdlib/types/is_list.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_LSIT checks whether value is a list value.

--- a/pkg/stdlib/types/is_map.go
+++ b/pkg/stdlib/types/is_map.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_MAP checks whether value is a map value.

--- a/pkg/stdlib/types/is_nan.go
+++ b/pkg/stdlib/types/is_nan.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_NAN checks whether value is NaN.

--- a/pkg/stdlib/types/is_none.go
+++ b/pkg/stdlib/types/is_none.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_NONE checks whether value is a none value.

--- a/pkg/stdlib/types/is_object.go
+++ b/pkg/stdlib/types/is_object.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_OBJECT checks whether value is an object value.

--- a/pkg/stdlib/types/is_string.go
+++ b/pkg/stdlib/types/is_string.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // IS_STRING checks whether value is a string value.

--- a/pkg/stdlib/types/lib.go
+++ b/pkg/stdlib/types/lib.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/types/to_array.go
+++ b/pkg/stdlib/types/to_array.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_ARRAY takes an input value of any type and convert it into an array value.

--- a/pkg/stdlib/types/to_binary.go
+++ b/pkg/stdlib/types/to_binary.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // ToBinary takes an input value of any type and converts it into a binary value.

--- a/pkg/stdlib/types/to_boolean.go
+++ b/pkg/stdlib/types/to_boolean.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_BOOL takes an input value of any type and converts it into the appropriate boolean value.

--- a/pkg/stdlib/types/to_date_time.go
+++ b/pkg/stdlib/types/to_date_time.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_DATETIME takes an input value of any type and converts it into the appropriate date time value.

--- a/pkg/stdlib/types/to_float.go
+++ b/pkg/stdlib/types/to_float.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_FLOAT takes an input value of any type and convert it into a float value.

--- a/pkg/stdlib/types/to_int.go
+++ b/pkg/stdlib/types/to_int.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_INT takes an input value of any type and convert it into an integer value.

--- a/pkg/stdlib/types/to_object.go
+++ b/pkg/stdlib/types/to_object.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_OBJECT converts the given value to an object.

--- a/pkg/stdlib/types/to_string.go
+++ b/pkg/stdlib/types/to_string.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // TO_STRING takes an input value of any type and convert it into a string value.

--- a/pkg/stdlib/utils/lib.go
+++ b/pkg/stdlib/utils/lib.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func RegisterLib(ns runtime.Namespace) error {

--- a/pkg/stdlib/utils/log.go
+++ b/pkg/stdlib/utils/log.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // PRINT writes messages into the system log.

--- a/pkg/stdlib/utils/wait.go
+++ b/pkg/stdlib/utils/wait.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // WAIT pauses the execution for a given period.

--- a/pkg/vm/env.go
+++ b/pkg/vm/env.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"os"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type (

--- a/pkg/vm/env_options.go
+++ b/pkg/vm/env_options.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func WithParams(params map[string]runtime.Value) EnvironmentOption {

--- a/pkg/vm/error_handler.go
+++ b/pkg/vm/error_handler.go
@@ -3,9 +3,9 @@ package vm
 import (
 	"errors"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func toRuntimeError(program *Program, pc int, err error) *RuntimeError {

--- a/pkg/vm/error_set.go
+++ b/pkg/vm/error_set.go
@@ -1,6 +1,6 @@
 package vm
 
-import "github.com/MontFerret/ferret/pkg/diagnostics"
+import "github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
 type RuntimeErrorSet = diagnostics.Diagnostics[*RuntimeError]
 

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 )
 
 // RuntimeError represents a VM execution error with source context.

--- a/pkg/vm/instruction.go
+++ b/pkg/vm/instruction.go
@@ -1,6 +1,6 @@
 package vm
 
-import "github.com/MontFerret/ferret/pkg/vm/internal/data"
+import "github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 
 type Instruction struct {
 	Opcode   Opcode

--- a/pkg/vm/internal/data/collector_counter.go
+++ b/pkg/vm/internal/data/collector_counter.go
@@ -3,7 +3,7 @@ package data
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // CounterCollector is a Transformer implementation that tracks and increments a counter of processed values.

--- a/pkg/vm/internal/data/collector_key.go
+++ b/pkg/vm/internal/data/collector_key.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // KeyCollector is a structure used to collect and group unique runtime values by their string keys.

--- a/pkg/vm/internal/data/collector_key_counter.go
+++ b/pkg/vm/internal/data/collector_key_counter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type KeyCounterCollector struct {

--- a/pkg/vm/internal/data/collector_key_group.go
+++ b/pkg/vm/internal/data/collector_key_group.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type KeyGroupCollector struct {

--- a/pkg/vm/internal/data/dataset.go
+++ b/pkg/vm/internal/data/dataset.go
@@ -3,7 +3,7 @@ package data
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type DataSet struct {

--- a/pkg/vm/internal/data/fast_object.go
+++ b/pkg/vm/internal/data/fast_object.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/wI2L/jettison"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type (

--- a/pkg/vm/internal/data/helpers.go
+++ b/pkg/vm/internal/data/helpers.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func ToRegexp(input runtime.Value) (*Regexp, error) {

--- a/pkg/vm/internal/data/iterator.go
+++ b/pkg/vm/internal/data/iterator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type Iterator struct {

--- a/pkg/vm/internal/data/kv.go
+++ b/pkg/vm/internal/data/kv.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/wI2L/jettison"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // KV represents a key-value pair where both the key and value are of type runtime.Value.

--- a/pkg/vm/internal/data/kv_iter.go
+++ b/pkg/vm/internal/data/kv_iter.go
@@ -3,7 +3,7 @@ package data
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type KVIterator struct {

--- a/pkg/vm/internal/data/noop_iter.go
+++ b/pkg/vm/internal/data/noop_iter.go
@@ -3,7 +3,7 @@ package data
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type noopIter struct{}

--- a/pkg/vm/internal/data/range.go
+++ b/pkg/vm/internal/data/range.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/wI2L/jettison"
 )

--- a/pkg/vm/internal/data/range_iter.go
+++ b/pkg/vm/internal/data/range_iter.go
@@ -3,7 +3,7 @@ package data
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type RangeIterator struct {

--- a/pkg/vm/internal/data/range_iter_test.go
+++ b/pkg/vm/internal/data/range_iter_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/vm/internal/data/regexp.go
+++ b/pkg/vm/internal/data/regexp.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/wI2L/jettison"
 )

--- a/pkg/vm/internal/data/sorter.go
+++ b/pkg/vm/internal/data/sorter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type Sorter struct {

--- a/pkg/vm/internal/data/sorter_multi.go
+++ b/pkg/vm/internal/data/sorter_multi.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type MultiSorter struct {

--- a/pkg/vm/internal/data/stream.go
+++ b/pkg/vm/internal/data/stream.go
@@ -3,7 +3,7 @@ package data
 import (
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type StreamValue struct {

--- a/pkg/vm/internal/data/transformer.go
+++ b/pkg/vm/internal/data/transformer.go
@@ -3,7 +3,7 @@ package data
 import (
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type Transformer interface {

--- a/pkg/vm/internal/mem/cache.go
+++ b/pkg/vm/internal/mem/cache.go
@@ -3,8 +3,8 @@ package mem
 import (
 	"regexp"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 )
 
 type (

--- a/pkg/vm/internal/mem/registers.go
+++ b/pkg/vm/internal/mem/registers.go
@@ -1,6 +1,6 @@
 package mem
 
-import "github.com/MontFerret/ferret/pkg/runtime"
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 type RegisterFile struct {
 	Values  []runtime.Value

--- a/pkg/vm/internal/operators/array.go
+++ b/pkg/vm/internal/operators/array.go
@@ -3,7 +3,7 @@ package operators
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func ArrayAll(ctx context.Context, cmp Comparator, left, right runtime.Value) (runtime.Boolean, error) {

--- a/pkg/vm/internal/operators/binary.go
+++ b/pkg/vm/internal/operators/binary.go
@@ -1,6 +1,6 @@
 package operators
 
-import "github.com/MontFerret/ferret/pkg/runtime"
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 func Negate(input runtime.Value) runtime.Value {
 	switch val := input.(type) {

--- a/pkg/vm/internal/operators/cmp.go
+++ b/pkg/vm/internal/operators/cmp.go
@@ -3,7 +3,7 @@ package operators
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type Comparator int

--- a/pkg/vm/internal/operators/collection.go
+++ b/pkg/vm/internal/operators/collection.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func Contains(ctx context.Context, input runtime.Value, value runtime.Value) runtime.Boolean {

--- a/pkg/vm/internal/operators/range.go
+++ b/pkg/vm/internal/operators/range.go
@@ -3,8 +3,8 @@ package operators
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 )
 
 func ToRange(ctx context.Context, left, right runtime.Value) (runtime.Value, error) {

--- a/pkg/vm/internal/operators/string.go
+++ b/pkg/vm/internal/operators/string.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gobwas/glob"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func Like(left, right runtime.Value) (runtime.Boolean, error) {

--- a/pkg/vm/program.go
+++ b/pkg/vm/program.go
@@ -1,8 +1,8 @@
 package vm
 
 import (
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type (

--- a/pkg/vm/validation.go
+++ b/pkg/vm/validation.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func validate(env *Environment, program *Program) error {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"io"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm/internal/data"
-	"github.com/MontFerret/ferret/pkg/vm/internal/mem"
-	"github.com/MontFerret/ferret/pkg/vm/internal/operators"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/operators"
 )
 
 type VM struct {

--- a/pkg/vm/vm_errors.go
+++ b/pkg/vm/vm_errors.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func (vm *VM) wrapRuntimeError(err error) error {

--- a/pkg/vm/vm_helpers.go
+++ b/pkg/vm/vm_helpers.go
@@ -3,9 +3,9 @@ package vm
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm/internal/data"
-	"github.com/MontFerret/ferret/pkg/vm/internal/mem"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
 func (vm *VM) tryCatch(pos int) (Catch, bool) {

--- a/pkg/vm/vm_warmup.go
+++ b/pkg/vm/vm_warmup.go
@@ -1,8 +1,8 @@
 package vm
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm/internal/mem"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
 func (vm *VM) warmup(env *Environment) error {

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -16,16 +16,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 
 	"github.com/rs/zerolog"
 
-	"github.com/MontFerret/ferret"
-	//"github.com/MontFerret/ferret/pkg/drivers/cdp"
-	//"github.com/MontFerret/ferret/pkg/drivers/http"
+	"github.com/MontFerret/ferret/v2"
+	//"github.com/MontFerret/ferret/v2/pkg/drivers/cdp"
+	//"github.com/MontFerret/ferret/v2/pkg/drivers/http"
 )
 
 type (

--- a/test/integration/base/assertions.go
+++ b/test/integration/base/assertions.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/smarty/assertions"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/test/integration/base/debug.go
+++ b/test/integration/base/debug.go
@@ -3,8 +3,8 @@ package base
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/asm"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/asm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func PrintDebugInfo(name string, uc TestCase, prog *vm.Program) {

--- a/test/integration/base/exec.go
+++ b/test/integration/base/exec.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	j "encoding/json"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func Compile(expression string) (*vm.Program, error) {

--- a/test/integration/base/fn.go
+++ b/test/integration/base/fn.go
@@ -3,7 +3,7 @@ package base
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type (

--- a/test/integration/base/helpers.go
+++ b/test/integration/base/helpers.go
@@ -3,7 +3,7 @@ package base
 import (
 	"context"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 func ForWhileHelpers() runtime.Functions {

--- a/test/integration/base/setup.go
+++ b/test/integration/base/setup.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/asm"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/asm"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func RunBenchmarkWith(b *testing.B, c *compiler.Compiler, expression string, opts ...vm.EnvironmentOption) {

--- a/test/integration/base/stdlib.go
+++ b/test/integration/base/stdlib.go
@@ -1,8 +1,8 @@
 package base
 
 import (
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/stdlib"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 )
 
 func Stdlib() runtime.Functions {

--- a/test/integration/benchmarks/bench_func_test.go
+++ b/test/integration/benchmarks/bench_func_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const (

--- a/test/integration/benchmarks/bench_member_test.go
+++ b/test/integration/benchmarks/bench_member_test.go
@@ -3,7 +3,7 @@ package benchmarks_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 const (

--- a/test/integration/benchmarks/shortcuts_test.go
+++ b/test/integration/benchmarks/shortcuts_test.go
@@ -3,9 +3,9 @@ package benchmarks_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func RunBenchmarkO0(b *testing.B, expression string, opts ...vm.EnvironmentOption) {

--- a/test/integration/compiler/assertions.go
+++ b/test/integration/compiler/assertions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func CastToProgram(prog any) *vm.Program {

--- a/test/integration/compiler/compiler_errors_syntax_literals_test.go
+++ b/test/integration/compiler/compiler_errors_syntax_literals_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestLiteralsSyntaxErrors(t *testing.T) {

--- a/test/integration/compiler/compiler_errors_syntax_loop_test.go
+++ b/test/integration/compiler/compiler_errors_syntax_loop_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestForLoopSyntaxErrors(t *testing.T) {

--- a/test/integration/compiler/compiler_errors_syntax_step_loop_test.go
+++ b/test/integration/compiler/compiler_errors_syntax_step_loop_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestStepLoopSyntaxErrors(t *testing.T) {

--- a/test/integration/compiler/compiler_errors_syntax_test.go
+++ b/test/integration/compiler/compiler_errors_syntax_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestSyntaxErrors(t *testing.T) {

--- a/test/integration/compiler/compiler_errors_test.go
+++ b/test/integration/compiler/compiler_errors_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestErrors(t *testing.T) {

--- a/test/integration/compiler/compiler_for_in_collect_agg_test.go
+++ b/test/integration/compiler/compiler_for_in_collect_agg_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestCollectAggregate(t *testing.T) {

--- a/test/integration/compiler/compiler_for_in_collect_test.go
+++ b/test/integration/compiler/compiler_for_in_collect_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestCollect(t *testing.T) {

--- a/test/integration/compiler/compiler_for_in_nested_test.go
+++ b/test/integration/compiler/compiler_for_in_nested_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForNested(t *testing.T) {

--- a/test/integration/compiler/compiler_for_in_sort_test.go
+++ b/test/integration/compiler/compiler_for_in_sort_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestSort(t *testing.T) {

--- a/test/integration/compiler/compiler_for_in_test.go
+++ b/test/integration/compiler/compiler_for_in_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestFor(t *testing.T) {

--- a/test/integration/compiler/compiler_for_while_distinct_test.go
+++ b/test/integration/compiler/compiler_for_while_distinct_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForWhileDistinct(t *testing.T) {

--- a/test/integration/compiler/compiler_for_while_filter_test.go
+++ b/test/integration/compiler/compiler_for_while_filter_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForWhileFilter(t *testing.T) {

--- a/test/integration/compiler/compiler_for_while_test.go
+++ b/test/integration/compiler/compiler_for_while_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForWhile(t *testing.T) {

--- a/test/integration/compiler/compiler_func_test.go
+++ b/test/integration/compiler/compiler_func_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestFunctionCall(t *testing.T) {

--- a/test/integration/compiler/compiler_member_test.go
+++ b/test/integration/compiler/compiler_member_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestMember(t *testing.T) {

--- a/test/integration/compiler/compiler_op_logical_test.go
+++ b/test/integration/compiler/compiler_op_logical_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestLogicalOperators(t *testing.T) {

--- a/test/integration/compiler/compiler_string_test.go
+++ b/test/integration/compiler/compiler_string_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestString(t *testing.T) {

--- a/test/integration/compiler/compiler_variable_test.go
+++ b/test/integration/compiler/compiler_variable_test.go
@@ -3,7 +3,7 @@ package compiler_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestVariables(t *testing.T) {

--- a/test/integration/compiler/shortcuts.go
+++ b/test/integration/compiler/shortcuts.go
@@ -1,8 +1,8 @@
 package compiler_test
 
 import (
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 type BC = []vm.Instruction

--- a/test/integration/compiler/test_case.go
+++ b/test/integration/compiler/test_case.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/pkg/asm"
+	"github.com/MontFerret/ferret/v2/pkg/asm"
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func Case(expression string, expected *vm.Program, desc ...string) UseCase {

--- a/test/integration/optimization/assertions.go
+++ b/test/integration/optimization/assertions.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func CastToProgram(prog any) *vm.Program {

--- a/test/integration/optimization/constant_propagation_test.go
+++ b/test/integration/optimization/constant_propagation_test.go
@@ -3,10 +3,10 @@ package optimization_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func compileOptimized(t *testing.T, expr string) *vm.Program {

--- a/test/integration/optimization/register_coalescing_test.go
+++ b/test/integration/optimization/register_coalescing_test.go
@@ -3,7 +3,7 @@ package optimization_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 )
 
 func TestRegisterCoalescing(t *testing.T) {

--- a/test/integration/optimization/shortcuts.go
+++ b/test/integration/optimization/shortcuts.go
@@ -3,7 +3,7 @@ package optimization_test
 import (
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 type (

--- a/test/integration/optimization/test_case.go
+++ b/test/integration/optimization/test_case.go
@@ -7,15 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/pkg/asm"
+	"github.com/MontFerret/ferret/v2/pkg/asm"
 
 	"github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func Case(expression string, expected *vm.Program, desc ...string) UseCase {

--- a/test/integration/vm/runtime_error_assertions.go
+++ b/test/integration/vm/runtime_error_assertions.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 type ExpectedRuntimeError struct {

--- a/test/integration/vm/shortcuts.go
+++ b/test/integration/vm/shortcuts.go
@@ -1,7 +1,7 @@
 package vm_test
 
 import (
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 type UseCase = base.TestCase

--- a/test/integration/vm/test_case.go
+++ b/test/integration/vm/test_case.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/diagnostics"
-	"github.com/MontFerret/ferret/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/file"
 
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func Case(expression string, expected any, desc ...string) UseCase {

--- a/test/integration/vm/vm_for_do_while_test.go
+++ b/test/integration/vm/vm_for_do_while_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForDoWhile(t *testing.T) {

--- a/test/integration/vm/vm_for_in_filter_test.go
+++ b/test/integration/vm/vm_for_in_filter_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForFilter(t *testing.T) {

--- a/test/integration/vm/vm_for_in_limit_test.go
+++ b/test/integration/vm/vm_for_in_limit_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForLimit(t *testing.T) {

--- a/test/integration/vm/vm_for_in_sort_test.go
+++ b/test/integration/vm/vm_for_in_sort_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForSort(t *testing.T) {

--- a/test/integration/vm/vm_for_in_test.go
+++ b/test/integration/vm/vm_for_in_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestForIn(t *testing.T) {

--- a/test/integration/vm/vm_for_step_distinct_test.go
+++ b/test/integration/vm/vm_for_step_distinct_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForStepDistinct(t *testing.T) {

--- a/test/integration/vm/vm_for_step_nested_test.go
+++ b/test/integration/vm/vm_for_step_nested_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForStepNested(t *testing.T) {

--- a/test/integration/vm/vm_for_step_ternary_test.go
+++ b/test/integration/vm/vm_for_step_ternary_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForTernaryStepExpression(t *testing.T) {

--- a/test/integration/vm/vm_for_while_collect_agg_test.go
+++ b/test/integration/vm/vm_for_while_collect_agg_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileCollectAggregate(t *testing.T) {

--- a/test/integration/vm/vm_for_while_collect_test.go
+++ b/test/integration/vm/vm_for_while_collect_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileCollect(t *testing.T) {

--- a/test/integration/vm/vm_for_while_distinct_test.go
+++ b/test/integration/vm/vm_for_while_distinct_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileDistinct(t *testing.T) {

--- a/test/integration/vm/vm_for_while_filter_test.go
+++ b/test/integration/vm/vm_for_while_filter_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileFilter(t *testing.T) {

--- a/test/integration/vm/vm_for_while_limit_test.go
+++ b/test/integration/vm/vm_for_while_limit_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileLimit(t *testing.T) {

--- a/test/integration/vm/vm_for_while_nested_test.go
+++ b/test/integration/vm/vm_for_while_nested_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileNested(t *testing.T) {

--- a/test/integration/vm/vm_for_while_sort_test.go
+++ b/test/integration/vm/vm_for_while_sort_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhileSort(t *testing.T) {

--- a/test/integration/vm/vm_for_while_ternary_test.go
+++ b/test/integration/vm/vm_for_while_ternary_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForTernaryWhileExpression(t *testing.T) {

--- a/test/integration/vm/vm_for_while_test.go
+++ b/test/integration/vm/vm_for_while_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 )
 
 func TestForWhile(t *testing.T) {

--- a/test/integration/vm/vm_func_test.go
+++ b/test/integration/vm/vm_func_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestFunctionCall(t *testing.T) {

--- a/test/integration/vm/vm_member_test.go
+++ b/test/integration/vm/vm_member_test.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/stdlib"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/parser"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/parser"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/test/integration/vm/vm_op_logical_test.go
+++ b/test/integration/vm/vm_op_logical_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestLogicalOperators(t *testing.T) {

--- a/test/integration/vm/vm_op_regex_test.go
+++ b/test/integration/vm/vm_op_regex_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/test/integration/vm/vm_op_ternary_test.go
+++ b/test/integration/vm/vm_op_ternary_test.go
@@ -3,12 +3,12 @@ package vm_test
 import (
 	"fmt"
 
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 
 	"testing"
 )

--- a/test/integration/vm/vm_op_unary_test.go
+++ b/test/integration/vm/vm_op_unary_test.go
@@ -3,9 +3,9 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
 	gocontext "context"
 

--- a/test/integration/vm/vm_param_test.go
+++ b/test/integration/vm/vm_param_test.go
@@ -3,7 +3,7 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestParam(t *testing.T) {

--- a/test/integration/vm/vm_range_test.go
+++ b/test/integration/vm/vm_range_test.go
@@ -3,8 +3,8 @@ package vm_test
 import (
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestRange(t *testing.T) {

--- a/test/integration/vm/vm_use_test.go
+++ b/test/integration/vm/vm_use_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func TestUse(t *testing.T) {

--- a/test/integration/vm/vm_variable_test.go
+++ b/test/integration/vm/vm_variable_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MontFerret/ferret/pkg/file"
-	"github.com/MontFerret/ferret/test/integration/base"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
 
-	"github.com/MontFerret/ferret/pkg/compiler"
-	"github.com/MontFerret/ferret/pkg/runtime"
-	"github.com/MontFerret/ferret/pkg/vm"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 
 	gocontext "context"
 


### PR DESCRIPTION
This pull request updates the import paths throughout the codebase to use the new Go module path `github.com/MontFerret/ferret/v2`, reflecting a major version upgrade. This change ensures compatibility with Go modules' versioning requirements and prevents dependency conflicts for downstream consumers.

Module path update:

* Changed the module path in `go.mod` to `github.com/MontFerret/ferret/v2`.

Import path updates:

* Updated all internal and external import statements across the codebase (including files in `pkg/asm`, `pkg/compiler`, `lib.go`, and example files) to use the new `/v2` module path. [[1]](diffhunk://#diff-24ee2abbb4556b154f9bada8de5f7961a957bd2267b3cdeeeaf23e619769c5c7L4-R7) [[2]](diffhunk://#diff-def44a8a467edaea2e68dc1002cd935b8f18b8a47351d39eaf5576a59e200daeL9-R12) [[3]](diffhunk://#diff-e0538f3734fc201adc22dc448563e1cd24e5e38532874be7c6dd280a6d8b0903L3-R3) [[4]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285L8-R8) [[5]](diffhunk://#diff-148946c5e708553857852a09851086dffb7b0ae5c028250139a22ff0585090d4L6-R7) [[6]](diffhunk://#diff-cc3debf20c35952d55c9b14d02264e3844ab54b046315c643108bbbc0d39f0d5L6-R15) [[7]](diffhunk://#diff-379152ec50d340bc5df5aa3430cf42532d8f62ad681e2b3b5dd03266db648becL4-R4) [[8]](diffhunk://#diff-1261f413ecb84c690fe430759c7cc807923132e16a806ed7c1461623d4178290L4-R6) [[9]](diffhunk://#diff-8be4b7e2ad761e846b5a576724135e874862d19a0139e02b268fa1b89b149049L4-R4) [[10]](diffhunk://#diff-b42d0ae7ec2df4abfc8d8669a7d6990d7a3a2bfc1bd9bc82bb996873bf6c68a1L4-R4) [[11]](diffhunk://#diff-5e5a9911401184c09b4185b2ca9957d69f6993474c18506af8475b689bab3dffL3-R3) [[12]](diffhunk://#diff-7abe691a4c130ccd80f4cd7d76610ce77dec8634940e8d4bfb05bcb8d1f4f975L4-R5) [[13]](diffhunk://#diff-6c76c1da5bfe94d58c672afccfed166ee6472f84c2e987f192ba31dae7460428L6-R7) [[14]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5L7-R8) [[15]](diffhunk://#diff-ce692e62fac6c98e4aa07ca4fbf4e3249c92ce169b209ea29146701708a3fb69L4-R4) [[16]](diffhunk://#diff-0b06a4a954abc723a26d0c9083c1ebc70271bb675bddd1e941a4f993645039cfL3-R3) [[17]](diffhunk://#diff-bb34df2fa73bc94c16f33d415084e1ce42b7815b768bf4d86543430be7bddb31L4-R4) [[18]](diffhunk://#diff-a64f4f3d30c7bb3acdc489ebb21327f11df0de60e77652e63a288ad675a9e68cL6-R6) [[19]](diffhunk://#diff-4fe93905060305063f9ebbe0048d838ef5f7963a6d16b2834799f5173634deebL4-R4)