### PR TITLE
Next regexp cache

### DIFF
--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -410,13 +410,18 @@ func (c *ExprCompiler) compileAtom(ctx fql.IExpressionAtomContext) vm.Operand {
 		})
 
 		if isRegexp {
-			if regRight.IsConstant() {
-				val := c.ctx.Symbols.Constant(regRight)
-				exp := val.String()
+			if rightCtx := ctx.ExpressionAtom(1); rightCtx != nil {
+				if lit := rightCtx.Literal(); lit != nil {
+					if sl := lit.StringLiteral(); sl != nil {
+						exp := parseStringLiteral(sl).String()
 
-				// Verify that the expression is a valid regular expression
-				if _, err := regexp.Compile(exp); err != nil {
-					c.ctx.Errors.InvalidRegexExpression(ctx, exp)
+						// Verify that the expression is a valid regular expression
+						if _, err := regexp.Compile(exp); err != nil {
+							c.ctx.Errors.InvalidRegexExpression(ctx, exp)
+						}
+					} else {
+						c.ctx.Errors.InvalidRegexExpression(ctx, lit.GetText())
+					}
 				}
 			}
 		}

--- a/pkg/vm/internal/mem/cache.go
+++ b/pkg/vm/internal/mem/cache.go
@@ -1,8 +1,6 @@
 package mem
 
 import (
-	"regexp"
-
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 )
@@ -11,7 +9,8 @@ type (
 	Cache struct {
 		FuncHash        uint64
 		Functions       map[int]*CachedFunction
-		Regexps         map[int]*regexp.Regexp
+		RegexpsWarmed   bool
+		Regexps         map[int]*CachedRegexp
 		LoadKeyICs      []*LoadKeyCache
 		LoadKeyConstICs []*LoadKeyConstCache
 		ShapeCache      *data.ShapeCache
@@ -24,6 +23,11 @@ type (
 		Fn3 runtime.Function3
 		Fn4 runtime.Function4
 		FnV runtime.Function
+	}
+
+	CachedRegexp struct {
+		Pattern string
+		Regexp  *data.Regexp
 	}
 
 	LoadKeyCache struct {
@@ -159,7 +163,7 @@ func (c *LoadKeyConstCache) Add(shapeID uint64, slot int) {
 func NewCache(bytecodeLen, shapeCacheLimit int) *Cache {
 	return &Cache{
 		Functions:       make(map[int]*CachedFunction),
-		Regexps:         make(map[int]*regexp.Regexp),
+		Regexps:         make(map[int]*CachedRegexp),
 		LoadKeyICs:      make([]*LoadKeyCache, bytecodeLen),
 		LoadKeyConstICs: make([]*LoadKeyConstCache, bytecodeLen),
 		ShapeCache:      data.NewShapeCache(shapeCacheLimit),

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -165,8 +165,7 @@ loop:
 				return nil, err
 			}
 		case OpRegexp:
-			// TODO: Add caching to avoid recompilation
-			r, err := data.ToRegexp(reg[src2])
+			r, err := vm.regexpCached(vm.pc-1, reg[src2])
 
 			if err == nil {
 				reg[dst] = r.Match(reg[src1])

--- a/pkg/vm/vm_helpers.go
+++ b/pkg/vm/vm_helpers.go
@@ -109,6 +109,39 @@ func (vm *VM) call4(ctx context.Context, pc int, src1 Operand) (runtime.Value, e
 	return cacheFn.FnV(ctx, arg1, arg2, arg3, arg4)
 }
 
+func (vm *VM) regexpCached(pc int, value runtime.Value) (*data.Regexp, error) {
+	// We compare patterns to ensure that the cached regexp is the same as the one we're trying to use.
+	// This is necessary because the same compiled function can be used in different places with different regexps,
+	// and we want to avoid caching a regexp that doesn't match the current pattern.
+	switch v := value.(type) {
+	case *data.Regexp:
+		pattern := v.String()
+
+		if cached := vm.cache.Regexps[pc]; cached == nil || cached.Pattern != pattern {
+			vm.cache.Regexps[pc] = &mem.CachedRegexp{Pattern: pattern, Regexp: v}
+		}
+
+		return v, nil
+	case runtime.String:
+		pattern := v.String()
+
+		if cached := vm.cache.Regexps[pc]; cached != nil && cached.Pattern == pattern {
+			return cached.Regexp, nil
+		}
+
+		r, err := data.NewRegexp(v)
+		if err != nil {
+			return nil, err
+		}
+
+		vm.cache.Regexps[pc] = &mem.CachedRegexp{Pattern: pattern, Regexp: r}
+
+		return r, nil
+	default:
+		return nil, runtime.TypeErrorOf(value, runtime.TypeString, runtime.TypeRegexp)
+	}
+}
+
 func (vm *VM) loadKeyCached(ctx context.Context, pc int, src, arg runtime.Value) (runtime.Value, error) {
 	obj, ok := src.(*data.FastObject)
 

--- a/pkg/vm/vm_warmup.go
+++ b/pkg/vm/vm_warmup.go
@@ -2,10 +2,13 @@ package vm
 
 import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
 func (vm *VM) warmup(env *Environment) error {
+	vm.warmupRegexps()
+
 	hash := env.Functions.Hash()
 
 	if vm.cache.FuncHash == hash || hash == 0 {
@@ -92,6 +95,48 @@ func (vm *VM) warmup(env *Environment) error {
 	vm.cache.FuncHash = env.Functions.Hash()
 
 	return nil
+}
+
+func (vm *VM) warmupRegexps() {
+	if vm.cache.RegexpsWarmed {
+		return
+	}
+
+	constants := vm.program.Constants
+	reg := map[Operand]runtime.Value{}
+
+	for pc, inst := range vm.program.Bytecode {
+		op := inst.Opcode
+		dst, src1, src2 := inst.Operands[0], inst.Operands[1], inst.Operands[2]
+
+		switch op {
+		case OpLoadConst:
+			reg[dst] = constants[src1.Constant()]
+		case OpMove:
+			if val, ok := reg[src1]; ok {
+				reg[dst] = val
+			} else {
+				delete(reg, dst)
+			}
+		case OpRegexp:
+			if val, ok := reg[src2]; ok {
+				r, err := data.ToRegexp(val)
+
+				if err == nil {
+					pattern := r.String()
+					if cached := vm.cache.Regexps[pc]; cached == nil || cached.Pattern != pattern {
+						vm.cache.Regexps[pc] = &mem.CachedRegexp{Pattern: pattern, Regexp: r}
+					}
+				}
+			}
+		}
+
+		if op != OpLoadConst && op != OpMove && dst.IsRegister() {
+			delete(reg, dst)
+		}
+	}
+
+	vm.cache.RegexpsWarmed = true
 }
 
 func resolveFnName(reg map[Operand]runtime.Value, dst Operand) (string, error) {

--- a/test/integration/benchmarks/bench_regexp_test.go
+++ b/test/integration/benchmarks/bench_regexp_test.go
@@ -1,0 +1,53 @@
+package benchmarks_test
+
+import "testing"
+
+func BenchmarkRegexp_Loop_O0(b *testing.B) {
+	RunBenchmarkO0(b, `
+LET users = [
+  {
+  	name: "Alice",
+  },
+{
+	name: "Bob",
+},
+{
+	name: "Charlie",
+},
+{
+	name: "Dave",
+},
+{
+	name: "Eve",
+}
+]
+FOR i IN users
+	FILTER i.name =~ "^[A-D].*"
+  	RETURN i.name
+`)
+}
+
+func BenchmarkRegexp_Loop_O1(b *testing.B) {
+	RunBenchmarkO1(b, `
+LET users = [
+  {
+  	name: "Alice",
+  },
+{
+	name: "Bob",
+},
+{
+	name: "Charlie",
+},
+{
+	name: "Dave",
+},
+{
+	name: "Eve",
+}
+]
+FOR i IN users
+	FILTER i.name =~ "^[A-D].*"
+  	RETURN i.name
+`)
+}

--- a/test/integration/vm/vm_op_regex_test.go
+++ b/test/integration/vm/vm_op_regex_test.go
@@ -18,8 +18,16 @@ func TestRegexpOperator(t *testing.T) {
 		Case(`RETURN "foo" =~ "^f[o].$" `, true),
 		Case(`RETURN "foo" !~ "[a-z]+bar$"`, true),
 		Case(`RETURN "foo" !~ T::REGEXP()`, true),
+		CaseArray(`FOR p IN ["^f..$", "^b..$"] RETURN "foo" =~ p`, []any{true, false}),
+		CaseArray(`FOR p IN [1, 2] RETURN "foo" =~ T::REGEXP_DYNAMIC(p)`, []any{true, false}),
 	}, vm.WithFunction("T::REGEXP", func(_ context.Context, _ ...runtime.Value) (value runtime.Value, e error) {
 		return runtime.NewString("[a-z]+bar$"), nil
+	}), vm.WithFunction("T::REGEXP_DYNAMIC", func(_ context.Context, args ...runtime.Value) (value runtime.Value, e error) {
+		if len(args) > 0 && args[0].String() == "1" {
+			return runtime.NewString("^f..$"), nil
+		}
+
+		return runtime.NewString("^b..$"), nil
 	}))
 
 	// TODO: Fix

--- a/test/integration/vm/vm_op_regex_test.go
+++ b/test/integration/vm/vm_op_regex_test.go
@@ -30,8 +30,7 @@ func TestRegexpOperator(t *testing.T) {
 		return runtime.NewString("^b..$"), nil
 	}))
 
-	// TODO: Fix
-	SkipConvey("Should return an error during compilation when a regexp string invalid", t, func() {
+	Convey("Should return an error during compilation when a regexp string invalid", t, func() {
 		_, err := compiler.New(compiler.WithOptimizationLevel(compiler.O0)).
 			Compile(file.NewAnonymousSource(`
 			RETURN "foo" !~ "[ ]\K(?<!\d )(?=(?: ?\d){8})(?!(?: ?\d){9})\d[ \d]+\d" 
@@ -40,8 +39,7 @@ func TestRegexpOperator(t *testing.T) {
 		So(err, ShouldBeError)
 	})
 
-	// TODO: Fix
-	SkipConvey("Should return an error during compilation when a regexp is not a string", t, func() {
+	Convey("Should return an error during compilation when a regexp is not a string", t, func() {
 		right := []string{
 			"[]",
 			"{}",


### PR DESCRIPTION
This pull request implements significant improvements to how regular expressions are handled and cached in the virtual machine. It introduces a new caching mechanism for regular expressions to avoid unnecessary recompilation, adds warmup logic to pre-cache regexps during VM initialization, and expands test coverage and benchmarks for regexp operations.

**Regular expression caching and warmup:**

* Introduced a `CachedRegexp` struct and updated the `Cache` to store compiled regexps by program counter (`pc`), ensuring that regexps are only compiled once per unique pattern at each instruction location. This avoids repeated recompilation and improves runtime performance. (`pkg/vm/internal/mem/cache.go` [[1]](diffhunk://#diff-a3c3050fe7435844f7329bc4b0dd83b9d91e72fb3d0814a9e7f6a79a18c6eb7cL14-R13) [[2]](diffhunk://#diff-a3c3050fe7435844f7329bc4b0dd83b9d91e72fb3d0814a9e7f6a79a18c6eb7cR28-R32) [[3]](diffhunk://#diff-a3c3050fe7435844f7329bc4b0dd83b9d91e72fb3d0814a9e7f6a79a18c6eb7cL162-R166); `pkg/vm/vm_helpers.go` [[4]](diffhunk://#diff-f0aa84675898001782c0e1adeed69d0acd360504d5e43b42cc0f21360f146a32R112-R144); `pkg/vm/vm.go` [[5]](diffhunk://#diff-5184da1da3707411ccc455aba81effcc985af06f4ab0c3e0bd8d827fb2c363dcL168-R168)
* Added a `warmupRegexps` method to the VM, which pre-caches regexps found in the bytecode during VM warmup, further reducing runtime overhead. (`pkg/vm/vm_warmup.go` [[1]](diffhunk://#diff-2117aa3f8578bd0ccfef933550feb2f4fc69f602ce555585b63b27daeec4593eR5-R11) [[2]](diffhunk://#diff-2117aa3f8578bd0ccfef933550feb2f4fc69f602ce555585b63b27daeec4593eR100-R141)

**Compiler improvements:**

* Improved the compiler's regexp validation logic to provide better error reporting when the right-hand side of a regexp operator is not a valid string literal. (`pkg/compiler/internal/expr.go` [pkg/compiler/internal/expr.goL413-R425](diffhunk://#diff-8933509822f2c1ec39a80f83a73147f9723915a2f9d1b86ffde9f0f65212cfa4L413-R425))

**Testing and benchmarking:**

* Added new benchmarks for regexp operations in loops to measure performance improvements from caching. (`test/integration/benchmarks/bench_regexp_test.go` [test/integration/benchmarks/bench_regexp_test.goR1-R53](diffhunk://#diff-1add0a74517844b14080b406105ffbc228c718f5179c0f0dc3c36bf56674afefR1-R53))
* Expanded test coverage for dynamic and array-based regexps, and enabled tests that check for proper error handling on invalid regexps and non-string patterns. (`test/integration/vm/vm_op_regex_test.go` [[1]](diffhunk://#diff-cf6e17073b2261d1ab0e9101776b4db4da15c4e4157e690c65590ae47efd9ef3R21-R33) [[2]](diffhunk://#diff-cf6e17073b2261d1ab0e9101776b4db4da15c4e4157e690c65590ae47efd9ef3L35-R42)