### PR TITLE
Next iter refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,5 @@ fmt:
 # https://github.com/mgechev/revive
 # go get github.com/mgechev/revive
 lint:
-	staticcheck -tests=false ./pkg/... && \
+	echo 'staticcheck -tests=false $$(go list ./pkg/... | grep -v /fql)' && \
 	echo 'revive -config revive.toml -formatter stylish -exclude ./pkg/parser/fql/... -exclude ./vendor/... -exclude ./*_test.go ./...'

--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,7 @@ package ferret
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -14,31 +15,19 @@ func IsScalar(result Result) bool {
 }
 
 func ForEach(ctx context.Context, result Result, predicate func(val runtime.Value) error) error {
-	hasNext, err := result.HasNext(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	for hasNext {
+	for {
 		val, err := result.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 
 		if err != nil {
 			return err
 		}
-
 		if err := predicate(val); err != nil {
 			return err
 		}
-
-		hasNext, err = result.HasNext(ctx)
-
-		if err != nil {
-			return err
-		}
 	}
-
-	return nil
 }
 
 func Collect(ctx context.Context, result Result) ([]runtime.Value, error) {
@@ -58,17 +47,16 @@ func Collect(ctx context.Context, result Result) ([]runtime.Value, error) {
 }
 
 func One(ctx context.Context, result Result) (runtime.Value, error) {
-	hasNext, err := result.HasNext(ctx)
+	val, err := result.Next(ctx)
+	if errors.Is(err, io.EOF) {
+		return runtime.None, nil
+	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	if !hasNext {
-		return runtime.None, nil
-	}
-
-	return result.Next(ctx)
+	return val, nil
 }
 
 func JSONStream(ctx context.Context, input io.Writer, result Result) error {

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -1079,6 +1079,7 @@ func (c *ExprCompiler) emitBooleanAnd(left, right bytecode.Operand) bytecode.Ope
 	return dst
 }
 
+//lint:ignore U1000 Ignore unused method
 func (c *ExprCompiler) compileArrayExpansion(src bytecode.Operand, expansion fql.IArrayExpansionContext, tail []fql.IMemberExpressionPathContext) bytecode.Operand {
 	span := diagnostics.SpanFromRuleContext(expansion)
 	inline := expansion.InlineExpression()

--- a/pkg/formatter/internal/literal.go
+++ b/pkg/formatter/internal/literal.go
@@ -73,6 +73,7 @@ func (f *literalFormatter) formatStringLiteralNodeWith(p *printer, ctx fql.IStri
 	}
 }
 
+//lint:ignore U1000 Ignore unused method
 func (f *literalFormatter) formatTemplateLiteral(ctx fql.ITemplateLiteralContext) {
 	f.formatTemplateLiteralWith(f.p, ctx)
 }
@@ -159,14 +160,17 @@ func (f *literalFormatter) formatComputedPropertyNameWith(p *printer, ctx *fql.C
 	p.write("]")
 }
 
+//lint:ignore U1000 Ignore unused method
 func (f *literalFormatter) formatPropertyAssignment(ctx *fql.PropertyAssignmentContext) {
 	f.formatPropertyAssignmentWith(f.p, ctx)
 }
 
+//lint:ignore U1000 Ignore unused method
 func (f *literalFormatter) formatPropertyName(ctx *fql.PropertyNameContext) {
 	f.formatPropertyNameWith(f.p, ctx)
 }
 
+//lint:ignore U1000 Ignore unused method
 func (f *literalFormatter) formatComputedPropertyName(ctx *fql.ComputedPropertyNameContext) {
 	f.formatComputedPropertyNameWith(f.p, ctx)
 }

--- a/pkg/runtime/array_iter.go
+++ b/pkg/runtime/array_iter.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"io"
 )
 
 type ArrayIterator struct {
@@ -14,13 +15,9 @@ func NewArrayIterator(values *Array) Iterator {
 	return &ArrayIterator{values: values, length: len(values.data), pos: 0}
 }
 
-func (iter *ArrayIterator) HasNext(_ context.Context) (bool, error) {
-	return iter.length > iter.pos, nil
-}
-
 func (iter *ArrayIterator) Next(_ context.Context) (value Value, key Value, err error) {
 	if iter.pos >= iter.length {
-		return None, None, Error(ErrInvalidOperation, "no more elements")
+		return None, None, io.EOF
 	}
 
 	value = iter.values.data[iter.pos]

--- a/pkg/runtime/array_iter_test.go
+++ b/pkg/runtime/array_iter_test.go
@@ -2,6 +2,8 @@ package runtime_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -15,10 +17,8 @@ func TestArrayIterator(t *testing.T) {
 		arr := runtime.NewArray(0)
 		iter := runtime.NewArrayIterator(arr)
 
-		hasNext, err := iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err := iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("One value", t, func() {
@@ -27,21 +27,14 @@ func TestArrayIterator(t *testing.T) {
 		arr.Append(ctx, runtime.NewInt(1))
 		iter := runtime.NewArrayIterator(arr)
 
-		hasNext, err := iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeTrue)
-
 		val, key, err := iter.Next(ctx)
 
 		So(err, ShouldBeNil)
 		So(val, ShouldEqual, runtime.NewInt(1))
 		So(key, ShouldEqual, runtime.NewInt(0))
 
-		hasNext, err = iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err = iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("Multiple values", t, func() {
@@ -57,11 +50,11 @@ func TestArrayIterator(t *testing.T) {
 		actual := make([]runtime.Int, 0, 5)
 
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			val, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			val, _, err := iter.Next(ctx)
+			So(err, ShouldBeNil)
 			actual = append(actual, val.(runtime.Int))
 		}
 
@@ -84,12 +77,13 @@ func BenchmarkArrayIterator(b *testing.B) {
 		iter := runtime.NewArrayIterator(arr)
 
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			_, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-
-			iter.Next(ctx)
+			if err != nil {
+				break
+			}
 		}
 	}
 }

--- a/pkg/runtime/array_test.go
+++ b/pkg/runtime/array_test.go
@@ -118,7 +118,9 @@ func TestArray(t *testing.T) {
 			Convey("When object and array are nested at the same time", func() {
 				arr1 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 					runtime.NewArrayWith(
 						runtime.NewInt(2),
@@ -126,7 +128,9 @@ func TestArray(t *testing.T) {
 				)
 				arr2 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 					runtime.NewArrayWith(
 						runtime.NewInt(2),
@@ -139,12 +143,16 @@ func TestArray(t *testing.T) {
 			Convey("When only objects are nested", func() {
 				arr1 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 				)
 				arr2 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 				)
 
@@ -170,7 +178,9 @@ func TestArray(t *testing.T) {
 				arr1 := runtime.NewArrayWith(
 					runtime.NewInt(0),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 					runtime.NewArrayWith(
 						runtime.NewInt(2),
@@ -179,7 +189,9 @@ func TestArray(t *testing.T) {
 				arr2 := runtime.NewArrayWith(
 					runtime.NewInt(0),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("one", runtime.NewInt(1)),
+						map[string]runtime.Value{
+							"one": runtime.NewInt(1),
+						},
 					),
 					runtime.NewArrayWith(
 						runtime.NewInt(2),
@@ -192,16 +204,16 @@ func TestArray(t *testing.T) {
 			Convey("When custom complex type", func() {
 				arr1 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty(
-							"arr", runtime.NewArrayWith(runtime.NewObject()),
-						),
+						map[string]runtime.Value{
+							"arr": runtime.NewArrayWith(runtime.NewObject()),
+						},
 					),
 				)
 				arr2 := runtime.NewArrayWith(
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty(
-							"arr", runtime.NewArrayWith(runtime.NewObject()),
-						),
+						map[string]runtime.Value{
+							"arr": runtime.NewArrayWith(runtime.NewObject()),
+						},
 					),
 				)
 
@@ -239,7 +251,11 @@ func TestArray(t *testing.T) {
 				runtime.NewString("foobar"),
 				runtime.NewCurrentDateTime(),
 				runtime.NewArrayWith(runtime.NewInt(1), runtime.True),
-				runtime.NewObjectWith(runtime.NewObjectProperty("foo", runtime.NewString("bar"))),
+				runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"foo": runtime.NewString("bar"),
+					},
+				),
 			)
 
 			h1 := arr.Hash()
@@ -512,7 +528,9 @@ func TestArray(t *testing.T) {
 			arr := runtime.NewArrayWith(
 				runtime.NewInt(0),
 				runtime.NewObjectWith(
-					runtime.NewObjectProperty("one", runtime.NewInt(1)),
+					map[string]runtime.Value{
+						"one": runtime.NewInt(1),
+					},
 				),
 				runtime.NewArrayWith(
 					runtime.NewInt(2),

--- a/pkg/runtime/decode.go
+++ b/pkg/runtime/decode.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"errors"
+	"io"
 	"reflect"
 	"strings"
 	"time"
@@ -205,8 +207,11 @@ func bindSlice(src Value, dst reflect.Value) error {
 	out := reflect.MakeSlice(dst.Type(), 0, 0)
 	index := 0
 
-	for hasNext, err := iter.HasNext(ctx); hasNext && err == nil; {
+	for {
 		val, _, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) || errors.Is(err, ErrTimeout) {
+			break
+		}
 		if err != nil {
 			return err
 		}
@@ -218,7 +223,6 @@ func bindSlice(src Value, dst reflect.Value) error {
 
 		out = reflect.Append(out, elem)
 		index++
-		hasNext, err = iter.HasNext(ctx)
 	}
 
 	dst.Set(out)
@@ -240,12 +244,15 @@ func bindArray(src Value, dst reflect.Value) error {
 	elemType := dst.Type().Elem()
 	index := 0
 
-	for hasNext, err := iter.HasNext(ctx); hasNext && err == nil; {
+	for {
 		if index >= dst.Len() {
 			return Error(ErrInvalidArgumentType, "source has more elements than target array")
 		}
 
 		val, _, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) || errors.Is(err, ErrTimeout) {
+			break
+		}
 		if err != nil {
 			return err
 		}
@@ -257,7 +264,6 @@ func bindArray(src Value, dst reflect.Value) error {
 
 		dst.Index(index).Set(elem)
 		index++
-		hasNext, err = iter.HasNext(ctx)
 	}
 
 	return nil
@@ -353,8 +359,11 @@ func collectEntries(src Value) (map[string]Value, error) {
 	}
 
 	out := make(map[string]Value)
-	for hasNext, err := iter.HasNext(ctx); hasNext && err == nil; {
+	for {
 		keyVal, _, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) || errors.Is(err, ErrTimeout) {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +379,6 @@ func collectEntries(src Value) (map[string]Value, error) {
 		}
 
 		out[key.String()] = val
-		hasNext, err = iter.HasNext(ctx)
 	}
 
 	return out, nil

--- a/pkg/runtime/encode_test.go
+++ b/pkg/runtime/encode_test.go
@@ -39,8 +39,10 @@ func TestEncode(t *testing.T) {
 		out := runtime.Encode(input)
 
 		expected := runtime.NewObjectWith(
-			runtime.NewObjectProperty("name", runtime.NewString("Alice")),
-			runtime.NewObjectProperty("age", runtime.NewInt(30)),
+			map[string]runtime.Value{
+				"name": runtime.NewString("Alice"),
+				"age":  runtime.NewInt(30),
+			},
 		)
 
 		So(out, ShouldResemble, expected)
@@ -58,10 +60,14 @@ func TestEncode(t *testing.T) {
 		out := runtime.Encode(input)
 
 		expected := runtime.NewObjectWith(
-			runtime.NewObjectProperty("inner", runtime.NewObjectWith(
-				runtime.NewObjectProperty("value", runtime.NewString("ok")),
-			)),
-			runtime.NewObjectProperty("count", runtime.NewInt(2)),
+			map[string]runtime.Value{
+				"inner": runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"value": runtime.NewString("ok"),
+					},
+				),
+				"count": runtime.NewInt(2),
+			},
 		)
 
 		So(out, ShouldResemble, expected)
@@ -123,12 +129,14 @@ func TestEncodeByKey(t *testing.T) {
 			},
 			Field: "pointerProp",
 			Expected: runtime.NewObjectWith(
-				runtime.NewObjectProperty("strProp", runtime.String("test")),
-				runtime.NewObjectProperty("intProp", runtime.Int(0)),
-				runtime.NewObjectProperty("sliceProp", runtime.NewArray(0)),
-				runtime.NewObjectProperty("pointerProp", runtime.None),
-				runtime.NewObjectProperty("jsonTag", runtime.EmptyString),
-				runtime.NewObjectProperty("ferretTag", runtime.EmptyString),
+				map[string]runtime.Value{
+					"strProp":     runtime.String("test"),
+					"intProp":     runtime.Int(0),
+					"sliceProp":   runtime.NewArray(0),
+					"pointerProp": runtime.None,
+					"jsonTag":     runtime.EmptyString,
+					"ferretTag":   runtime.EmptyString,
+				},
 			),
 		},
 		{

--- a/pkg/runtime/helpers.go
+++ b/pkg/runtime/helpers.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"hash/fnv"
+	"io"
 	"math"
 	"math/rand"
 	"reflect"
@@ -262,8 +264,12 @@ func ToList(ctx context.Context, input Value) List {
 
 		arr := NewArray(10)
 
-		for hasNext, err := iterator.HasNext(ctx); hasNext && err == nil; {
+		for {
 			val, _, err := iterator.Next(ctx)
+
+			if errors.Is(err, io.EOF) {
+				break
+			}
 
 			if err != nil {
 				return arr
@@ -299,8 +305,12 @@ func ToMap(ctx context.Context, input Value) Map {
 
 		obj := NewObject()
 
-		for hasNext, err := iterator.HasNext(ctx); hasNext && err == nil; {
+		for {
 			val, key, err := iterator.Next(ctx)
+
+			if errors.Is(err, io.EOF) {
+				break
+			}
 
 			if err != nil {
 				return obj
@@ -374,12 +384,14 @@ func ToFloat(ctx context.Context, input Value) (Float, error) {
 		res := ZeroFloat
 
 		for {
-			hasNext, err := iterator.HasNext(ctx)
-			if !hasNext || err != nil {
+			val, _, err := iterator.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
 
-			val, _, err := iterator.Next(ctx)
+			if errors.Is(err, ErrTimeout) {
+				break
+			}
 
 			if err != nil {
 				continue
@@ -447,12 +459,14 @@ func ToInt(ctx context.Context, input Value) (Int, error) {
 		res := ZeroInt
 
 		for {
-			hasNext, err := iterator.HasNext(ctx)
-			if !hasNext || err != nil {
+			item, _, err := iterator.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
 
-			item, _, err := iterator.Next(ctx)
+			if errors.Is(err, ErrTimeout) {
+				break
+			}
 
 			if err != nil {
 				continue
@@ -515,8 +529,16 @@ func ToNumberOnly(ctx context.Context, input Value) Value {
 		i := ZeroInt
 		f := ZeroFloat
 
-		for hasNext, err := iterator.HasNext(ctx); hasNext && err == nil; {
+		for {
 			val, _, err := iterator.Next(ctx)
+
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			if errors.Is(err, ErrTimeout) {
+				break
+			}
 
 			if err != nil {
 				continue

--- a/pkg/runtime/iterator.go
+++ b/pkg/runtime/iterator.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"io"
 )
 
@@ -12,8 +13,8 @@ type (
 	}
 
 	// Iterator represents an interface of an iterator.
+	// Next must return io.EOF when the iterator is exhausted.
 	Iterator interface {
-		HasNext(ctx context.Context) (bool, error)
 		Next(ctx context.Context) (value Value, key Value, err error)
 	}
 )
@@ -39,17 +40,11 @@ func ForEach(ctx context.Context, input Iterable, predicate Predicate) error {
 
 func ForEachIter(ctx context.Context, iter Iterator, predicate Predicate) error {
 	for {
-		hasNext, err := iter.HasNext(ctx)
+		val, key, err := iter.Next(ctx)
 
-		if err != nil {
-			return err
-		}
-
-		if !hasNext {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
-
-		val, key, err := iter.Next(ctx)
 
 		if err != nil {
 			return err

--- a/pkg/runtime/iterator_bench_test.go
+++ b/pkg/runtime/iterator_bench_test.go
@@ -2,61 +2,35 @@ package runtime
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 )
 
-type twoCallIter struct {
+type eofIter struct {
 	n int
 	i int
 }
 
-func (it *twoCallIter) HasNext(_ context.Context) (bool, error) {
-	return it.i < it.n, nil
-}
-
-func (it *twoCallIter) Next(_ context.Context) (Value, Value, error) {
+func (it *eofIter) Next(_ context.Context) (Value, Value, error) {
+	if it.i >= it.n {
+		return None, None, io.EOF
+	}
 	it.i++
 	return ZeroInt, ZeroInt, nil
 }
 
-type oneCallIter struct {
-	n int
-	i int
-}
-
-func (it *oneCallIter) Next(_ context.Context) (Value, Value, bool, error) {
-	if it.i >= it.n {
-		return None, None, false, nil
-	}
-	it.i++
-	return ZeroInt, ZeroInt, true, nil
-}
-
-func BenchmarkIteratorTwoCall(b *testing.B) {
+func BenchmarkIteratorEOF(b *testing.B) {
 	ctx := context.Background()
 
 	for i := 0; i < b.N; i++ {
-		it := &twoCallIter{n: 1024}
+		it := &eofIter{n: 1024}
 		for {
-			ok, err := it.HasNext(ctx)
-			if err != nil || !ok {
+			_, _, err := it.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			if _, _, err := it.Next(ctx); err != nil {
-				break
-			}
-		}
-	}
-}
-
-func BenchmarkIteratorOneCall(b *testing.B) {
-	ctx := context.Background()
-
-	for i := 0; i < b.N; i++ {
-		it := &oneCallIter{n: 1024}
-		for {
-			_, _, ok, err := it.Next(ctx)
-			if err != nil || !ok {
+			if err != nil {
 				break
 			}
 		}

--- a/pkg/runtime/logger.go
+++ b/pkg/runtime/logger.go
@@ -54,7 +54,7 @@ func (l LogLevel) String() string {
 	return zerolog.Level(l).String()
 }
 
-func LoggerWithContext(ctx context.Context, opts LogSettings) context.Context {
+func WithLogger(ctx context.Context, opts LogSettings) context.Context {
 	c := zerolog.New(opts.Writer).With().Timestamp()
 
 	for k, v := range opts.Fields {
@@ -66,7 +66,7 @@ func LoggerWithContext(ctx context.Context, opts LogSettings) context.Context {
 	return logger.WithContext(ctx)
 }
 
-func LoggerFromContext(ctx context.Context) zerolog.Logger {
+func GetLogger(ctx context.Context) zerolog.Logger {
 	found := zerolog.Ctx(ctx)
 
 	if found == nil {
@@ -74,8 +74,4 @@ func LoggerFromContext(ctx context.Context) zerolog.Logger {
 	}
 
 	return *found
-}
-
-func LogWithName(ctx zerolog.Context, name string) zerolog.Context {
-	return ctx.Str("component", name)
 }

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -22,7 +22,11 @@ func NewObjectOf(size int) *Object {
 }
 
 func NewObjectWith(props map[string]Value) *Object {
-	return &Object{props}
+	data := make(map[string]Value, len(props))
+	for k, v := range props {
+		data[k] = v
+	}
+	return &Object{data}
 }
 
 func (t *Object) ObjectLike() {}

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -9,19 +9,8 @@ import (
 	"github.com/wI2L/jettison"
 )
 
-type (
-	ObjectProperty struct {
-		key   string
-		value Value
-	}
-
-	Object struct {
-		data map[string]Value
-	}
-)
-
-func NewObjectProperty(name string, value Value) *ObjectProperty {
-	return &ObjectProperty{name, value}
+type Object struct {
+	data map[string]Value
 }
 
 func NewObject() *Object {
@@ -32,14 +21,8 @@ func NewObjectOf(size int) *Object {
 	return &Object{make(map[string]Value, size)}
 }
 
-func NewObjectWith(props ...*ObjectProperty) *Object {
-	obj := &Object{make(map[string]Value)}
-
-	for _, prop := range props {
-		obj.data[prop.key] = prop.value
-	}
-
-	return obj
+func NewObjectWith(props map[string]Value) *Object {
+	return &Object{props}
 }
 
 func (t *Object) ObjectLike() {}

--- a/pkg/runtime/object_iter.go
+++ b/pkg/runtime/object_iter.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"io"
 )
 
 type ObjectIterator struct {
@@ -23,13 +24,9 @@ func NewObjectIterator(obj *Object) Iterator {
 	return iter
 }
 
-func (iter *ObjectIterator) HasNext(_ context.Context) (bool, error) {
-	return len(iter.keys) > iter.pos, nil
-}
-
 func (iter *ObjectIterator) Next(_ context.Context) (Value, Value, error) {
 	if iter.pos >= len(iter.keys) {
-		return None, None, Error(ErrInvalidOperation, "no more elements")
+		return None, None, io.EOF
 	}
 
 	key := iter.keys[iter.pos]

--- a/pkg/runtime/object_iter_test.go
+++ b/pkg/runtime/object_iter_test.go
@@ -2,6 +2,8 @@ package runtime_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"slices"
 	"testing"
 
@@ -16,10 +18,8 @@ func TestObjectIterator(t *testing.T) {
 		obj := NewObject()
 		iter := NewObjectIterator(obj)
 
-		hasNext, err := iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err := iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("One value", t, func() {
@@ -28,21 +28,14 @@ func TestObjectIterator(t *testing.T) {
 		obj.Set(ctx, NewString("key"), NewInt(1))
 		iter := NewObjectIterator(obj)
 
-		hasNext, err := iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeTrue)
-
 		val, key, err := iter.Next(ctx)
 
 		So(err, ShouldBeNil)
 		So(val, ShouldEqual, NewInt(1))
 		So(key, ShouldEqual, NewString("key"))
 
-		hasNext, err = iter.HasNext(ctx)
-
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err = iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("Multiple values", t, func() {
@@ -58,12 +51,11 @@ func TestObjectIterator(t *testing.T) {
 		actual := make([][2]Value, 0, 5)
 
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			val, key, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-
-			val, key, err := iter.Next(ctx)
+			So(err, ShouldBeNil)
 
 			actual = append(actual, [2]Value{key, val})
 		}
@@ -91,17 +83,18 @@ func BenchmarkObjectIterator(b *testing.B) {
 		obj.Set(ctx, NewString("key"+ToString(NewInt(i)).String()), NewInt(i))
 	}
 
-	iter := NewObjectIterator(obj)
-
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		iter := NewObjectIterator(obj)
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			_, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			iter.Next(ctx)
+			if err != nil {
+				break
+			}
 		}
 	}
 }

--- a/pkg/runtime/object_test.go
+++ b/pkg/runtime/object_test.go
@@ -21,13 +21,15 @@ func TestObject(t *testing.T) {
 
 		Convey("Should create an object, from passed values", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("none", None),
-				NewObjectProperty("boolean", False),
-				NewObjectProperty("int", NewInt(1)),
-				NewObjectProperty("float", Float(1)),
-				NewObjectProperty("string", NewString("1")),
-				NewObjectProperty("array", NewArray(10)),
-				NewObjectProperty("object", NewObject()),
+				map[string]Value{
+					"none":    None,
+					"boolean": False,
+					"int":     NewInt(1),
+					"float":   Float(1),
+					"string":  NewString("1"),
+					"array":   NewArray(10),
+					"object":  NewObject(),
+				},
 			)
 
 			size, err := obj.Length(c.Background())
@@ -49,13 +51,15 @@ func TestObject(t *testing.T) {
 
 		Convey("Should serialize full object", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("none", None),
-				NewObjectProperty("boolean", False),
-				NewObjectProperty("int", NewInt(1)),
-				NewObjectProperty("float", Float(1)),
-				NewObjectProperty("string", NewString("1")),
-				NewObjectProperty("array", NewArray(10)),
-				NewObjectProperty("object", NewObject()),
+				map[string]Value{
+					"none":    None,
+					"boolean": False,
+					"int":     NewInt(1),
+					"float":   Float(1),
+					"string":  NewString("1"),
+					"array":   NewArray(10),
+					"object":  NewObject(),
+				},
 			)
 			marshaled, err := obj.MarshalJSON()
 
@@ -68,7 +72,9 @@ func TestObject(t *testing.T) {
 	Convey(".String", t, func() {
 		Convey("Should return a string representation ", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("foo", NewString("bar")),
+				map[string]Value{
+					"foo": NewString("bar"),
+				},
 			)
 
 			So(obj.String(), ShouldEqual, "{\"foo\":\"bar\"}")
@@ -108,12 +114,16 @@ func TestObject(t *testing.T) {
 
 		Convey("It should return 0 when both objects are equal (independent of key order)", func() {
 			obj1 := NewObjectWith(
-				NewObjectProperty("foo", NewString("foo")),
-				NewObjectProperty("bar", NewString("bar")),
+				map[string]Value{
+					"foo": NewString("foo"),
+					"bar": NewString("bar"),
+				},
 			)
 			obj2 := NewObjectWith(
-				NewObjectProperty("foo", NewString("foo")),
-				NewObjectProperty("bar", NewString("bar")),
+				map[string]Value{
+					"foo": NewString("foo"),
+					"bar": NewString("bar"),
+				},
 			)
 
 			So(obj1.Compare(obj1), ShouldEqual, 0)
@@ -123,69 +133,121 @@ func TestObject(t *testing.T) {
 		})
 
 		Convey("It should return 1 when other array is empty", func() {
-			obj1 := NewObjectWith(NewObjectProperty("foo", NewString("bar")))
+			obj1 := NewObjectWith(
+				map[string]Value{
+					"foo": NewString("bar"),
+				},
+			)
 			obj2 := NewObject()
 
 			So(obj1.Compare(obj2), ShouldEqual, 1)
 		})
 
 		Convey("It should return 1 when values are bigger", func() {
-			obj1 := NewObjectWith(NewObjectProperty("foo", NewFloat(3)))
-			obj2 := NewObjectWith(NewObjectProperty("foo", NewFloat(2)))
+			obj1 := NewObjectWith(
+				map[string]Value{
+					"foo": NewFloat(3),
+				},
+			)
+			obj2 := NewObjectWith(
+				map[string]Value{
+					"foo": NewFloat(2),
+				},
+			)
 
 			So(obj1.Compare(obj2), ShouldEqual, 1)
 		})
 
 		Convey("It should return 1 when values are less", func() {
-			obj1 := NewObjectWith(NewObjectProperty("foo", NewFloat(1)))
-			obj2 := NewObjectWith(NewObjectProperty("foo", NewFloat(2)))
+			obj1 := NewObjectWith(
+				map[string]Value{
+					"foo": NewFloat(1),
+				},
+			)
+			obj2 := NewObjectWith(
+				map[string]Value{
+					"foo": NewFloat(2),
+				},
+			)
 
 			So(obj1.Compare(obj2), ShouldEqual, -1)
 		})
 
 		Convey("ArangoDB compatibility", func() {
 			Convey("It should return 1 when {a:1} and {b:2}", func() {
-				obj1 := NewObjectWith(NewObjectProperty("a", NewInt(1)))
-				obj2 := NewObjectWith(NewObjectProperty("b", NewInt(2)))
+				obj1 := NewObjectWith(
+					map[string]Value{
+						"a": NewInt(1),
+					},
+				)
+				obj2 := NewObjectWith(
+					map[string]Value{
+						"b": NewInt(2),
+					},
+				)
 
 				So(obj1.Compare(obj2), ShouldEqual, 1)
 			})
 
 			Convey("It should return 0 when {a:1} and {a:1}", func() {
-				obj1 := NewObjectWith(NewObjectProperty("a", NewInt(1)))
-				obj2 := NewObjectWith(NewObjectProperty("a", NewInt(1)))
+				obj1 := NewObjectWith(
+					map[string]Value{
+						"a": NewInt(1),
+					},
+				)
+				obj2 := NewObjectWith(
+					map[string]Value{
+						"a": NewInt(1),
+					},
+				)
 
 				So(obj1.Compare(obj2), ShouldEqual, 0)
 			})
 
 			Convey("It should return 0 {a:1, c:2} and {c:2, a:1}", func() {
 				obj1 := NewObjectWith(
-					NewObjectProperty("a", NewInt(1)),
-					NewObjectProperty("c", NewInt(2)),
+					map[string]Value{
+						"a": NewInt(1),
+						"c": NewInt(2),
+					},
 				)
 				obj2 := NewObjectWith(
-					NewObjectProperty("c", NewInt(2)),
-					NewObjectProperty("a", NewInt(1)),
+					map[string]Value{
+						"c": NewInt(2),
+						"a": NewInt(1),
+					},
 				)
 
 				So(obj1.Compare(obj2), ShouldEqual, 0)
 			})
 
 			Convey("It should return -1 when {a:1} and {a:2}", func() {
-				obj1 := NewObjectWith(NewObjectProperty("a", NewInt(1)))
-				obj2 := NewObjectWith(NewObjectProperty("a", NewInt(2)))
+				obj1 := NewObjectWith(
+					map[string]Value{
+						"a": NewInt(1),
+					},
+				)
+				obj2 := NewObjectWith(
+					map[string]Value{
+						"a": NewInt(2),
+					},
+				)
 
 				So(obj1.Compare(obj2), ShouldEqual, -1)
 			})
 
 			Convey("It should return 1 when {a:1, c:2} and {c:2, b:2}", func() {
 				obj1 := NewObjectWith(
-					NewObjectProperty("a", NewInt(1)),
-					NewObjectProperty("c", NewInt(2)),
+					map[string]Value{
+						"a": NewInt(1),
+						"c": NewInt(2),
+					},
 				)
 				obj2 := NewObjectWith(
-					NewObjectProperty("c", NewInt(2)),
-					NewObjectProperty("b", NewInt(2)),
+					map[string]Value{
+						"c": NewInt(2),
+						"b": NewInt(2),
+					},
 				)
 
 				So(obj1.Compare(obj2), ShouldEqual, 1)
@@ -193,12 +255,16 @@ func TestObject(t *testing.T) {
 
 			Convey("It should return 1 {a:1, c:3} and {c:2, a:1}", func() {
 				obj1 := NewObjectWith(
-					NewObjectProperty("a", NewInt(1)),
-					NewObjectProperty("c", NewInt(3)),
+					map[string]Value{
+						"a": NewInt(1),
+						"c": NewInt(3),
+					},
 				)
 				obj2 := NewObjectWith(
-					NewObjectProperty("c", NewInt(2)),
-					NewObjectProperty("a", NewInt(1)),
+					map[string]Value{
+						"c": NewInt(2),
+						"a": NewInt(1),
+					},
 				)
 
 				So(obj1.Compare(obj2), ShouldEqual, 1)
@@ -209,9 +275,11 @@ func TestObject(t *testing.T) {
 	Convey(".Hash", t, func() {
 		Convey("It should calculate hash of non-empty object", func() {
 			v := NewObjectWith(
-				NewObjectProperty("foo", NewString("bar")),
-				NewObjectProperty("faz", NewInt(1)),
-				NewObjectProperty("qaz", True),
+				map[string]Value{
+					"foo": NewString("bar"),
+					"faz": NewInt(1),
+					"qaz": True,
+				},
 			)
 
 			h := v.Hash()
@@ -229,13 +297,15 @@ func TestObject(t *testing.T) {
 
 		Convey("Hash sum should be consistent", func() {
 			v := NewObjectWith(
-				NewObjectProperty("boolean", True),
-				NewObjectProperty("int", NewInt(1)),
-				NewObjectProperty("float", NewFloat(1.1)),
-				NewObjectProperty("string", NewString("foobar")),
-				NewObjectProperty("datetime", NewCurrentDateTime()),
-				NewObjectProperty("array", NewArrayWith(NewInt(1), True)),
-				NewObjectProperty("object", NewObjectWith(NewObjectProperty("foo", NewString("bar")))),
+				map[string]Value{
+					"boolean":  True,
+					"int":      NewInt(1),
+					"float":    NewFloat(1.1),
+					"string":   NewString("foobar"),
+					"datetime": NewCurrentDateTime(),
+					"array":    NewArrayWith(NewInt(1), True),
+					"object":   NewObjectWith(map[string]Value{"foo": NewString("bar")}),
+				},
 			)
 
 			h1 := v.Hash()
@@ -256,8 +326,10 @@ func TestObject(t *testing.T) {
 
 		Convey("Should return greater than 0 when not empty", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("foo", ZeroInt),
-				NewObjectProperty("bar", ZeroInt),
+				map[string]Value{
+					"foo": ZeroInt,
+					"bar": ZeroInt,
+				},
 			)
 
 			size, err := obj.Length(c.Background())
@@ -269,8 +341,10 @@ func TestObject(t *testing.T) {
 	Convey(".ForEachIter", t, func() {
 		Convey("Should iterate over elements", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("bar", ZeroInt),
-				NewObjectProperty("foo", ZeroInt),
+				map[string]Value{
+					"bar": ZeroInt,
+					"foo": ZeroInt,
+				},
 			)
 			counter := 0
 			ctx := c.Background()
@@ -307,11 +381,13 @@ func TestObject(t *testing.T) {
 
 		Convey("Should break iteration when false returned", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("1", NewInt(1)),
-				NewObjectProperty("2", NewInt(2)),
-				NewObjectProperty("3", NewInt(3)),
-				NewObjectProperty("4", NewInt(4)),
-				NewObjectProperty("5", NewInt(5)),
+				map[string]Value{
+					"1": NewInt(1),
+					"2": NewInt(2),
+					"3": NewInt(3),
+					"4": NewInt(4),
+					"5": NewInt(5),
+				},
 			)
 			threshold := 3
 			counter := 0
@@ -365,8 +441,10 @@ func TestObject(t *testing.T) {
 	Convey(".Clone", t, func() {
 		Convey("Cloned object should be equal to source object", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("one", NewInt(1)),
-				NewObjectProperty("two", NewInt(2)),
+				map[string]Value{
+					"one": NewInt(1),
+					"two": NewInt(2),
+				},
 			)
 
 			ctx := c.Background()
@@ -378,8 +456,10 @@ func TestObject(t *testing.T) {
 
 		Convey("Cloned object should be independent of the source object", func() {
 			obj := NewObjectWith(
-				NewObjectProperty("one", NewInt(1)),
-				NewObjectProperty("two", NewInt(2)),
+				map[string]Value{
+					"one": NewInt(1),
+					"two": NewInt(2),
+				},
 			)
 
 			ctx := c.Background()
@@ -393,9 +473,9 @@ func TestObject(t *testing.T) {
 
 		Convey("Cloned object must contain copies of the nested objects", func() {
 			obj := NewObjectWith(
-				NewObjectProperty(
-					"arr", NewArrayWith(NewInt(1)),
-				),
+				map[string]Value{
+					"arr": NewArrayWith(NewInt(1)),
+				},
 			)
 
 			ctx := c.Background()

--- a/pkg/runtime/observable_iter.go
+++ b/pkg/runtime/observable_iter.go
@@ -2,13 +2,13 @@ package runtime
 
 import (
 	"context"
+	"io"
 	"time"
 )
 
 type StreamIterator struct {
 	stream      Stream
 	channel     <-chan Message
-	message     Message
 	timeout     time.Duration
 	initialized bool
 	closed      bool
@@ -25,14 +25,14 @@ func NewIteratorWithTimeout(stream Stream, timeout time.Duration) Iterator {
 	}
 }
 
-func (s *StreamIterator) HasNext(ctx context.Context) (bool, error) {
+func (s *StreamIterator) Next(ctx context.Context) (value Value, key Value, err error) {
 	if !s.initialized {
 		s.channel = s.stream.Read(ctx)
 		s.initialized = true
 	}
 
 	if s.closed {
-		return false, nil
+		return None, None, io.EOF
 	}
 
 	var message Message
@@ -41,22 +41,16 @@ func (s *StreamIterator) HasNext(ctx context.Context) (bool, error) {
 	select {
 	case message, isOpen = <-s.channel:
 	case <-time.After(s.timeout):
-		return false, ErrTimeout
+		return None, None, ErrTimeout
 	}
 
 	if !isOpen {
 		s.closed = true
 
-		return false, nil
+		return None, None, io.EOF
 	}
 
-	s.message = message
-
-	return true, nil
-}
-
-func (s *StreamIterator) Next(_ context.Context) (value Value, key Value, err error) {
-	return s.message.Value(), None, s.message.Err()
+	return message.Value(), None, message.Err()
 }
 
 func (s *StreamIterator) Close() error {

--- a/pkg/runtime/proxy.go
+++ b/pkg/runtime/proxy.go
@@ -84,7 +84,7 @@ func (p *Proxy[T]) Compare(other Value) int64 {
 }
 
 func (p *Proxy[T]) Copy() Value {
-	return NewProxy(p.target)
+	return NewProxy[T](p.target)
 }
 
 func (p *Proxy[T]) Length(ctx context.Context) (Int, error) {

--- a/pkg/runtime/proxy.go
+++ b/pkg/runtime/proxy.go
@@ -9,17 +9,21 @@ import (
 	"github.com/wI2L/jettison"
 )
 
-type Proxy struct {
+type Proxy[T any] struct {
 	target any
 }
 
-func NewProxy(target any) *Proxy {
-	return &Proxy{
+func NewProxy[T any](target T) *Proxy[T] {
+	return &Proxy[T]{
 		target: target,
 	}
 }
 
-func (p *Proxy) Type() Type {
+func (p *Proxy[T]) Target() T {
+	return p.target.(T)
+}
+
+func (p *Proxy[T]) Type() Type {
 	typed, ok := p.target.(Typed)
 
 	if ok {
@@ -29,7 +33,7 @@ func (p *Proxy) Type() Type {
 	return NewReflectType(p.target)
 }
 
-func (p *Proxy) Unwrap() any {
+func (p *Proxy[T]) Unwrap() any {
 	unwrappable, ok := p.target.(Unwrappable)
 
 	if ok {
@@ -39,7 +43,7 @@ func (p *Proxy) Unwrap() any {
 	return p.target
 }
 
-func (p *Proxy) MarshalJSON() ([]byte, error) {
+func (p *Proxy[T]) MarshalJSON() ([]byte, error) {
 	marshaler, ok := p.target.(json.Marshaler)
 
 	if ok {
@@ -49,7 +53,7 @@ func (p *Proxy) MarshalJSON() ([]byte, error) {
 	return jettison.MarshalOpts(p.target, jettison.NoHTMLEscaping())
 }
 
-func (p *Proxy) String() string {
+func (p *Proxy[T]) String() string {
 	stringer, ok := p.target.(fmt.Stringer)
 
 	if ok {
@@ -59,7 +63,7 @@ func (p *Proxy) String() string {
 	return fmt.Sprintf("%v", p.target)
 }
 
-func (p *Proxy) Hash() uint64 {
+func (p *Proxy[T]) Hash() uint64 {
 	hashable, ok := p.target.(Hashable)
 
 	if ok {
@@ -69,7 +73,7 @@ func (p *Proxy) Hash() uint64 {
 	return uint64(reflect.ValueOf(p.target).Pointer())
 }
 
-func (p *Proxy) Compare(other Value) int64 {
+func (p *Proxy[T]) Compare(other Value) int64 {
 	comp, ok := p.target.(Comparable)
 
 	if ok {
@@ -79,11 +83,11 @@ func (p *Proxy) Compare(other Value) int64 {
 	return -1
 }
 
-func (p *Proxy) Copy() Value {
+func (p *Proxy[T]) Copy() Value {
 	return NewProxy(p.target)
 }
 
-func (p *Proxy) Length(ctx context.Context) (Int, error) {
+func (p *Proxy[T]) Length(ctx context.Context) (Int, error) {
 	measurable, ok := p.target.(Measurable)
 
 	if ok {
@@ -93,7 +97,7 @@ func (p *Proxy) Length(ctx context.Context) (Int, error) {
 	return -1, ProxyError(p.target, TypeMeasurable)
 }
 
-func (p *Proxy) Get(ctx context.Context, key Value) (Value, error) {
+func (p *Proxy[T]) Get(ctx context.Context, key Value) (Value, error) {
 	keyReadable, ok := p.target.(KeyReadable)
 
 	if ok {
@@ -103,7 +107,7 @@ func (p *Proxy) Get(ctx context.Context, key Value) (Value, error) {
 	return None, ProxyError(p.target, TypeKeyReadable)
 }
 
-func (p *Proxy) Set(ctx context.Context, key, value Value) error {
+func (p *Proxy[T]) Set(ctx context.Context, key, value Value) error {
 	keyWritable, ok := p.target.(KeyWritable)
 
 	if ok {
@@ -113,7 +117,7 @@ func (p *Proxy) Set(ctx context.Context, key, value Value) error {
 	return ProxyError(p.target, TypeKeyWritable)
 }
 
-func (p *Proxy) Iterate(ctx context.Context) (Iterator, error) {
+func (p *Proxy[T]) Iterate(ctx context.Context) (Iterator, error) {
 	iterable, ok := p.target.(Iterable)
 
 	if ok {
@@ -123,7 +127,7 @@ func (p *Proxy) Iterate(ctx context.Context) (Iterator, error) {
 	return nil, ProxyError(p.target, TypeIterable)
 }
 
-func (p *Proxy) SortAsc(ctx context.Context) error {
+func (p *Proxy[T]) SortAsc(ctx context.Context) error {
 	sortable, ok := p.target.(Sortable)
 
 	if ok {
@@ -133,7 +137,7 @@ func (p *Proxy) SortAsc(ctx context.Context) error {
 	return ProxyError(p.target, TypeSortable)
 }
 
-func (p *Proxy) SortDesc(ctx context.Context) error {
+func (p *Proxy[T]) SortDesc(ctx context.Context) error {
 	sortable, ok := p.target.(Sortable)
 
 	if ok {
@@ -143,7 +147,7 @@ func (p *Proxy) SortDesc(ctx context.Context) error {
 	return ProxyError(p.target, TypeSortable)
 }
 
-func (p *Proxy) Dispatch(ctx context.Context, event DispatchEvent) (Value, error) {
+func (p *Proxy[T]) Dispatch(ctx context.Context, event DispatchEvent) (Value, error) {
 	dispatchable, ok := p.target.(Dispatchable)
 
 	if ok {
@@ -153,7 +157,7 @@ func (p *Proxy) Dispatch(ctx context.Context, event DispatchEvent) (Value, error
 	return None, ProxyError(p.target, TypeDispatchable)
 }
 
-func (p *Proxy) Subscribe(ctx context.Context, subscription Subscription) (Stream, error) {
+func (p *Proxy[T]) Subscribe(ctx context.Context, subscription Subscription) (Stream, error) {
 	observable, ok := p.target.(Observable)
 
 	if ok {
@@ -163,7 +167,7 @@ func (p *Proxy) Subscribe(ctx context.Context, subscription Subscription) (Strea
 	return nil, ProxyError(p.target, TypeObservable)
 }
 
-func (p *Proxy) Query(ctx context.Context, q Query) (Value, error) {
+func (p *Proxy[T]) Query(ctx context.Context, q Query) (Value, error) {
 	queryable, ok := p.target.(Queryable)
 
 	if ok {

--- a/pkg/runtime/proxy.go
+++ b/pkg/runtime/proxy.go
@@ -95,7 +95,7 @@ func (p *Proxy[T]) Compare(other Value) int64 {
 }
 
 func (p *Proxy[T]) Copy() Value {
-	return NewProxy[T](p.target)
+	return NewProxy[T](p.Target())
 }
 
 func (p *Proxy[T]) Length(ctx context.Context) (Int, error) {

--- a/pkg/runtime/proxy.go
+++ b/pkg/runtime/proxy.go
@@ -20,6 +20,17 @@ func NewProxy[T any](target T) *Proxy[T] {
 }
 
 func (p *Proxy[T]) Target() T {
+	// Safeguard against nil target.
+	// This can happen if the constructor is bypassed or misused, which is a programming error.
+	// In such cases, we return the zero value of T to prevent panics in methods that rely on the target.
+	if p.target == nil {
+		var zero T
+
+		return zero
+	}
+
+	// This should not panic because the constructor enforces the type.
+	// If the target is not of type T, it means that the constructor was bypassed or misused, which is a programming error.
 	return p.target.(T)
 }
 

--- a/pkg/runtime/type.go
+++ b/pkg/runtime/type.go
@@ -121,12 +121,12 @@ func TypeOf(input Value) Type {
 		return TypeDateTime
 	case *Array:
 		return TypeArray
+	case *Object:
+		return TypeObject
 	case ObjectLike:
 		return TypeObject
 	case List:
 		return TypeList
-	case *Object:
-		return TypeObject
 	case Map:
 		return TypeMap
 	case Binary:

--- a/pkg/stdlib/collections/count_distinct_test.go
+++ b/pkg/stdlib/collections/count_distinct_test.go
@@ -65,9 +65,11 @@ func TestCountDistinct(t *testing.T) {
 
 	Convey("When counting distinct elements in object", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewInt(2)),
-			runtime.NewObjectProperty("c", runtime.NewInt(1)), // duplicate value
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewInt(2),
+				"c": runtime.NewInt(1), // duplicate value
+			},
 		)
 
 		result, err := collections.CountDistinct(context.Background(), obj)
@@ -108,13 +110,19 @@ func TestCountDistinct(t *testing.T) {
 
 	Convey("When counting distinct with complex objects", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("x", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"x": runtime.NewInt(1),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("x", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"x": runtime.NewInt(1),
+			},
 		)
 		obj3 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("x", runtime.NewInt(2)),
+			map[string]runtime.Value{
+				"x": runtime.NewInt(2),
+			},
 		)
 
 		arr := runtime.NewArrayWith(obj1, obj2, obj3)

--- a/pkg/stdlib/collections/count_test.go
+++ b/pkg/stdlib/collections/count_test.go
@@ -53,8 +53,10 @@ func TestCount(t *testing.T) {
 
 	Convey("When counting an object", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewInt(2)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewInt(2),
+			},
 		)
 
 		result, err := collections.Count(context.Background(), obj)

--- a/pkg/stdlib/collections/includes_test.go
+++ b/pkg/stdlib/collections/includes_test.go
@@ -120,9 +120,11 @@ func TestIncludes(t *testing.T) {
 	Convey("When searching in object", t, func() {
 		Convey("Should find existing value", func() {
 			obj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(1)),
-				runtime.NewObjectProperty("b", runtime.NewString("hello")),
-				runtime.NewObjectProperty("c", runtime.NewBoolean(true)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(1),
+					"b": runtime.NewString("hello"),
+					"c": runtime.NewBoolean(true),
+				},
 			)
 			needle := runtime.NewString("hello")
 
@@ -134,8 +136,10 @@ func TestIncludes(t *testing.T) {
 
 		Convey("Should not find non-existing value", func() {
 			obj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(1)),
-				runtime.NewObjectProperty("b", runtime.NewString("hello")),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(1),
+					"b": runtime.NewString("hello"),
+				},
 			)
 			needle := runtime.NewString("world")
 
@@ -147,7 +151,9 @@ func TestIncludes(t *testing.T) {
 
 		Convey("Should not find key as value", func() {
 			obj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("hello", runtime.NewString("world")),
+				map[string]runtime.Value{
+					"hello": runtime.NewString("world"),
+				},
 			)
 			needle := runtime.NewString("hello") // This is a key, not a value
 
@@ -180,10 +186,14 @@ func TestIncludes(t *testing.T) {
 
 	Convey("When searching with complex objects", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("x", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"x": runtime.NewInt(1),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("x", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"x": runtime.NewInt(1),
+			},
 		)
 		arr := runtime.NewArrayWith(obj1, runtime.NewString("test"))
 
@@ -229,7 +239,9 @@ func TestIncludes(t *testing.T) {
 	Convey("Edge cases for array/object searching", t, func() {
 		Convey("Should handle nested objects", func() {
 			innerObj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("nested", runtime.NewString("value")),
+				map[string]runtime.Value{
+					"nested": runtime.NewString("value"),
+				},
 			)
 			arr := runtime.NewArrayWith(runtime.NewInt(1), innerObj)
 

--- a/pkg/stdlib/io/fs/write_test.go
+++ b/pkg/stdlib/io/fs/write_test.go
@@ -20,7 +20,9 @@ func TestWrite(t *testing.T) {
 		path := runtime.NewString("path.txt")
 		data := runtime.NewBinary([]byte("3timeslazy"))
 		params := runtime.NewObjectWith(
-			runtime.NewObjectProperty("mode", runtime.NewString("w")),
+			map[string]runtime.Value{
+				"mode": runtime.NewString("w"),
+			},
 		)
 		someInt := runtime.NewInt(0)
 
@@ -93,7 +95,9 @@ func TestWrite(t *testing.T) {
 
 					Convey(name, func() {
 						params := runtime.NewObjectWith(
-							runtime.NewObjectProperty("mode", mode),
+							map[string]runtime.Value{
+								"mode": mode,
+							},
 						)
 
 						none, err := fs.Write(context.Background(), path, data, params)
@@ -116,7 +120,9 @@ func TestWrite(t *testing.T) {
 				runtime.NewString(file.Name()),
 				runtime.NewBinary([]byte("3timeslazy")),
 				runtime.NewObjectWith(
-					runtime.NewObjectProperty("mode", runtime.NewString("wx")),
+					map[string]runtime.Value{
+						"mode": runtime.NewString("wx"),
+					},
 				),
 			)
 			So(none, ShouldResemble, runtime.None)
@@ -143,7 +149,9 @@ func TestWrite(t *testing.T) {
 			data := runtime.NewBinary([]byte("3timeslazy"))
 			fpath := runtime.NewString(file.Name())
 			params := runtime.NewObjectWith(
-				runtime.NewObjectProperty("mode", runtime.NewString("w")),
+				map[string]runtime.Value{
+					"mode": runtime.NewString("w"),
+				},
 			)
 
 			for _ = range [2]struct{}{} {
@@ -167,7 +175,9 @@ func TestWrite(t *testing.T) {
 			data := runtime.NewBinary([]byte("3timeslazy"))
 			fpath := runtime.NewString(file.Name())
 			params := runtime.NewObjectWith(
-				runtime.NewObjectProperty("mode", runtime.NewString("a")),
+				map[string]runtime.Value{
+					"mode": runtime.NewString("a"),
+				},
 			)
 
 			for i := range [2]struct{}{} {

--- a/pkg/stdlib/io/net/http/delete_test.go
+++ b/pkg/stdlib/io/net/http/delete_test.go
@@ -66,8 +66,10 @@ func TestDELETE(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		out, err := http.DELETE(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", runtime.NewBinary(b)),
+			map[string]runtime.Value{
+				"url":  runtime.NewString(url),
+				"body": runtime.NewBinary(b),
+			},
 		))
 
 		So(err, ShouldBeNil)

--- a/pkg/stdlib/io/net/http/get_test.go
+++ b/pkg/stdlib/io/net/http/get_test.go
@@ -56,11 +56,15 @@ func TestGET(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.GET(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("headers", runtime.NewObjectWith(
-				runtime.NewObjectProperty("X-token", runtime.NewString("Ferret")),
-				runtime.NewObjectProperty("X-From", runtime.NewString("localhost")),
-			)),
+			map[string]runtime.Value{
+				"url": runtime.NewString(url),
+				"headers": runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"X-token": runtime.NewString("Ferret"),
+						"X-From":  runtime.NewString("localhost"),
+					},
+				),
+			},
 		))
 
 		So(err, ShouldBeNil)

--- a/pkg/stdlib/io/net/http/lib_test.go
+++ b/pkg/stdlib/io/net/http/lib_test.go
@@ -75,8 +75,10 @@ func TestREQUEST(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.REQUEST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("method", runtime.NewString("GET")),
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
+			map[string]runtime.Value{
+				"method": runtime.NewString("GET"),
+				"url":    runtime.NewString(url),
+			},
 		))
 
 		So(err, ShouldBeNil)
@@ -95,9 +97,11 @@ func TestREQUEST(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.REQUEST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("method", runtime.NewString("POST")),
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", runtime.NewBinary([]byte("test data"))),
+			map[string]runtime.Value{
+				"method": runtime.NewString("POST"),
+				"url":    runtime.NewString(url),
+				"body":   runtime.NewBinary([]byte("test data")),
+			},
 		))
 
 		So(err, ShouldBeNil)
@@ -119,11 +123,15 @@ func TestREQUEST(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.REQUEST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("method", runtime.NewString("POST")),
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("headers", runtime.NewObjectWith(
-				runtime.NewObjectProperty("X-Token", runtime.NewString("test-token")),
-			)),
+			map[string]runtime.Value{
+				"method": runtime.NewString("POST"),
+				"url":    runtime.NewString(url),
+				"headers": runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"X-Token": runtime.NewString("test-token"),
+					},
+				),
+			},
 		))
 
 		So(err, ShouldBeNil)
@@ -145,11 +153,15 @@ func TestREQUEST(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.REQUEST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("method", runtime.NewString("POST")),
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", runtime.NewObjectWith(
-				runtime.NewObjectProperty("test", runtime.NewString("data")),
-			)),
+			map[string]runtime.Value{
+				"method": runtime.NewString("POST"),
+				"url":    runtime.NewString(url),
+				"body": runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"test": runtime.NewString("data"),
+					},
+				),
+			},
 		))
 
 		So(err, ShouldBeNil)
@@ -160,7 +172,9 @@ func TestREQUEST(t *testing.T) {
 		ctx := context.Background()
 
 		out, err := http.REQUEST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("method", runtime.NewString("GET")),
+			map[string]runtime.Value{
+				"method": runtime.NewString("GET"),
+			},
 		))
 
 		So(out, ShouldEqual, runtime.None)

--- a/pkg/stdlib/io/net/http/post_test.go
+++ b/pkg/stdlib/io/net/http/post_test.go
@@ -66,8 +66,10 @@ func TestPOST(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		out, err := http.POST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", runtime.NewBinary(b)),
+			map[string]runtime.Value{
+				"url":  runtime.NewString(url),
+				"body": runtime.NewBinary(b),
+			},
 		))
 
 		So(err, ShouldBeNil)
@@ -109,13 +111,17 @@ func TestPOST(t *testing.T) {
 		ctx := context.Background()
 
 		j := runtime.NewObjectWith(
-			runtime.NewObjectProperty("first_name", runtime.NewString("Rob")),
-			runtime.NewObjectProperty("last_name", runtime.NewString("Pike")),
+			map[string]runtime.Value{
+				"first_name": runtime.NewString("Rob"),
+				"last_name":  runtime.NewString("Pike"),
+			},
 		)
 
 		out, err := http.POST(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", j),
+			map[string]runtime.Value{
+				"url":  runtime.NewString(url),
+				"body": j,
+			},
 		))
 
 		So(err, ShouldBeNil)

--- a/pkg/stdlib/io/net/http/put_test.go
+++ b/pkg/stdlib/io/net/http/put_test.go
@@ -66,8 +66,10 @@ func TestPUT(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		out, err := http.PUT(ctx, runtime.NewObjectWith(
-			runtime.NewObjectProperty("url", runtime.NewString(url)),
-			runtime.NewObjectProperty("body", runtime.NewBinary(b)),
+			map[string]runtime.Value{
+				"url":  runtime.NewString(url),
+				"body": runtime.NewBinary(b),
+			},
 		))
 
 		So(err, ShouldBeNil)

--- a/pkg/stdlib/objects/has_test.go
+++ b/pkg/stdlib/objects/has_test.go
@@ -15,7 +15,9 @@ import (
 func TestHas(t *testing.T) {
 	Convey("When key exists", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("key", runtime.NewString("val")),
+			map[string]runtime.Value{
+				"key": runtime.NewString("val"),
+			},
 		)
 
 		val, err := objects.Has(context.Background(), obj, runtime.NewString("key"))
@@ -28,7 +30,9 @@ func TestHas(t *testing.T) {
 
 	Convey("When key doesn't exists", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("anyOtherKey", runtime.NewString("val")),
+			map[string]runtime.Value{
+				"anyOtherKey": runtime.NewString("val"),
+			},
 		)
 
 		val, err := objects.Has(context.Background(), obj, runtime.NewString("key"))
@@ -83,7 +87,9 @@ func TestHas(t *testing.T) {
 
 	Convey("When key is empty string", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("", runtime.NewString("empty")),
+			map[string]runtime.Value{
+				"": runtime.NewString("empty"),
+			},
 		)
 
 		val, err := objects.Has(context.Background(), obj, runtime.NewString(""))
@@ -94,14 +100,13 @@ func TestHas(t *testing.T) {
 	})
 
 	Convey("When object has many keys", t, func() {
-		properties := make([]*runtime.ObjectProperty, 100)
+		properties := make(map[string]runtime.Value, 100)
+
 		for i := 0; i < 100; i++ {
-			properties[i] = runtime.NewObjectProperty(
-				fmt.Sprintf("key%d", i),
-				runtime.NewInt(i),
-			)
+			properties[fmt.Sprintf("key%d", i)] = runtime.NewInt(i)
 		}
-		obj := runtime.NewObjectWith(properties...)
+
+		obj := runtime.NewObjectWith(properties)
 
 		// Test existing key
 		val, err := objects.Has(context.Background(), obj, runtime.NewString("key50"))

--- a/pkg/stdlib/objects/keep_keys_test.go
+++ b/pkg/stdlib/objects/keep_keys_test.go
@@ -51,7 +51,9 @@ func TestKeepKeys(t *testing.T) {
 	Convey("Result object is independent of the source object", t, func() {
 		arr := runtime.NewArrayWith(runtime.Int(0))
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", arr),
+			map[string]runtime.Value{
+				"a": arr,
+			},
 		)
 
 		afterKeepKeys, err := objects.KeepKeys(context.Background(), obj, runtime.NewString("a"))
@@ -61,7 +63,9 @@ func TestKeepKeys(t *testing.T) {
 		arr.Append(context.Background(), runtime.NewInt(1))
 
 		resultObj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewArrayWith(runtime.Int(0))),
+			map[string]runtime.Value{
+				"a": runtime.NewArrayWith(runtime.Int(0)),
+			},
 		)
 		So(runtime.CompareValues(afterKeepKeys, resultObj), ShouldEqual, 0)
 	})
@@ -70,11 +74,15 @@ func TestKeepKeys(t *testing.T) {
 func TestKeepKeysStrings(t *testing.T) {
 	Convey("KeepKeys key 'a'", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		resultObj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+			},
 		)
 
 		afterKeepKeys, err := objects.KeepKeys(context.Background(), obj, runtime.NewString("a"))
@@ -85,8 +93,10 @@ func TestKeepKeysStrings(t *testing.T) {
 
 	Convey("KeepKeys key doesn't exists", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		resultObj := runtime.NewObject()
 
@@ -98,12 +108,16 @@ func TestKeepKeysStrings(t *testing.T) {
 
 	Convey("KeepKeys when there are more keys than object properties", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		resultObj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 
 		afterKeepKeys, err := objects.KeepKeys(context.Background(), obj,
@@ -118,12 +132,16 @@ func TestKeepKeysStrings(t *testing.T) {
 func TestKeepKeysArray(t *testing.T) {
 	Convey("KeepKeys array", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		keys := runtime.NewArrayWith(runtime.NewString("a"))
 		resultObj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+			},
 		)
 
 		afterKeepKeys, err := objects.KeepKeys(context.Background(), obj, keys)
@@ -134,8 +152,10 @@ func TestKeepKeysArray(t *testing.T) {
 
 	Convey("KeepKeys empty array", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		keys := runtime.NewArray(0)
 		resultObj := runtime.NewObject()
@@ -148,15 +168,19 @@ func TestKeepKeysArray(t *testing.T) {
 
 	Convey("KeepKeys when there are more keys than object properties", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		keys := runtime.NewArrayWith(
 			runtime.NewString("a"), runtime.NewString("b"), runtime.NewString("c"),
 		)
 		resultObj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 
 		afterKeepKeys, err := objects.KeepKeys(context.Background(), obj, keys)
@@ -167,8 +191,10 @@ func TestKeepKeysArray(t *testing.T) {
 
 	Convey("When there is not string key", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("b", runtime.NewString("string")),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(1),
+				"b": runtime.NewString("string"),
+			},
 		)
 		keys := runtime.NewArrayWith(
 			runtime.NewString("a"),

--- a/pkg/stdlib/objects/keys_test.go
+++ b/pkg/stdlib/objects/keys_test.go
@@ -14,9 +14,11 @@ import (
 func TestKeys(t *testing.T) {
 	Convey("Keys(obj, false) should return 'a', 'c', 'b' in any order", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(0)),
-			runtime.NewObjectProperty("b", runtime.NewInt(1)),
-			runtime.NewObjectProperty("c", runtime.NewInt(2)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(0),
+				"b": runtime.NewInt(1),
+				"c": runtime.NewInt(2),
+			},
 		)
 
 		keys, err := objects.Keys(context.Background(), obj)
@@ -47,9 +49,11 @@ func TestKeys(t *testing.T) {
 
 	Convey("Keys(obj, true) should return ['a', 'b', 'c'] in sorted order", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("b", runtime.NewInt(0)),
-			runtime.NewObjectProperty("a", runtime.NewInt(1)),
-			runtime.NewObjectProperty("c", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"b": runtime.NewInt(0),
+				"a": runtime.NewInt(1),
+				"c": runtime.NewInt(3),
+			},
 		)
 
 		keys, err := objects.Keys(context.Background(), obj, runtime.NewBoolean(true))
@@ -106,10 +110,12 @@ func TestKeys(t *testing.T) {
 
 	Convey("When object has special character keys", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("key with spaces", runtime.NewInt(1)),
-			runtime.NewObjectProperty("key_with_underscores", runtime.NewInt(2)),
-			runtime.NewObjectProperty("key-with-dashes", runtime.NewInt(3)),
-			runtime.NewObjectProperty("key.with.dots", runtime.NewInt(4)),
+			map[string]runtime.Value{
+				"key with spaces":      runtime.NewInt(1),
+				"key_with_underscores": runtime.NewInt(2),
+				"key-with-dashes":      runtime.NewInt(3),
+				"key.with.dots":        runtime.NewInt(4),
+			},
 		)
 
 		keys, err := objects.Keys(context.Background(), obj, runtime.NewBoolean(true))

--- a/pkg/stdlib/objects/merge_recursive_test.go
+++ b/pkg/stdlib/objects/merge_recursive_test.go
@@ -36,10 +36,14 @@ func TestMergeRecursive(t *testing.T) {
 
 	Convey("Merge single object", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(0)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(0),
+			},
 		)
 		expected := runtime.NewObjectWith(
-			runtime.NewObjectProperty("a", runtime.NewInt(0)),
+			map[string]runtime.Value{
+				"a": runtime.NewInt(0),
+			},
 		)
 
 		actual, err := objects.MergeRecursive(context.Background(), obj)
@@ -51,18 +55,24 @@ func TestMergeRecursive(t *testing.T) {
 	Convey("Merge two objects", t, func() {
 		Convey("When there are no common keys", func() {
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(0)),
-				runtime.NewObjectProperty("b", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(0),
+					"b": runtime.NewInt(1),
+				},
 			)
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("c", runtime.NewInt(2)),
-				runtime.NewObjectProperty("d", runtime.NewInt(3)),
+				map[string]runtime.Value{
+					"c": runtime.NewInt(2),
+					"d": runtime.NewInt(3),
+				},
 			)
 			expected := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(0)),
-				runtime.NewObjectProperty("b", runtime.NewInt(1)),
-				runtime.NewObjectProperty("c", runtime.NewInt(2)),
-				runtime.NewObjectProperty("d", runtime.NewInt(3)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(0),
+					"b": runtime.NewInt(1),
+					"c": runtime.NewInt(2),
+					"d": runtime.NewInt(3),
+				},
 			)
 
 			actual, err := objects.MergeRecursive(context.Background(), obj1, obj2)
@@ -73,17 +83,23 @@ func TestMergeRecursive(t *testing.T) {
 
 		Convey("When objects with the same key", func() {
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(0)),
-				runtime.NewObjectProperty("b", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(0),
+					"b": runtime.NewInt(1),
+				},
 			)
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(2)), // Same key, different value
-				runtime.NewObjectProperty("c", runtime.NewInt(3)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(2), // Same key, different value
+					"c": runtime.NewInt(3),
+				},
 			)
 			expected := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(2)), // Second object's value should win
-				runtime.NewObjectProperty("b", runtime.NewInt(1)),
-				runtime.NewObjectProperty("c", runtime.NewInt(3)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(2), // Second object's value should win
+					"b": runtime.NewInt(1),
+					"c": runtime.NewInt(3),
+				},
 			)
 
 			actual, err := objects.MergeRecursive(context.Background(), obj1, obj2)
@@ -94,19 +110,27 @@ func TestMergeRecursive(t *testing.T) {
 
 		Convey("Merge two objects with the same keys and nested objects", func() {
 			nestedObj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("x", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"x": runtime.NewInt(1),
+				},
 			)
 			nestedObj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("y", runtime.NewInt(2)),
+				map[string]runtime.Value{
+					"y": runtime.NewInt(2),
+				},
 			)
 
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("nested", nestedObj1),
-				runtime.NewObjectProperty("simple", runtime.NewString("value1")),
+				map[string]runtime.Value{
+					"nested": nestedObj1,
+					"simple": runtime.NewString("value1"),
+				},
 			)
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("nested", nestedObj2),                  // Should merge recursively
-				runtime.NewObjectProperty("simple", runtime.NewString("value2")), // Should overwrite
+				map[string]runtime.Value{
+					"nested": nestedObj2,                  // Should merge recursively
+					"simple": runtime.NewString("value2"), // Should overwrite
+				},
 			)
 
 			actual, err := objects.MergeRecursive(context.Background(), obj1, obj2)
@@ -135,10 +159,14 @@ func TestMergeRecursive(t *testing.T) {
 			arr2 := runtime.NewArrayWith(runtime.NewInt(3), runtime.NewInt(4))
 
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("arr", arr1),
+				map[string]runtime.Value{
+					"arr": arr1,
+				},
 			)
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("arr", arr2),
+				map[string]runtime.Value{
+					"arr": arr2,
+				},
 			)
 
 			actual, err := objects.MergeRecursive(context.Background(), obj1, obj2)
@@ -161,37 +189,33 @@ func TestMergeRecursive(t *testing.T) {
 		Convey("When there are nested objects (example from ArangoDB doc)", func() {
 			// { "user-1": { "name": "Jane", "livesIn": { "city": "LA" } } }
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty(
-					"user-1", runtime.NewObjectWith(
-						runtime.NewObjectProperty(
-							"name", runtime.NewString("Jane"),
-						),
-						runtime.NewObjectProperty(
-							"livesIn", runtime.NewObjectWith(
-								runtime.NewObjectProperty(
-									"city", runtime.NewString("LA"),
-								),
+				map[string]runtime.Value{
+					"user-1": runtime.NewObjectWith(
+						map[string]runtime.Value{
+							"name": runtime.NewString("Jane"),
+							"livesIn": runtime.NewObjectWith(
+								map[string]runtime.Value{
+									"city": runtime.NewString("LA"),
+								},
 							),
-						),
+						},
 					),
-				),
+				},
 			)
 			// { "user-1": { "age": 42, "livesIn": { "state": "CA" } } }
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty(
-					"user-1", runtime.NewObjectWith(
-						runtime.NewObjectProperty(
-							"age", runtime.NewInt(42),
-						),
-						runtime.NewObjectProperty(
-							"livesIn", runtime.NewObjectWith(
-								runtime.NewObjectProperty(
-									"state", runtime.NewString("CA"),
-								),
+				map[string]runtime.Value{
+					"user-1": runtime.NewObjectWith(
+						map[string]runtime.Value{
+							"age": runtime.NewInt(42),
+							"livesIn": runtime.NewObjectWith(
+								map[string]runtime.Value{
+									"state": runtime.NewString("CA"),
+								},
 							),
-						),
+						},
 					),
-				),
+				},
 			)
 
 			actual, err := objects.MergeRecursive(context.Background(), obj1, obj2)
@@ -226,7 +250,10 @@ func TestMergeRecursive(t *testing.T) {
 	Convey("Merged object should be independent of source objects", t, func() {
 		Convey("When array", func() {
 			arr := runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2))
-			obj := runtime.NewObjectWith(runtime.NewObjectProperty("arr", arr))
+			obj := runtime.NewObjectWith(
+				map[string]runtime.Value{
+					"arr": arr,
+				})
 
 			actual, err := objects.MergeRecursive(context.Background(), obj)
 
@@ -245,9 +272,13 @@ func TestMergeRecursive(t *testing.T) {
 
 		Convey("When object", func() {
 			nested := runtime.NewObjectWith(
-				runtime.NewObjectProperty("nested", runtime.NewInt(0)),
-			)
-			obj := runtime.NewObjectWith(runtime.NewObjectProperty("obj", nested))
+				map[string]runtime.Value{
+					"nested": runtime.NewInt(0),
+				})
+			obj := runtime.NewObjectWith(
+				map[string]runtime.Value{
+					"obj": nested,
+				})
 
 			actual, err := objects.MergeRecursive(context.Background(), obj)
 

--- a/pkg/stdlib/objects/merge_test.go
+++ b/pkg/stdlib/objects/merge_test.go
@@ -40,17 +40,23 @@ func TestMerge(t *testing.T) {
 
 	Convey("Merged object should be independent of source objects", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		result := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1, obj2)
@@ -70,12 +76,16 @@ func TestMerge(t *testing.T) {
 func TestMergeObjects(t *testing.T) {
 	Convey("Merge single object", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 		result := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1)
@@ -86,17 +96,23 @@ func TestMergeObjects(t *testing.T) {
 
 	Convey("Merge two objects", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		result := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1, obj2)
@@ -107,17 +123,23 @@ func TestMergeObjects(t *testing.T) {
 
 	Convey("When keys are repeated", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(2)), // Same key, different value
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(2), // Same key, different value
+			},
 		)
 
 		// Later objects should overwrite earlier ones
 		result := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(2)), // Should be the value from obj2
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(2), // Should be the value from obj2
+				"prop2": runtime.NewString("str"),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1, obj2)
@@ -139,13 +161,21 @@ func TestMergeObjects(t *testing.T) {
 
 	Convey("Merge objects with complex values", t, func() {
 		arr := runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2))
-		nestedObj := runtime.NewObjectWith(runtime.NewObjectProperty("nested", runtime.NewString("value")))
+		nestedObj := runtime.NewObjectWith(
+			map[string]runtime.Value{
+				"nested": runtime.NewString("value"),
+			},
+		)
 
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("array", arr),
+			map[string]runtime.Value{
+				"array": arr,
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("object", nestedObj),
+			map[string]runtime.Value{
+				"object": nestedObj,
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1, obj2)
@@ -177,18 +207,24 @@ func TestMergeObjects(t *testing.T) {
 func TestMergeArray(t *testing.T) {
 	Convey("Merge array", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+			},
 		)
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		objArr := runtime.NewArrayWith(obj1, obj2)
 		result := runtime.NewObjectWith(
-			runtime.NewObjectProperty("prop1", runtime.NewInt(1)),
-			runtime.NewObjectProperty("prop2", runtime.NewString("str")),
-			runtime.NewObjectProperty("prop3", runtime.NewInt(3)),
+			map[string]runtime.Value{
+				"prop1": runtime.NewInt(1),
+				"prop2": runtime.NewString("str"),
+				"prop3": runtime.NewInt(3),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), objArr)
@@ -222,7 +258,9 @@ func TestMergeArray(t *testing.T) {
 	Convey("Merge with empty objects", t, func() {
 		obj1 := runtime.NewObject()
 		obj2 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("key", runtime.NewString("value")),
+			map[string]runtime.Value{
+				"key": runtime.NewString("value"),
+			},
 		)
 
 		merged, err := objects.Merge(context.Background(), obj1, obj2)
@@ -236,7 +274,9 @@ func TestMergeArray(t *testing.T) {
 
 	Convey("MergeRecursive with identical objects", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("key", runtime.NewString("value")),
+			map[string]runtime.Value{
+				"key": runtime.NewString("value"),
+			},
 		)
 
 		merged, err := objects.MergeRecursive(context.Background(), obj, obj)

--- a/pkg/stdlib/objects/values_test.go
+++ b/pkg/stdlib/objects/values_test.go
@@ -21,8 +21,10 @@ func TestValues(t *testing.T) {
 
 		Convey("When 2 arguments", func() {
 			obj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("k1", runtime.NewInt(0)),
-				runtime.NewObjectProperty("k2", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"k1": runtime.NewInt(0),
+					"k2": runtime.NewInt(1),
+				},
 			)
 
 			actual, err := objects.Values(context.Background(), obj, obj)
@@ -46,8 +48,10 @@ func TestValues(t *testing.T) {
 
 	Convey("When simple type attributes (same type)", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("k1", runtime.NewInt(0)),
-			runtime.NewObjectProperty("k2", runtime.NewInt(1)),
+			map[string]runtime.Value{
+				"k1": runtime.NewInt(0),
+				"k2": runtime.NewInt(1),
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -81,8 +85,10 @@ func TestValues(t *testing.T) {
 
 	Convey("When simple type attributes (different types)", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("k1", runtime.NewInt(0)),
-			runtime.NewObjectProperty("k2", runtime.NewString("v2")),
+			map[string]runtime.Value{
+				"k1": runtime.NewInt(0),
+				"k2": runtime.NewString("v2"),
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -121,8 +127,10 @@ func TestValues(t *testing.T) {
 			runtime.NewInt(2), runtime.NewInt(3),
 		)
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("k1", arr1),
-			runtime.NewObjectProperty("k2", arr2),
+			map[string]runtime.Value{
+				"k1": arr1,
+				"k2": arr2,
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -162,16 +170,20 @@ func TestValues(t *testing.T) {
 
 	Convey("When both type attributes", t, func() {
 		obj1 := runtime.NewObjectWith(
-			runtime.NewObjectProperty("k1", runtime.NewInt(0)),
+			map[string]runtime.Value{
+				"k1": runtime.NewInt(0),
+			},
 		)
 		arr1 := runtime.NewArrayWith(
 			runtime.NewInt(0), runtime.NewInt(1),
 		)
 		int1 := runtime.NewInt(0)
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("obj", obj1),
-			runtime.NewObjectProperty("arr", arr1),
-			runtime.NewObjectProperty("int", int1),
+			map[string]runtime.Value{
+				"obj": obj1,
+				"arr": arr1,
+				"int": int1,
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -206,7 +218,9 @@ func TestValues(t *testing.T) {
 	Convey("Result is independent on the source object (array)", t, func() {
 		arr := runtime.NewArrayWith(runtime.NewInt(0))
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("arr", arr),
+			map[string]runtime.Value{
+				"arr": arr,
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -231,10 +245,14 @@ func TestValues(t *testing.T) {
 
 	Convey("Result is independent on the source object (object)", t, func() {
 		nested := runtime.NewObjectWith(
-			runtime.NewObjectProperty("int", runtime.NewInt(0)),
+			map[string]runtime.Value{
+				"int": runtime.NewInt(0),
+			},
 		)
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("nested", nested),
+			map[string]runtime.Value{
+				"nested": nested,
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -270,9 +288,11 @@ func TestValues(t *testing.T) {
 
 	Convey("When object has nil values", t, func() {
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("none", runtime.None),
-			runtime.NewObjectProperty("bool", runtime.NewBoolean(false)),
-			runtime.NewObjectProperty("empty_string", runtime.NewString("")),
+			map[string]runtime.Value{
+				"none":         runtime.None,
+				"bool":         runtime.NewBoolean(false),
+				"empty_string": runtime.NewString(""),
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -307,15 +327,22 @@ func TestValues(t *testing.T) {
 
 	Convey("When object has deeply nested structures", t, func() {
 		deepObject := runtime.NewObjectWith(
-			runtime.NewObjectProperty("level1", runtime.NewObjectWith(
-				runtime.NewObjectProperty("level2", runtime.NewObjectWith(
-					runtime.NewObjectProperty("level3", runtime.NewString("deep")),
-				)),
-			)),
+			map[string]runtime.Value{
+				"level1": runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"level2": runtime.NewObjectWith(
+							map[string]runtime.Value{
+								"level3": runtime.NewString("deep"),
+							},
+						),
+					}),
+			},
 		)
 
 		obj := runtime.NewObjectWith(
-			runtime.NewObjectProperty("deep", deepObject),
+			map[string]runtime.Value{
+				"deep": deepObject,
+			},
 		)
 
 		actual, err := objects.Values(context.Background(), obj)
@@ -340,14 +367,20 @@ func TestValues(t *testing.T) {
 	Convey("Stress test", t, func() {
 		for i := 0; i < 100; i++ {
 			obj1 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("int0", runtime.NewInt(0)),
+				map[string]runtime.Value{
+					"int0": runtime.NewInt(0),
+				},
 			)
 			obj2 := runtime.NewObjectWith(
-				runtime.NewObjectProperty("int1", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"int1": runtime.NewInt(1),
+				},
 			)
 			obj := runtime.NewObjectWith(
-				runtime.NewObjectProperty("k1", obj1),
-				runtime.NewObjectProperty("k2", obj2),
+				map[string]runtime.Value{
+					"k1": obj1,
+					"k2": obj2,
+				},
 			)
 
 			actual, err := objects.Values(context.Background(), obj)

--- a/pkg/stdlib/objects/zip_test.go
+++ b/pkg/stdlib/objects/zip_test.go
@@ -94,7 +94,9 @@ func TestZip(t *testing.T) {
 			keys := runtime.NewArrayWith(runtime.NewString("k1"))
 			vals := runtime.NewArrayWith(runtime.NewInt(1))
 			expected := runtime.NewObjectWith(
-				runtime.NewObjectProperty("k1", runtime.NewInt(1)),
+				map[string]runtime.Value{
+					"k1": runtime.NewInt(1),
+				},
 			)
 
 			actual, err := objects.Zip(context.Background(), keys, vals)
@@ -113,8 +115,10 @@ func TestZip(t *testing.T) {
 				runtime.NewInt(2),
 			)
 			expected := runtime.NewObjectWith(
-				runtime.NewObjectProperty("k1", runtime.NewInt(1)),
-				runtime.NewObjectProperty("k2", runtime.NewInt(2)),
+				map[string]runtime.Value{
+					"k1": runtime.NewInt(1),
+					"k2": runtime.NewInt(2),
+				},
 			)
 
 			actual, err := objects.Zip(context.Background(), keys, vals)
@@ -135,8 +139,10 @@ func TestZip(t *testing.T) {
 				runtime.NewInt(3),
 			)
 			expected := runtime.NewObjectWith(
-				runtime.NewObjectProperty("a", runtime.NewInt(1)),
-				runtime.NewObjectProperty("b", runtime.NewInt(2)),
+				map[string]runtime.Value{
+					"a": runtime.NewInt(1),
+					"b": runtime.NewInt(2),
+				},
 			)
 
 			actual, err := objects.Zip(context.Background(), keys, vals)
@@ -152,7 +158,11 @@ func TestZip(t *testing.T) {
 			)
 			vals := runtime.NewArrayWith(
 				runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2)),
-				runtime.NewObjectWith(runtime.NewObjectProperty("nested", runtime.NewString("value"))),
+				runtime.NewObjectWith(
+					map[string]runtime.Value{
+						"nested": runtime.NewString("value"),
+					},
+				),
 			)
 
 			actual, err := objects.Zip(context.Background(), keys, vals)

--- a/pkg/stdlib/strings/fmt_test.go
+++ b/pkg/stdlib/strings/fmt_test.go
@@ -64,9 +64,9 @@ func TestFmt(t *testing.T) {
 			Format:   "{}",
 			Args: []runtime.Value{
 				runtime.NewObjectWith(
-					runtime.NewObjectProperty(
-						"key", runtime.NewString("value"),
-					),
+					map[string]runtime.Value{
+						"key": runtime.NewString("value"),
+					},
 				),
 			},
 		},
@@ -76,12 +76,10 @@ func TestFmt(t *testing.T) {
 			Format:   "{}",
 			Args: []runtime.Value{
 				runtime.NewObjectWith(
-					runtime.NewObjectProperty(
-						"key", runtime.NewString("value"),
-					),
-					runtime.NewObjectProperty(
-						"yek", runtime.NewString("eulav"),
-					),
+					map[string]runtime.Value{
+						"key": runtime.NewString("value"),
+						"yek": runtime.NewString("eulav"),
+					},
 				),
 			},
 		},

--- a/pkg/stdlib/testing/empty_test.go
+++ b/pkg/stdlib/testing/empty_test.go
@@ -85,9 +85,11 @@ func TestEmpty(t *t.T) {
 				_, err := Empty(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 				)
 
@@ -182,9 +184,11 @@ func TestNotEmpty(t *t.T) {
 				_, err := NotEmpty(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 				)
 

--- a/pkg/stdlib/testing/include_test.go
+++ b/pkg/stdlib/testing/include_test.go
@@ -79,9 +79,11 @@ func TestInclude(t *t.T) {
 				_, err := Include(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(4),
 				)
@@ -96,9 +98,11 @@ func TestInclude(t *t.T) {
 				_, err := Include(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(2),
 				)
@@ -176,9 +180,11 @@ func TestNotInclude(t *t.T) {
 				_, err := NotInclude(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(4),
 				)
@@ -192,9 +198,11 @@ func TestNotInclude(t *t.T) {
 				_, err := NotInclude(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(2),
 				)

--- a/pkg/stdlib/testing/len_test.go
+++ b/pkg/stdlib/testing/len_test.go
@@ -88,9 +88,11 @@ func TestLen(t *t.T) {
 				_, err := Len(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(1),
 				)
@@ -105,9 +107,11 @@ func TestLen(t *t.T) {
 				_, err := Len(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(3),
 				)
@@ -193,9 +197,11 @@ func TestNotLen(t *t.T) {
 				_, err := NotLen(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(1),
 				)
@@ -209,9 +215,11 @@ func TestNotLen(t *t.T) {
 				_, err := NotLen(
 					context.Background(),
 					runtime.NewObjectWith(
-						runtime.NewObjectProperty("a", runtime.NewInt(1)),
-						runtime.NewObjectProperty("b", runtime.NewInt(2)),
-						runtime.NewObjectProperty("c", runtime.NewInt(3)),
+						map[string]runtime.Value{
+							"a": runtime.NewInt(1),
+							"b": runtime.NewInt(2),
+							"c": runtime.NewInt(3),
+						},
 					),
 					runtime.NewInt(3),
 				)

--- a/pkg/stdlib/testing/object_test.go
+++ b/pkg/stdlib/testing/object_test.go
@@ -63,7 +63,9 @@ func TestObject(t *t.T) {
 		Convey("When arg is non-empty object", func() {
 			Convey("It should not return an error", func() {
 				_, err := Object(context.Background(), runtime.NewObjectWith(
-					runtime.NewObjectProperty("key", runtime.NewString("value")),
+					map[string]runtime.Value{
+						"key": runtime.NewString("value"),
+					},
 				))
 
 				So(err, ShouldBeNil)
@@ -96,7 +98,9 @@ func TestNotObject(t *t.T) {
 		Convey("When arg is non-empty object", func() {
 			Convey("It should return an error", func() {
 				_, err := NotObject(context.Background(), runtime.NewObjectWith(
-					runtime.NewObjectProperty("key", runtime.NewString("value")),
+					map[string]runtime.Value{
+						"key": runtime.NewString("value"),
+					},
 				))
 
 				So(err, ShouldBeError)

--- a/pkg/stdlib/utils/log.go
+++ b/pkg/stdlib/utils/log.go
@@ -25,7 +25,7 @@ func Print(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		}
 	}
 
-	logger := runtime.LoggerFromContext(ctx)
+	logger := runtime.GetLogger(ctx)
 	logger.Print(messages...)
 
 	return runtime.None, nil

--- a/pkg/vm/internal/data/collector_single_group_test.go
+++ b/pkg/vm/internal/data/collector_single_group_test.go
@@ -2,6 +2,8 @@ package data_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
@@ -136,16 +138,10 @@ func TestKeyCounterCollectorAllowsEmptyStringKey(t *testing.T) {
 		t.Fatalf("iterate: %v", err)
 	}
 
-	hasNext, err := iter.HasNext(ctx)
-	if err != nil {
-		t.Fatalf("has next: %v", err)
-	}
-
-	if !hasNext {
+	value, key, err := iter.Next(ctx)
+	if errors.Is(err, io.EOF) {
 		t.Fatal("expected one iterator item")
 	}
-
-	value, key, err := iter.Next(ctx)
 	if err != nil {
 		t.Fatalf("next: %v", err)
 	}

--- a/pkg/vm/internal/data/fast_object.go
+++ b/pkg/vm/internal/data/fast_object.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"hash/fnv"
+	"io"
 	"sort"
 
 	"github.com/wI2L/jettison"
@@ -845,13 +846,9 @@ type fastObjectIterator struct {
 	pos     int
 }
 
-func (iter *fastObjectIterator) HasNext(_ context.Context) (bool, error) {
-	return len(iter.entries) > iter.pos, nil
-}
-
 func (iter *fastObjectIterator) Next(_ context.Context) (runtime.Value, runtime.Value, error) {
 	if iter.pos >= len(iter.entries) {
-		return runtime.None, runtime.None, runtime.Error(runtime.ErrInvalidOperation, "no more elements")
+		return runtime.None, runtime.None, io.EOF
 	}
 
 	entry := iter.entries[iter.pos]
@@ -870,13 +867,9 @@ type fastObjectDictIterator struct {
 	pos  int
 }
 
-func (iter *fastObjectDictIterator) HasNext(_ context.Context) (bool, error) {
-	return len(iter.keys) > iter.pos, nil
-}
-
 func (iter *fastObjectDictIterator) Next(_ context.Context) (runtime.Value, runtime.Value, error) {
 	if iter.pos >= len(iter.keys) {
-		return runtime.None, runtime.None, runtime.Error(runtime.ErrInvalidOperation, "no more elements")
+		return runtime.None, runtime.None, io.EOF
 	}
 
 	key := iter.keys[iter.pos]

--- a/pkg/vm/internal/data/iterator.go
+++ b/pkg/vm/internal/data/iterator.go
@@ -19,10 +19,6 @@ func NewIterator(src runtime.Iterator) *Iterator {
 	return &Iterator{src, runtime.None, runtime.None}
 }
 
-func (it *Iterator) HasNext(ctx context.Context) (bool, error) {
-	return it.src.HasNext(ctx)
-}
-
 func (it *Iterator) Next(ctx context.Context) error {
 	val, key, err := it.src.Next(ctx)
 

--- a/pkg/vm/internal/data/kv_iter.go
+++ b/pkg/vm/internal/data/kv_iter.go
@@ -16,10 +16,6 @@ func NewKVIterator(source runtime.Iterator) runtime.Iterator {
 	}
 }
 
-func (iter *KVIterator) HasNext(ctx context.Context) (bool, error) {
-	return iter.source.HasNext(ctx)
-}
-
 func (iter *KVIterator) Next(ctx context.Context) (runtime.Value, runtime.Value, error) {
 	value, key, err := iter.source.Next(ctx)
 

--- a/pkg/vm/internal/data/noop_iter.go
+++ b/pkg/vm/internal/data/noop_iter.go
@@ -2,16 +2,13 @@ package data
 
 import (
 	"context"
+	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type noopIter struct{}
 
-func (n noopIter) HasNext(_ context.Context) (bool, error) {
-	return false, nil
-}
-
 func (n noopIter) Next(_ context.Context) (value runtime.Value, key runtime.Value, err error) {
-	return runtime.None, runtime.None, nil
+	return runtime.None, runtime.None, io.EOF
 }

--- a/pkg/vm/internal/data/range_iter.go
+++ b/pkg/vm/internal/data/range_iter.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
@@ -21,15 +22,15 @@ func NewRangeIterator(values *Range) runtime.Iterator {
 	return &RangeIterator{values: values, pos: values.start, counter: -1, descending: true}
 }
 
-func (iter *RangeIterator) HasNext(_ context.Context) (bool, error) {
-	if !iter.descending {
-		return iter.values.end >= iter.pos, nil
+func (iter *RangeIterator) Next(_ context.Context) (value runtime.Value, key runtime.Value, err error) {
+	if !iter.descending && iter.pos > iter.values.end {
+		return runtime.None, runtime.None, io.EOF
 	}
 
-	return iter.values.end <= iter.pos, nil
-}
+	if iter.descending && iter.pos < iter.values.end {
+		return runtime.None, runtime.None, io.EOF
+	}
 
-func (iter *RangeIterator) Next(_ context.Context) (value runtime.Value, key runtime.Value, err error) {
 	iter.counter++
 
 	if !iter.descending {

--- a/pkg/vm/internal/data/range_iter_test.go
+++ b/pkg/vm/internal/data/range_iter_test.go
@@ -2,6 +2,8 @@ package data_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
@@ -17,29 +19,20 @@ func TestRangeIterator(t *testing.T) {
 		r := data.NewRange(0, 0)
 		iter := data.NewRangeIterator(r)
 
-		hasNext, err := iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeTrue)
-
 		val, key, err := iter.Next(ctx)
 
 		So(err, ShouldBeNil)
 		So(val, ShouldEqual, runtime.NewInt(0))
 		So(key, ShouldEqual, runtime.NewInt(0))
 
-		hasNext, err = iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err = iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("Two values", t, func() {
 		ctx := context.Background()
 		r := data.NewRange(0, 1)
 		iter := data.NewRangeIterator(r)
-
-		hasNext, err := iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeTrue)
 
 		val, key, err := iter.Next(ctx)
 
@@ -53,19 +46,14 @@ func TestRangeIterator(t *testing.T) {
 		So(val, ShouldEqual, runtime.NewInt(1))
 		So(key, ShouldEqual, runtime.NewInt(1))
 
-		hasNext, err = iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err = iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("Two values (2)", t, func() {
 		ctx := context.Background()
 		r := data.NewRange(1, 2)
 		iter := data.NewRangeIterator(r)
-
-		hasNext, err := iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeTrue)
 
 		val, key, err := iter.Next(ctx)
 
@@ -79,9 +67,8 @@ func TestRangeIterator(t *testing.T) {
 		So(val, ShouldEqual, runtime.NewInt(2))
 		So(key, ShouldEqual, runtime.NewInt(1))
 
-		hasNext, err = iter.HasNext(ctx)
-		So(err, ShouldBeNil)
-		So(hasNext, ShouldBeFalse)
+		_, _, err = iter.Next(ctx)
+		So(errors.Is(err, io.EOF), ShouldBeTrue)
 	})
 
 	Convey("Multiple ascending values", t, func() {
@@ -92,12 +79,11 @@ func TestRangeIterator(t *testing.T) {
 		actual := make([]runtime.Int, 0, 10)
 
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			val, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-
-			val, _, err := iter.Next(ctx)
+			So(err, ShouldBeNil)
 			actual = append(actual, val.(runtime.Int))
 		}
 
@@ -112,12 +98,11 @@ func TestRangeIterator(t *testing.T) {
 		actual := make([]runtime.Int, 0, 10)
 
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			val, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-
-			val, _, err := iter.Next(ctx)
+			So(err, ShouldBeNil)
 			actual = append(actual, val.(runtime.Int))
 		}
 
@@ -129,17 +114,18 @@ func BenchmarkRangeIterator(b *testing.B) {
 	size := 100
 	ctx := context.Background()
 	r := data.NewRange(0, int64(size))
-	iter := data.NewRangeIterator(r)
-
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		iter := data.NewRangeIterator(r)
 		for {
-			hasNext, err := iter.HasNext(ctx)
-			if !hasNext || err != nil {
+			_, _, err := iter.Next(ctx)
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			iter.Next(ctx)
+			if err != nil {
+				break
+			}
 		}
 	}
 }

--- a/pkg/vm/op_exists_test.go
+++ b/pkg/vm/op_exists_test.go
@@ -66,7 +66,7 @@ func TestOpExists(t *testing.T) {
 		},
 		{
 			name: "non-empty object is true",
-			program: programWithConst(runtime.NewObjectWith(runtime.NewObjectProperty("a", runtime.NewInt(1))),
+			program: programWithConst(runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.NewInt(1)}),
 				bytecode.NewInstruction(bytecode.OpExists, bytecode.NewRegister(2), bytecode.NewRegister(1)),
 				bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(2)),
 			),

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
@@ -571,18 +572,12 @@ loop:
 			}
 		case bytecode.OpIterNext:
 			iterator := reg[src1].(*data.Iterator)
-			hasNext, err := iterator.HasNext(ctx)
-
-			if err != nil {
-				return nil, err
-			}
-
-			if hasNext {
-				if err := iterator.Next(ctx); err != nil {
+			if err := iterator.Next(ctx); err != nil {
+				if errors.Is(err, io.EOF) {
+					vm.pc = int(dst)
+				} else {
 					return nil, err
 				}
-			} else {
-				vm.pc = int(dst)
 			}
 		case bytecode.OpIterValue:
 			iterator := reg[src1].(*data.Iterator)

--- a/result.go
+++ b/result.go
@@ -12,7 +12,6 @@ type (
 	Result interface {
 		io.Closer
 
-		HasNext(ctx context.Context) (bool, error)
 		Next(ctx context.Context) (runtime.Value, error)
 	}
 
@@ -25,8 +24,6 @@ type (
 		value runtime.Iterable
 		iter  runtime.Iterator
 		err   error
-		peek  runtime.Value
-		has   bool
 		done  bool
 	}
 )
@@ -57,10 +54,6 @@ func (r *scalarResult) Close() error {
 	return closable.Close()
 }
 
-func (r *scalarResult) HasNext(_ context.Context) (bool, error) {
-	return !r.consumed, nil
-}
-
 func (r *scalarResult) Next(_ context.Context) (runtime.Value, error) {
 	if r.consumed {
 		return runtime.None, io.EOF
@@ -80,42 +73,6 @@ func (r *rowsResult) Close() error {
 	return closable.Close()
 }
 
-func (r *rowsResult) HasNext(ctx context.Context) (bool, error) {
-	if r.err != nil {
-		return false, r.err
-	}
-
-	if r.done {
-		return false, nil
-	}
-
-	if r.iter == nil {
-		r.iter, r.err = r.value.Iterate(ctx)
-
-		if r.err != nil {
-			return false, r.err
-		}
-	}
-
-	if r.has {
-		return true, nil
-	}
-
-	val, _, err := r.iter.Next(ctx)
-	if errors.Is(err, io.EOF) {
-		r.done = true
-		return false, nil
-	}
-	if err != nil {
-		r.err = err
-		return false, err
-	}
-
-	r.peek = val
-	r.has = true
-	return true, nil
-}
-
 func (r *rowsResult) Next(ctx context.Context) (runtime.Value, error) {
 	if r.err != nil {
 		return runtime.None, r.err
@@ -126,12 +83,10 @@ func (r *rowsResult) Next(ctx context.Context) (runtime.Value, error) {
 	}
 
 	if r.iter == nil {
-		return runtime.None, io.ErrUnexpectedEOF
-	}
-
-	if r.has {
-		r.has = false
-		return r.peek, nil
+		r.iter, r.err = r.value.Iterate(ctx)
+		if r.err != nil {
+			return runtime.None, r.err
+		}
 	}
 
 	val, _, err := r.iter.Next(ctx)

--- a/result.go
+++ b/result.go
@@ -2,6 +2,7 @@ package ferret
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -24,6 +25,9 @@ type (
 		value runtime.Iterable
 		iter  runtime.Iterator
 		err   error
+		peek  runtime.Value
+		has   bool
+		done  bool
 	}
 )
 
@@ -81,6 +85,10 @@ func (r *rowsResult) HasNext(ctx context.Context) (bool, error) {
 		return false, r.err
 	}
 
+	if r.done {
+		return false, nil
+	}
+
 	if r.iter == nil {
 		r.iter, r.err = r.value.Iterate(ctx)
 
@@ -89,7 +97,23 @@ func (r *rowsResult) HasNext(ctx context.Context) (bool, error) {
 		}
 	}
 
-	return r.iter.HasNext(ctx)
+	if r.has {
+		return true, nil
+	}
+
+	val, _, err := r.iter.Next(ctx)
+	if errors.Is(err, io.EOF) {
+		r.done = true
+		return false, nil
+	}
+	if err != nil {
+		r.err = err
+		return false, err
+	}
+
+	r.peek = val
+	r.has = true
+	return true, nil
 }
 
 func (r *rowsResult) Next(ctx context.Context) (runtime.Value, error) {
@@ -97,11 +121,25 @@ func (r *rowsResult) Next(ctx context.Context) (runtime.Value, error) {
 		return runtime.None, r.err
 	}
 
+	if r.done {
+		return runtime.None, io.EOF
+	}
+
 	if r.iter == nil {
 		return runtime.None, io.ErrUnexpectedEOF
 	}
 
+	if r.has {
+		r.has = false
+		return r.peek, nil
+	}
+
 	val, _, err := r.iter.Next(ctx)
+
+	if errors.Is(err, io.EOF) {
+		r.done = true
+		return runtime.None, io.EOF
+	}
 
 	if err != nil {
 		r.err = err


### PR DESCRIPTION
This pull request refactors the iterator interface and its usage throughout the codebase, removing the `HasNext` method in favor of using `Next` with `io.EOF` to signal the end of iteration. This approach simplifies iteration logic and aligns with common Go idioms. The changes also update all relevant helpers and tests to use the new pattern, and standardize object creation in tests.

Iterator refactor and usage updates:

* Removed the `HasNext` method from the `Iterator` interface and updated its documentation to require that `Next` returns `io.EOF` when exhausted. All iterator consumers (such as `ForEach`, `Collect`, `ToList`, `ToMap`, `ToFloat`, `ToInt`, `ToNumberOnly`, and decoding helpers) now use a `for` loop with `Next` and check for `io.EOF` to terminate iteration. (`[[1]](diffhunk://#diff-6a1ab6b40d26fe27670f9f3de7371fd0488358005ab59fb5fd911c7ddf26c9ffR16-L16)`, `[[2]](diffhunk://#diff-39d5a6b30be644e376c8fb8102f8e86f6c8255587f993e6d04966909b4144661L17-R20)`, `[[3]](diffhunk://#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9L17-L43)`, `[[4]](diffhunk://#diff-dff3b88feba71aef2bcd69ddaa8324f1c309e451372a309a62f86ddbd77ffce0L265-R273)`, `[[5]](diffhunk://#diff-dff3b88feba71aef2bcd69ddaa8324f1c309e451372a309a62f86ddbd77ffce0L302-R314)`, `[[6]](diffhunk://#diff-dff3b88feba71aef2bcd69ddaa8324f1c309e451372a309a62f86ddbd77ffce0L377-R394)`, `[[7]](diffhunk://#diff-dff3b88feba71aef2bcd69ddaa8324f1c309e451372a309a62f86ddbd77ffce0L450-R469)`, `[[8]](diffhunk://#diff-dff3b88feba71aef2bcd69ddaa8324f1c309e451372a309a62f86ddbd77ffce0L518-R542)`, `[[9]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL208-R214)`, `[[10]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL221)`, `[[11]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL243-R255)`, `[[12]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL260)`, `[[13]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL356-R366)`, `[[14]](diffhunk://#diff-b8bb7a1dfaf97d9bc5d4de23884639ff117cc5e68e7ad83f12e6f65cba47221cL373)`)

* Updated the `ArrayIterator` implementation to return `io.EOF` when iteration is complete, and removed the `HasNext` method. (`[pkg/runtime/array_iter.goL17-R20](diffhunk://#diff-39d5a6b30be644e376c8fb8102f8e86f6c8255587f993e6d04966909b4144661L17-R20)`)

Helper and API adjustments:

* Refactored helper functions like `ForEach`, `One`, and others in `helpers.go` to use the new iteration pattern, removing reliance on `HasNext`. (`[[1]](diffhunk://#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9L17-L43)`, `[[2]](diffhunk://#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9L61-R59)`)

Test updates and standardization:

* Updated all affected tests and benchmarks to use the new iteration pattern, checking for `io.EOF` from `Next` instead of calling `HasNext`. (`[[1]](diffhunk://#diff-e92de0129fd0e52c0554e9b14649bb8a22b941a04ac5d6bc25455ad411dfbba8L18-R21)`, `[[2]](diffhunk://#diff-e92de0129fd0e52c0554e9b14649bb8a22b941a04ac5d6bc25455ad411dfbba8L30-R37)`, `[[3]](diffhunk://#diff-e92de0129fd0e52c0554e9b14649bb8a22b941a04ac5d6bc25455ad411dfbba8L60-R57)`, `[[4]](diffhunk://#diff-e92de0129fd0e52c0554e9b14649bb8a22b941a04ac5d6bc25455ad411dfbba8L87-L92)`)

Object construction in tests:

* Standardized object construction in tests by replacing `NewObjectProperty` with map-based initialization for clarity and consistency. (`[[1]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL121-R133)`, `[[2]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL142-R155)`, `[[3]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL173-R183)`, `[[4]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL182-R194)`, `[[5]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL195-R216)`, `[[6]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL242-R258)`, `[[7]](diffhunk://#diff-02a1e88845424554b11c52e411ce7e61e20ca3434a68732eead4c15746a4414dL515-R533)`, `[[8]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L42-R45)`, `[[9]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L61-R70)`, `[[10]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L126-R139)`)

These changes collectively modernize and simplify the iteration logic across the codebase, reduce boilerplate, and improve test clarity.