### PR TITLE
refactor: reorganize error handling and diagnostics structure

### DIFF
--- a/pkg/vm/error_set.go
+++ b/pkg/vm/error_set.go
@@ -1,9 +1,9 @@
 package vm
 
-import "github.com/MontFerret/ferret/v2/pkg/diagnostics"
+import "github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostic"
 
-type RuntimeErrorSet = diagnostics.Diagnostics[*RuntimeError]
+type RuntimeErrorSet = diagnostic.RuntimeErrorSet
 
 func NewRuntimeErrorSet(size int) *RuntimeErrorSet {
-	return diagnostics.NewDiagnostics[*RuntimeError](size)
+	return diagnostic.NewRuntimeErrorSet(size)
 }

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -1,98 +1,28 @@
 package vm
 
 import (
-	"errors"
-	"strings"
-
-	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostic"
 )
 
 // RuntimeError represents a VM execution error with source context.
-type (
-	RuntimeError struct {
-		*diagnostics.Diagnostic
-	}
-
-	warmupError struct {
-		Err error
-		PC  int
-		Dst bytecode.Operand
-	}
-
-	warmupErrorSet struct {
-		Errors []*warmupError
-	}
-)
-
-func (e *warmupError) Error() string {
-	return e.Err.Error()
-}
-
-func (e *warmupError) Unwrap() error {
-	return e.Err
-}
-
-func (e *warmupErrorSet) Unwrap() error {
-	if len(e.Errors) == 0 {
-		return nil
-	}
-
-	var err error
-
-	for _, we := range e.Errors {
-		if err == nil {
-			err = we
-		} else {
-			err = errors.Join(err, we)
-		}
-	}
-
-	return err
-}
-
-func (e *warmupErrorSet) Error() string {
-	if len(e.Errors) == 0 {
-		return ""
-	}
-
-	var b strings.Builder
-
-	for _, we := range e.Errors {
-		b.WriteString(we.Error())
-		b.WriteString("\n")
-	}
-
-	return b.String()
-}
-
-func (e *warmupErrorSet) Add(err error, pc int, dst bytecode.Operand) {
-	e.Errors = append(e.Errors, &warmupError{
-		Err: err,
-		PC:  pc,
-		Dst: dst,
-	})
-}
-
-func (e *warmupErrorSet) Size() int {
-	return len(e.Errors)
-}
+type RuntimeError = diagnostic.RuntimeError
 
 const (
-	ArityError       diagnostics.Kind = "ArityError"
-	NullDereferenced diagnostics.Kind = "NullDereference"
-	DivideByZero     diagnostics.Kind = "DivideByZero"
-	ModuloByZero     diagnostics.Kind = "ModuloByZero"
-	AssertionFailed  diagnostics.Kind = "AssertionFailed"
-	UnresolvedSymbol diagnostics.Kind = "UnresolvedSymbol"
-	UncaughtError    diagnostics.Kind = "UncaughtError"
+	ArityError       diagnostics.Kind = diagnostic.ArityError
+	NullDereferenced diagnostics.Kind = diagnostic.NullDereferenced
+	DivideByZero     diagnostics.Kind = diagnostic.DivideByZero
+	ModuloByZero     diagnostics.Kind = diagnostic.ModuloByZero
+	AssertionFailed  diagnostics.Kind = diagnostic.AssertionFailed
+	UnresolvedSymbol diagnostics.Kind = diagnostic.UnresolvedSymbol
+	UncaughtError    diagnostics.Kind = diagnostic.UncaughtError
 )
 
 var (
-	ErrMissedParam           = errors.New("missed parameter")
-	ErrInsufficientRegisters = errors.New("insufficient registers")
-	ErrUnresolvedFunction    = errors.New("unresolved function")
-	ErrInvalidFunctionName   = errors.New("invalid function name")
-	ErrDivisionByZero        = errors.New("division by zero")
-	ErrModuloByZero          = errors.New("modulo by zero")
+	ErrMissedParam           = diagnostic.ErrMissedParam
+	ErrInsufficientRegisters = diagnostic.ErrInsufficientRegisters
+	ErrUnresolvedFunction    = diagnostic.ErrUnresolvedFunction
+	ErrInvalidFunctionName   = diagnostic.ErrInvalidFunctionName
+	ErrDivisionByZero        = diagnostic.ErrDivisionByZero
+	ErrModuloByZero          = diagnostic.ErrModuloByZero
 )

--- a/pkg/vm/internal/diagnostic/errors.go
+++ b/pkg/vm/internal/diagnostic/errors.go
@@ -1,0 +1,102 @@
+package diagnostic
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+)
+
+// RuntimeError represents a VM execution error with source context.
+type RuntimeError struct {
+	*diagnostics.Diagnostic
+}
+
+type WarmupError struct {
+	Err error
+	PC  int
+	Dst bytecode.Operand
+}
+
+type WarmupErrorSet struct {
+	Errors []*WarmupError
+}
+
+func (e *WarmupError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *WarmupError) Unwrap() error {
+	return e.Err
+}
+
+func (e *WarmupErrorSet) Unwrap() error {
+	if len(e.Errors) == 0 {
+		return nil
+	}
+
+	var err error
+
+	for _, we := range e.Errors {
+		if err == nil {
+			err = we
+		} else {
+			err = errors.Join(err, we)
+		}
+	}
+
+	return err
+}
+
+func (e *WarmupErrorSet) Error() string {
+	if len(e.Errors) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	for _, we := range e.Errors {
+		b.WriteString(we.Error())
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func (e *WarmupErrorSet) Add(err error, pc int, dst bytecode.Operand) {
+	e.Errors = append(e.Errors, &WarmupError{
+		Err: err,
+		PC:  pc,
+		Dst: dst,
+	})
+}
+
+func (e *WarmupErrorSet) Size() int {
+	return len(e.Errors)
+}
+
+type RuntimeErrorSet = diagnostics.Diagnostics[*RuntimeError]
+
+func NewRuntimeErrorSet(size int) *RuntimeErrorSet {
+	return diagnostics.NewDiagnostics[*RuntimeError](size)
+}
+
+const (
+	ArityError       diagnostics.Kind = "ArityError"
+	NullDereferenced diagnostics.Kind = "NullDereference"
+	DivideByZero     diagnostics.Kind = "DivideByZero"
+	ModuloByZero     diagnostics.Kind = "ModuloByZero"
+	AssertionFailed  diagnostics.Kind = "AssertionFailed"
+	UnresolvedSymbol diagnostics.Kind = "UnresolvedSymbol"
+	UncaughtError    diagnostics.Kind = "UncaughtError"
+)
+
+var (
+	ErrMissedParam           = errors.New("missed parameter")
+	ErrInsufficientRegisters = errors.New("insufficient registers")
+	ErrUnresolvedFunction    = errors.New("unresolved function")
+	ErrInvalidFunctionName   = errors.New("invalid function name")
+	ErrDivisionByZero        = errors.New("division by zero")
+	ErrModuloByZero          = errors.New("modulo by zero")
+)

--- a/pkg/vm/internal/diagnostic/member_access.go
+++ b/pkg/vm/internal/diagnostic/member_access.go
@@ -1,6 +1,10 @@
-package runtime
+package diagnostic
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
 
 type MemberAccessKind string
 
@@ -10,14 +14,14 @@ const (
 )
 
 type MemberAccessError struct {
-	Target Type
+	Target runtime.Type
 	Access MemberAccessKind
 	Member string
 }
 
-func MemberAccessErrorOf(target Value, access MemberAccessKind, member Value) error {
+func MemberAccessErrorOf(target runtime.Value, access MemberAccessKind, member runtime.Value) error {
 	return &MemberAccessError{
-		Target: TypeOf(target),
+		Target: runtime.TypeOf(target),
 		Access: access,
 		Member: memberAccessName(member),
 	}
@@ -51,7 +55,7 @@ func (e *MemberAccessError) Error() string {
 }
 
 func (e *MemberAccessError) Unwrap() error {
-	return ErrInvalidType
+	return runtime.ErrInvalidType
 }
 
 func (e *MemberAccessError) Label() string {
@@ -76,7 +80,7 @@ func (e *MemberAccessError) Hint() string {
 		return ""
 	}
 
-	if e.Target == TypeNone {
+	if e.Target == runtime.TypeNone {
 		return "Use optional chaining (?.) or check for None before accessing a member"
 	}
 
@@ -90,13 +94,13 @@ func (e *MemberAccessError) Hint() string {
 	}
 }
 
-func memberAccessName(member Value) string {
-	if member == nil || member == None {
+func memberAccessName(member runtime.Value) string {
+	if member == nil || member == runtime.None {
 		return ""
 	}
 
 	switch v := member.(type) {
-	case String:
+	case runtime.String:
 		return string(v)
 	default:
 		return v.String()

--- a/pkg/vm/internal/diagnostic/runtime_error.go
+++ b/pkg/vm/internal/diagnostic/runtime_error.go
@@ -1,7 +1,9 @@
-package vm
+package diagnostic
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
@@ -10,7 +12,75 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
-func toRuntimeError(program *bytecode.Program, pc int, err error) *RuntimeError {
+func WrapRuntimeError(program *bytecode.Program, pc int, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var runtimeError *RuntimeError
+
+	if errors.As(err, &runtimeError) {
+		return err
+	}
+
+	var wpErrorSet *WarmupErrorSet
+
+	if errors.As(err, &wpErrorSet) {
+		errs := NewRuntimeErrorSet(5)
+
+		for _, wer := range wpErrorSet.Errors {
+			// warmup PCs are zero-based instruction indices (no pre-increment),
+			// while ToRuntimeError expects a post-increment pc (see pc-1 usage)
+			errs.Add(ToRuntimeError(program, wer.PC+1, wer.Err))
+		}
+
+		return errs
+	}
+
+	return ToRuntimeError(program, pc, err)
+}
+
+func RuntimeErrorFromPanic(program *bytecode.Program, pc int, r any) error {
+	message := "unexpected runtime panic"
+	cause := fmt.Errorf("panic: %v", r)
+
+	if err, ok := r.(error); ok {
+		cause = err
+	}
+
+	return &RuntimeError{
+		Diagnostic: &diagnostics.Diagnostic{
+			Kind:    diagnostics.UnexpectedError,
+			Message: fmt.Sprintf("%s. %s", message, cause.Error()),
+			Source:  program.Source,
+			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(SpanAt(program, pc-1), "")},
+			Cause:   cause,
+		},
+	}
+}
+
+func NewRuntimeError(
+	program *bytecode.Program,
+	pc int,
+	kind diagnostics.Kind,
+	message string,
+	label string,
+	hint string,
+	note string,
+) *RuntimeError {
+	return &RuntimeError{
+		Diagnostic: &diagnostics.Diagnostic{
+			Kind:    kind,
+			Message: message,
+			Hint:    hint,
+			Note:    note,
+			Source:  program.Source,
+			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(SpanAt(program, pc-1), label)},
+		},
+	}
+}
+
+func ToRuntimeError(program *bytecode.Program, pc int, err error) *RuntimeError {
 	if err == nil {
 		return nil
 	}
@@ -27,7 +97,7 @@ func toRuntimeError(program *bytecode.Program, pc int, err error) *RuntimeError 
 	hint := ""
 	note := ""
 	var cause error
-	var memberErr *runtime.MemberAccessError
+	var memberErr *MemberAccessError
 
 	switch {
 	case errors.Is(err, ErrDivisionByZero):
@@ -127,13 +197,13 @@ func toRuntimeError(program *bytecode.Program, pc int, err error) *RuntimeError 
 			Hint:    hint,
 			Note:    note,
 			Source:  program.Source,
-			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(spanAt(program, pc-1), label)},
+			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(SpanAt(program, pc-1), label)},
 			Cause:   cause,
 		},
 	}
 }
 
-func spanAt(program *bytecode.Program, pc int) file.Span {
+func SpanAt(program *bytecode.Program, pc int) file.Span {
 	if program == nil {
 		return file.Span{Start: -1, End: -1}
 	}
@@ -143,4 +213,54 @@ func spanAt(program *bytecode.Program, pc int) file.Span {
 	}
 
 	return program.Metadata.DebugSpans[pc]
+}
+
+func CheckDivisionByZero(
+	ctx context.Context,
+	program *bytecode.Program,
+	pc int,
+	left runtime.Value,
+	right runtime.Value,
+) error {
+	l := runtime.ToNumberOnly(ctx, left)
+	if _, ok := l.(runtime.Int); !ok {
+		return nil
+	}
+
+	r := runtime.ToNumberOnly(ctx, right)
+	if rv, ok := r.(runtime.Int); ok && rv == 0 {
+		return NewRuntimeError(
+			program,
+			pc,
+			DivideByZero,
+			"Division by zero",
+			"attempt to divide by zero",
+			"Ensure the denominator is non-zero before division",
+			"Add a conditional check before dividing",
+		)
+	}
+
+	return nil
+}
+
+func CheckModuloByZero(
+	ctx context.Context,
+	program *bytecode.Program,
+	pc int,
+	right runtime.Value,
+) error {
+	rv, _ := runtime.ToInt(ctx, right)
+	if rv == 0 {
+		return NewRuntimeError(
+			program,
+			pc,
+			ModuloByZero,
+			"Modulo by zero",
+			"attempt to take modulo by zero",
+			"Ensure the divisor is non-zero before modulo",
+			"Add a conditional check before modulo",
+		)
+	}
+
+	return nil
 }

--- a/pkg/vm/vm_errors.go
+++ b/pkg/vm/vm_errors.go
@@ -2,104 +2,28 @@ package vm
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostic"
 )
 
 func (vm *VM) wrapRuntimeError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var runtimeError *RuntimeError
-
-	if errors.As(err, &runtimeError) {
-		return err
-	}
-
-	var wpErrorSet *warmupErrorSet
-
-	if errors.As(err, &wpErrorSet) {
-		errs := NewRuntimeErrorSet(5)
-
-		for _, wer := range wpErrorSet.Errors {
-			// warmup PCs are zero-based instruction indices (no pre-increment),
-			// while toRuntimeError expects a post-increment pc (see pc-1 usage)
-			errs.Add(toRuntimeError(vm.program, wer.PC+1, wer.Err))
-		}
-
-		return errs
-	}
-
-	return toRuntimeError(vm.program, vm.pc, err)
+	return diagnostic.WrapRuntimeError(vm.program, vm.pc, err)
 }
 
 func (vm *VM) runtimeErrorFromPanic(r any) error {
-	message := "unexpected runtime panic"
-	cause := fmt.Errorf("panic: %v", r)
-
-	if err, ok := r.(error); ok {
-		cause = err
-	}
-
-	return &RuntimeError{
-		Diagnostic: &diagnostics.Diagnostic{
-			Kind:    diagnostics.UnexpectedError,
-			Message: fmt.Sprintf("%s. %s", message, cause.Error()),
-			Source:  vm.program.Source,
-			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(spanAt(vm.program, vm.pc-1), "")},
-			Cause:   cause,
-		},
-	}
+	return diagnostic.RuntimeErrorFromPanic(vm.program, vm.pc, r)
 }
 
 func (vm *VM) newRuntimeError(kind diagnostics.Kind, message, label, hint, note string) *RuntimeError {
-	return &RuntimeError{
-		Diagnostic: &diagnostics.Diagnostic{
-			Kind:    kind,
-			Message: message,
-			Hint:    hint,
-			Note:    note,
-			Source:  vm.program.Source,
-			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(spanAt(vm.program, vm.pc-1), label)},
-		},
-	}
+	return diagnostic.NewRuntimeError(vm.program, vm.pc, kind, message, label, hint, note)
 }
 
 func (vm *VM) checkDivisionByZero(ctx context.Context, left, right runtime.Value) error {
-	l := runtime.ToNumberOnly(ctx, left)
-	if _, ok := l.(runtime.Int); !ok {
-		return nil
-	}
-
-	r := runtime.ToNumberOnly(ctx, right)
-	if rv, ok := r.(runtime.Int); ok && rv == 0 {
-		return vm.newRuntimeError(
-			DivideByZero,
-			"Division by zero",
-			"attempt to divide by zero",
-			"Ensure the denominator is non-zero before division",
-			"Add a conditional check before dividing",
-		)
-	}
-
-	return nil
+	return diagnostic.CheckDivisionByZero(ctx, vm.program, vm.pc, left, right)
 }
 
 func (vm *VM) checkModuloByZero(ctx context.Context, right runtime.Value) error {
-	rv, _ := runtime.ToInt(ctx, right)
-	if rv == 0 {
-		return vm.newRuntimeError(
-			ModuloByZero,
-			"Modulo by zero",
-			"attempt to take modulo by zero",
-			"Ensure the divisor is non-zero before modulo",
-			"Add a conditional check before modulo",
-		)
-	}
-
-	return nil
+	return diagnostic.CheckModuloByZero(ctx, vm.program, vm.pc, right)
 }

--- a/pkg/vm/vm_helpers.go
+++ b/pkg/vm/vm_helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostic"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
@@ -454,7 +455,7 @@ func (vm *VM) loadIndex(ctx context.Context, src, arg runtime.Value) (runtime.Va
 	indexed, ok := src.(runtime.IndexReadable)
 
 	if !ok {
-		return nil, runtime.MemberAccessErrorOf(src, runtime.MemberAccessIndex, arg)
+		return nil, diagnostic.MemberAccessErrorOf(src, diagnostic.MemberAccessIndex, arg)
 	}
 
 	var idx runtime.Int
@@ -481,7 +482,7 @@ func (vm *VM) loadKey(ctx context.Context, src, arg runtime.Value) (runtime.Valu
 	keyed, ok := src.(runtime.KeyReadable)
 
 	if !ok {
-		return nil, runtime.MemberAccessErrorOf(src, runtime.MemberAccessProperty, arg)
+		return nil, diagnostic.MemberAccessErrorOf(src, diagnostic.MemberAccessProperty, arg)
 	}
 
 	out, err := keyed.Get(ctx, arg)

--- a/pkg/vm/vm_warmup.go
+++ b/pkg/vm/vm_warmup.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/data"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostic"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
@@ -16,7 +17,7 @@ func (vm *VM) warmup(env *Environment) error {
 		return nil
 	}
 
-	errors := &warmupErrorSet{}
+	errors := &diagnostic.WarmupErrorSet{}
 	constants := vm.program.Constants
 	functions := env.Functions
 	reg := map[bytecode.Operand]runtime.Value{}
@@ -183,7 +184,7 @@ func resolveFnAndCache[T runtime.FunctionConstraint](
 	fallback runtime.FunctionCollection[runtime.Function],
 	assign func(*mem.CachedFunction, T),
 	funcs map[int]*mem.CachedFunction,
-	errList *warmupErrorSet,
+	errList *diagnostic.WarmupErrorSet,
 ) {
 	fnName, err := resolveFnName(reg, dst)
 


### PR DESCRIPTION
This pull request refactors and centralizes the handling of VM runtime errors by moving error types and related logic into a new `diagnostic` internal package. The refactor improves code organization, encapsulates error management, and makes error handling more maintainable and consistent across the codebase. The most significant changes are the relocation and consolidation of error types, error set management, and error-handling utilities.

**Error handling refactor and centralization:**

* Introduced a new internal package `pkg/vm/internal/diagnostic` to encapsulate VM runtime error types (`RuntimeError`, `WarmupError`, `WarmupErrorSet`, `RuntimeErrorSet`) and error-handling functions (`WrapRuntimeError`, `RuntimeErrorFromPanic`, `NewRuntimeError`, `ToRuntimeError`, `CheckDivisionByZero`, `CheckModuloByZero`, etc.), moving these from `pkg/vm` and related files. [[1]](diffhunk://#diff-fcc3f566dd9566654f87e867dfaaff7559a6c38c9f9f508ab761723bfe34b681R1-R102) [[2]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L1-R6) [[3]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L13-R83) [[4]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L30-R100) [[5]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L130-R206) [[6]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402R217-R266) [[7]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L1-R7) [[8]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L13-R24) [[9]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L54-R58) [[10]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L79-R83) [[11]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L93-R103)

* Updated all references in the VM to use the new `diagnostic` package for error creation, wrapping, and checking, including in `vm_errors.go`, `vm_helpers.go`, and `vm_warmup.go`. [[1]](diffhunk://#diff-bcecfcfe8b5952aa19a1a078f72cbf5ad3b0122af3deb63516e7950fc3bdf8baL5-R28) [[2]](diffhunk://#diff-f0aa84675898001782c0e1adeed69d0acd360504d5e43b42cc0f21360f146a32R10) [[3]](diffhunk://#diff-f0aa84675898001782c0e1adeed69d0acd360504d5e43b42cc0f21360f146a32L457-R458) [[4]](diffhunk://#diff-f0aa84675898001782c0e1adeed69d0acd360504d5e43b42cc0f21360f146a32L484-R485) [[5]](diffhunk://#diff-2117aa3f8578bd0ccfef933550feb2f4fc69f602ce555585b63b27daeec4593eR7) [[6]](diffhunk://#diff-2117aa3f8578bd0ccfef933550feb2f4fc69f602ce555585b63b27daeec4593eL19-R20) [[7]](diffhunk://#diff-2117aa3f8578bd0ccfef933550feb2f4fc69f602ce555585b63b27daeec4593eL186-R187)

**Code cleanup and simplification:**

* Removed duplicated error logic and types from `pkg/vm/errors.go` and `pkg/vm/error_set.go`, replacing them with aliases or calls to the new `diagnostic` package. [[1]](diffhunk://#diff-d70d95416ed92039898cf19c6d66745b62c3cf6aab6c7c88a5ffb1007028d9b8L3-R8) [[2]](diffhunk://#diff-e5d687241576487092b1ef2f304ce6d342abb2457169055500b145b7b0076aadL4-R27)

* Renamed and updated files to reflect the new structure (e.g., `error_member_access.go` → `internal/diagnostic/member_access.go`, `error_handler.go` → `internal/diagnostic/runtime_error.go`). [[1]](diffhunk://#diff-e120f9922385899809b141a22839962bd3e8e6f399f7cf469da7a650060ea2c8L1-R7) [[2]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L1-R6)

**Improvements to error context and reporting:**

* Enhanced error reporting by ensuring all error creation and wrapping functions in the VM now consistently include program source, PC, and context-specific hints and notes. [[1]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L13-R83) [[2]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L130-R206) [[3]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402R217-R266)

Overall, this refactor improves maintainability, readability, and consistency of error handling in the VM by centralizing related logic and types. [[1]](diffhunk://#diff-fcc3f566dd9566654f87e867dfaaff7559a6c38c9f9f508ab761723bfe34b681R1-R102) [[2]](diffhunk://#diff-904f63533e546842d20512b4213ef0fe3b3cb3b74d5b0286e0715e97bd696402L1-R6) [[3]](diffhunk://#diff-bcecfcfe8b5952aa19a1a078f72cbf5ad3b0122af3deb63516e7950fc3bdf8baL5-R28)