### PR TITLE
refactor: update linting configuration and improve error handling in …

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 # This file contains all available configuration options
 # with their default values.
+version: 2
 
 # options for analysis running
 run:
@@ -16,6 +17,17 @@ run:
 linters:
   disable:
     - errcheck
+    - unused
+
+linters-settings:
+  staticcheck:
+    checks:
+      - all
+      - -U1000
+      - -ST1000
+      - -ST1001
+      - -ST1020
+      - -ST1022
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.
@@ -25,6 +37,14 @@ issues:
   exclude:
     - '^(G104|G401|G505|G501):'
     - '^shadow: declaration of'
+    - '^ST1000:'
+    - '^ST1001:'
+    - '^ST1020:'
+    - 'should not use dot imports'
+  exclude-rules:
+    - text: "ST1001: should not use dot imports"
+      linters:
+        - staticcheck
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,5 @@ fmt:
 # https://github.com/mgechev/revive
 # go get github.com/mgechev/revive
 lint:
-	echo 'staticcheck -tests=false $$(go list ./pkg/... | grep -v /fql)' && \
-	echo 'revive -config revive.toml -formatter stylish -exclude ./pkg/parser/fql/... -exclude ./vendor/... -exclude ./*_test.go ./...'
+	staticcheck -tests=false -checks=all,-U1000,-ST1000,-ST1001,-ST1020,-ST1022 $$(go list ./pkg/... | grep -v /fql) && \
+	revive -config revive.toml -formatter stylish -exclude ./pkg/parser/fql/... -exclude ./vendor/... -exclude ./*_test.go ./...

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -74,11 +74,12 @@ func (c *ExprCompiler) CompileIncDec(token antlr.Token, target bytecode.Operand)
 
 	operator := token.GetText()
 
-	if operator == "++" {
+	switch operator {
+	case "++":
 		c.ctx.Emitter.EmitA(bytecode.OpIncr, target)
-	} else if operator == "--" {
+	case "--":
 		c.ctx.Emitter.EmitA(bytecode.OpDecr, target)
-	} else {
+	default:
 		c.ctx.Errors.InvalidToken(token)
 
 		return bytecode.NoopOperand

--- a/pkg/compiler/internal/optimization/analysis.go
+++ b/pkg/compiler/internal/optimization/analysis.go
@@ -242,17 +242,17 @@ func (cfg *ControlFlowGraph) ToDOT() string {
 	// Write nodes
 	for _, block := range cfg.Blocks {
 		if block == cfg.Exit {
-			sb.WriteString(fmt.Sprintf("  block%d [label=\"Exit\", shape=ellipse];\n", block.ID))
+			fmt.Fprintf(&sb, "  block%d [label=\"Exit\", shape=ellipse];\n", block.ID)
 		} else {
 			label := fmt.Sprintf("Block %d\\n[%d:%d]", block.ID, block.Start, block.End)
-			sb.WriteString(fmt.Sprintf("  block%d [label=\"%s\"];\n", block.ID, label))
+			fmt.Fprintf(&sb, "  block%d [label=\"%s\"];\n", block.ID, label)
 		}
 	}
 
 	// Write edges
 	for _, block := range cfg.Blocks {
 		for _, succ := range block.Successors {
-			sb.WriteString(fmt.Sprintf("  block%d -> block%d;\n", block.ID, succ.ID))
+			fmt.Fprintf(&sb, "  block%d -> block%d;\n", block.ID, succ.ID)
 		}
 	}
 
@@ -266,9 +266,9 @@ func (cfg *ControlFlowGraph) String() string {
 	var sb strings.Builder
 
 	sb.WriteString("Control Flow Graph:\n")
-	sb.WriteString(fmt.Sprintf("  Entry: Block %d\n", cfg.Entry.ID))
-	sb.WriteString(fmt.Sprintf("  Exit: Block %d\n", cfg.Exit.ID))
-	sb.WriteString(fmt.Sprintf("  Blocks: %d\n\n", len(cfg.Blocks)))
+	fmt.Fprintf(&sb, "  Entry: Block %d\n", cfg.Entry.ID)
+	fmt.Fprintf(&sb, "  Exit: Block %d\n", cfg.Exit.ID)
+	fmt.Fprintf(&sb, "  Blocks: %d\n\n", len(cfg.Blocks))
 
 	for _, block := range cfg.Blocks {
 		if block != cfg.Exit {

--- a/pkg/compiler/internal/optimization/cfg.go
+++ b/pkg/compiler/internal/optimization/cfg.go
@@ -91,19 +91,19 @@ func (bb *BasicBlock) IsTerminator() bool {
 func (bb *BasicBlock) String() string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("Block %d [%d:%d]:\n", bb.ID, bb.Start, bb.End))
+	fmt.Fprintf(&sb, "Block %d [%d:%d]:\n", bb.ID, bb.Start, bb.End)
 
 	for i, inst := range bb.Instructions {
-		sb.WriteString(fmt.Sprintf("  %d: %s", bb.Start+i, inst.Opcode.String()))
+		fmt.Fprintf(&sb, "  %d: %s", bb.Start+i, inst.Opcode.String())
 
 		if inst.Operands[0] != 0 || inst.Operands[1] != 0 || inst.Operands[2] != 0 {
-			sb.WriteString(fmt.Sprintf(" %d", inst.Operands[0]))
+			fmt.Fprintf(&sb, " %d", inst.Operands[0])
 
 			if inst.Operands[1] != 0 || inst.Operands[2] != 0 {
-				sb.WriteString(fmt.Sprintf(" %d", inst.Operands[1]))
+				fmt.Fprintf(&sb, " %d", inst.Operands[1])
 
 				if inst.Operands[2] != 0 {
-					sb.WriteString(fmt.Sprintf(" %d", inst.Operands[2]))
+					fmt.Fprintf(&sb, " %d", inst.Operands[2])
 				}
 			}
 		}
@@ -118,7 +118,7 @@ func (bb *BasicBlock) String() string {
 			sb.WriteString(", ")
 		}
 
-		sb.WriteString(fmt.Sprintf("%d", succ.ID))
+		fmt.Fprintf(&sb, "%d", succ.ID)
 	}
 
 	sb.WriteString("\n")

--- a/pkg/compiler/internal/wait.go
+++ b/pkg/compiler/internal/wait.go
@@ -760,7 +760,7 @@ func parseDurationLiteral(text string) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	multiplier := float64(1)
+	var multiplier float64
 	switch unit {
 	case "MS":
 		multiplier = 1

--- a/pkg/file/source_test.go
+++ b/pkg/file/source_test.go
@@ -57,7 +57,7 @@ func TestSourceName(t *testing.T) {
 		})
 
 		Convey("Should return empty string for nil source", func() {
-			var source *Source = nil
+			var source *Source
 
 			So(source.Name(), ShouldEqual, "")
 		})
@@ -79,7 +79,7 @@ func TestSourceEmpty(t *testing.T) {
 		})
 
 		Convey("Should return true for nil source", func() {
-			var source *Source = nil
+			var source *Source
 
 			So(source.Empty(), ShouldBeTrue)
 		})
@@ -167,7 +167,7 @@ func TestSourceLocationAt(t *testing.T) {
 			})
 
 			Convey("Should handle nil source", func() {
-				var nilSource *Source = nil
+				var nilSource *Source
 				line, col := nilSource.LocationAt(Span{Start: 0, End: 1})
 				So(line, ShouldEqual, 0)
 				So(col, ShouldEqual, 0)
@@ -241,7 +241,7 @@ func TestSourceSnippet(t *testing.T) {
 		})
 
 		Convey("Nil source", func() {
-			var source *Source = nil
+			var source *Source
 			span := Span{Start: 0, End: 1}
 
 			snippets := source.Snippet(span)

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -73,9 +73,5 @@ func (fmt *Formatter) Format(out io.Writer, src *file.Source) error {
 		return errorHandler.Unwrap()
 	}
 
-	if err := l.Err(); err != nil {
-		return err
-	}
-
-	return nil
+	return l.Err()
 }

--- a/pkg/parser/diagnostics/match_error_array_ops.go
+++ b/pkg/parser/diagnostics/match_error_array_ops.go
@@ -33,7 +33,7 @@ func matchArrayOperatorErrors(src *file.Source, err *diagnostics.Diagnostic, off
 }
 
 func matchQueryOperatorErrors(src *file.Source, err *diagnostics.Diagnostic, offending *TokenNode) bool {
-	if !(isMismatched(err.Message) || isMissing(err.Message) || isNoAlternative(err.Message)) {
+	if !isMismatched(err.Message) && !isMissing(err.Message) && !isNoAlternative(err.Message) {
 		return false
 	}
 
@@ -165,7 +165,7 @@ func matchArrayInlineReturnErrors(src *file.Source, err *diagnostics.Diagnostic,
 }
 
 func matchArrayQuestionQuantifierErrors(src *file.Source, err *diagnostics.Diagnostic, offending *TokenNode) bool {
-	if !(isMismatched(err.Message) || isMissing(err.Message) || isNoAlternative(err.Message)) {
+	if !isMismatched(err.Message) && !isMissing(err.Message) && !isNoAlternative(err.Message) {
 		return false
 	}
 
@@ -197,7 +197,7 @@ func matchArrayQuestionQuantifierErrors(src *file.Source, err *diagnostics.Diagn
 }
 
 func matchArrayOperatorUnclosed(src *file.Source, err *diagnostics.Diagnostic, offending *TokenNode) bool {
-	if !(isMismatched(err.Message) || isMissing(err.Message) || isNoAlternative(err.Message)) {
+	if !isMismatched(err.Message) && !isMissing(err.Message) && !isNoAlternative(err.Message) {
 		return false
 	}
 

--- a/pkg/parser/diagnostics/match_error_waitfor.go
+++ b/pkg/parser/diagnostics/match_error_waitfor.go
@@ -40,11 +40,12 @@ func matchWaitForErrors(src *file.Source, err *diagnostics.Diagnostic, offending
 	if clause, spanNode := waitForMissingClauseValue(offending); clause != "" {
 		span := spanFromTokenSafe(spanNode.Token(), src)
 		err.Message = fmt.Sprintf("Expected value after '%s' in WAITFOR clause", clause)
-		if clause == "BACKOFF" {
+		switch clause {
+		case "BACKOFF":
 			err.Hint = "Provide a backoff strategy, e.g. BACKOFF LINEAR."
-		} else if clause == "JITTER" {
+		case "JITTER":
 			err.Hint = "Provide a jitter value between 0 and 1, e.g. JITTER 0.2."
-		} else {
+		default:
 			err.Hint = fmt.Sprintf("Provide a duration, e.g. %s 100ms.", clause)
 		}
 		err.Spans = []diagnostics.ErrorSpan{

--- a/pkg/runtime/boolean.go
+++ b/pkg/runtime/boolean.go
@@ -77,9 +77,9 @@ func (t Boolean) String() string {
 func (t Boolean) Hash() uint64 {
 	if t {
 		return hashTrue
-	} else {
-		return hashFalse
 	}
+
+	return hashFalse
 }
 
 func (t Boolean) Copy() Value {

--- a/pkg/runtime/date_time.go
+++ b/pkg/runtime/date_time.go
@@ -72,7 +72,7 @@ func (dt DateTime) Hash() uint64 {
 	h.Write([]byte(TypeDateTime))
 	h.Write([]byte(":"))
 
-	bytes, err := dt.Time.GobEncode()
+	bytes, err := dt.GobEncode()
 
 	if err != nil {
 		return 0

--- a/pkg/runtime/encode_test.go
+++ b/pkg/runtime/encode_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -160,7 +161,7 @@ func TestEncodeByKey(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			Convey(tc.Name, t, func() {
-				actual, err := runtime.EncodeField(t.Context(), tc.Input, runtime.String(tc.Field))
+				actual, err := runtime.EncodeField(context.Background(), tc.Input, runtime.String(tc.Field))
 
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, tc.Expected)
@@ -175,7 +176,7 @@ func TestEncodeByKey(t *testing.T) {
 				privateStrProp: "hello world",
 			}
 
-			res, err := runtime.EncodeField(nil, sv, runtime.String("privateStrProp"))
+			res, err := runtime.EncodeField(context.TODO(), sv, runtime.String("privateStrProp"))
 
 			So(res, ShouldEqual, runtime.None)
 			So(err, ShouldBeNil)
@@ -185,7 +186,7 @@ func TestEncodeByKey(t *testing.T) {
 			sv := SomeValue{
 				privateStrProp: "hello world",
 			}
-			actual, err := runtime.EncodeField(nil, sv, runtime.String("UntaggedProp"))
+			actual, err := runtime.EncodeField(context.TODO(), sv, runtime.String("UntaggedProp"))
 
 			So(err, ShouldBeNil)
 			So(actual, ShouldEqual, runtime.None)

--- a/pkg/runtime/helpers_test.go
+++ b/pkg/runtime/helpers_test.go
@@ -211,6 +211,7 @@ func TestHelpers(t *testing.T) {
 				So(output, ShouldEqual, runtime.NewFloat(100.1))
 
 				output2, err := runtime.ToFloat(ctx, runtime.NewString("foobar"))
+				So(err, ShouldNotBeNil)
 				So(output2, ShouldEqual, runtime.ZeroFloat)
 			})
 
@@ -240,7 +241,7 @@ func TestHelpers(t *testing.T) {
 
 			Convey("Should convert DateTime", func() {
 				dt := runtime.NewCurrentDateTime()
-				ts := dt.Time.Unix()
+				ts := dt.Unix()
 
 				out, err := runtime.ToFloat(ctx, dt)
 				So(err, ShouldBeNil)
@@ -316,7 +317,7 @@ func TestHelpers(t *testing.T) {
 
 			Convey("Should convert DateTime", func() {
 				dt := runtime.NewCurrentDateTime()
-				ts := dt.Time.Unix()
+				ts := dt.Unix()
 				out, err := runtime.ToInt(ctx, dt)
 
 				So(err, ShouldBeNil)

--- a/pkg/stdlib/io/fs/util_test.go
+++ b/pkg/stdlib/io/fs/util_test.go
@@ -1,14 +1,13 @@
 package fs_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func tempFile() (*os.File, func()) {
-	file, err := ioutil.TempFile("", "fstest")
+	file, err := os.CreateTemp("", "fstest")
 	So(err, ShouldBeNil)
 
 	fn := func() {

--- a/pkg/stdlib/io/fs/write_test.go
+++ b/pkg/stdlib/io/fs/write_test.go
@@ -154,7 +154,7 @@ func TestWrite(t *testing.T) {
 				},
 			)
 
-			for _ = range [2]struct{}{} {
+			for range [2]struct{}{} {
 				// at first iteration check that `Write` creates file and writes `data`.
 				// At second iteration check that `Write` truncates the file and
 				// writes `data` again

--- a/pkg/stdlib/math/exp2_test.go
+++ b/pkg/stdlib/math/exp2_test.go
@@ -17,7 +17,7 @@ func TestExp2(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(out, ShouldEqual, 65536)
 
-		out, err = math.Exp(context.Background(), runtime.NewFloat(1))
+		_, err = math.Exp(context.Background(), runtime.NewFloat(1))
 
 		So(err, ShouldBeNil)
 		//So(out.Compare(runtime.NewFloat(2)) == 1, ShouldBeTrue)

--- a/pkg/stdlib/math/exp_test.go
+++ b/pkg/stdlib/math/exp_test.go
@@ -17,7 +17,7 @@ func TestExp(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(out, ShouldEqual, 2.718281828459045)
 
-		out, err = math.Exp(context.Background(), runtime.NewFloat(10))
+		_, err = math.Exp(context.Background(), runtime.NewFloat(10))
 
 		So(err, ShouldBeNil)
 		//So(out.Compare(runtime.NewFloat(22026.46579480671)) == 1, ShouldBeTrue)

--- a/pkg/stdlib/math/percentile_test.go
+++ b/pkg/stdlib/math/percentile_test.go
@@ -72,7 +72,7 @@ func TestPercentile(t *testing.T) {
 		So(runtime.Unwrap(runtime.IsNaN(out.(runtime.Float))), ShouldBeTrue)
 
 		// Invalid percentile (outside range)
-		out, err = math.Percentile(
+		_, err = math.Percentile(
 			context.Background(),
 			runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2)),
 			runtime.NewInt(0),

--- a/pkg/vm/internal/data/fast_object.go
+++ b/pkg/vm/internal/data/fast_object.go
@@ -57,7 +57,7 @@ func NewShapeCache(limit int) *ShapeCache {
 	return cache
 }
 
-func (c *ShapeCache) Root() *fastShape {
+func (c *ShapeCache) Root() *Shape {
 	if c == nil {
 		return nil
 	}
@@ -65,7 +65,7 @@ func (c *ShapeCache) Root() *fastShape {
 	return c.root
 }
 
-func (c *ShapeCache) Transition(shape *fastShape, key string) *fastShape {
+func (c *ShapeCache) Transition(shape *Shape, key string) *Shape {
 	if c == nil || shape == nil {
 		return nil
 	}

--- a/pkg/vm/internal/data/range.go
+++ b/pkg/vm/internal/data/range.go
@@ -93,11 +93,13 @@ func (r *Range) Compare(_ context.Context, other runtime.Value) (int64, error) {
 
 	if r.start == otherRange.start && r.end == otherRange.end {
 		return 0, nil
-	} else if r.start < otherRange.start || r.end < otherRange.end {
-		return -1, nil
-	} else {
-		return 1, nil
 	}
+
+	if r.start < otherRange.start || r.end < otherRange.end {
+		return -1, nil
+	}
+
+	return 1, nil
 }
 
 func (r *Range) calculateCapacity(start int64, end int64) int64 {

--- a/pkg/vm/validation.go
+++ b/pkg/vm/validation.go
@@ -8,11 +8,7 @@ import (
 )
 
 func validate(env *Environment, program *bytecode.Program) error {
-	if err := validateParams(env, program); err != nil {
-		return err
-	}
-
-	return nil
+	return validateParams(env, program)
 }
 
 func validateParams(env *Environment, program *bytecode.Program) error {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -510,9 +510,9 @@ loop:
 			if err := ds.Append(ctx, reg[src1]); err != nil {
 				if _, catch := vm.tryCatch(vm.pc); catch {
 					continue
-				} else {
-					return nil, err
 				}
+
+				return nil, err
 			}
 		case bytecode.OpArrayPush:
 			ds := reg[dst].(*runtime.Array)
@@ -610,9 +610,9 @@ loop:
 			if err != nil {
 				if _, catch := vm.tryCatch(vm.pc); catch {
 					continue
-				} else {
-					return nil, err
 				}
+
+				return nil, err
 			}
 
 			stream, err := observable.Subscribe(ctx, runtime.Subscription{
@@ -623,9 +623,9 @@ loop:
 			if err != nil {
 				if _, catch := vm.tryCatch(vm.pc); catch {
 					continue
-				} else {
-					return nil, err
 				}
+
+				return nil, err
 			}
 
 			reg[dst] = data.NewStreamValue(stream)
@@ -640,9 +640,9 @@ loop:
 				if err != nil {
 					if _, catch := vm.tryCatch(vm.pc); catch {
 						continue
-					} else {
-						return nil, err
 					}
+
+					return nil, err
 				}
 
 				timeout = t
@@ -678,9 +678,9 @@ loop:
 			if err != nil {
 				if _, catch := vm.tryCatch(vm.pc); catch {
 					continue
-				} else {
-					return nil, err
 				}
+
+				return nil, err
 			}
 
 			if err := data.Sleep(ctx, dur); err != nil {

--- a/pkg/vm/vm_helpers.go
+++ b/pkg/vm/vm_helpers.go
@@ -214,20 +214,12 @@ func (vm *VM) applyQuery(ctx context.Context, reg []runtime.Value, src1 bytecode
 	queryable, ok := src.(runtime.Queryable)
 
 	if !ok {
-		if err := vm.setOrTryCatch(dst, runtime.None, runtime.TypeErrorOf(src, runtime.TypeQueryable)); err != nil {
-			return err
-		}
-
-		return nil
+		return vm.setOrTryCatch(dst, runtime.None, runtime.TypeErrorOf(src, runtime.TypeQueryable))
 	}
 
 	res, err := queryable.Query(ctx, query)
 
-	if err := vm.setOrTryCatch(dst, res, err); err != nil {
-		return err
-	}
-
-	return nil
+	return vm.setOrTryCatch(dst, res, err)
 }
 
 func (vm *VM) regexpCached(pc int, value runtime.Value) (*data.Regexp, error) {

--- a/revive.toml
+++ b/revive.toml
@@ -5,15 +5,10 @@ errorCode = 1
 warningCode = 0
 
 [rule.blank-imports]
-[rule.context-as-argument]
-[rule.context-keys-type]
-[rule.dot-imports]
 [rule.error-return]
 [rule.error-strings]
 [rule.error-naming]
 [rule.if-return]
-[rule.increment-decrement]
-[rule.var-naming]
 [rule.var-declaration]
 [rule.range]
 [rule.receiver-naming]
@@ -23,6 +18,4 @@ warningCode = 0
 [rule.errorf]
 [rule.empty-block]
 [rule.superfluous-else]
-[rule.unused-parameter]
 [rule.unreachable-code]
-[rule.redefines-builtin-id]

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -294,7 +294,6 @@ func main() {
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, os.Kill)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/test/integration/base/assertions.go
+++ b/test/integration/base/assertions.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 
-	. "github.com/smartystreets/goconvey/convey"
+	convey "github.com/smartystreets/goconvey/convey"
 )
 
 type (
@@ -47,7 +47,7 @@ func ShouldHaveSameItems(actual any, expected ...any) string {
 	expectedArr := wapper[0].([]any)
 
 	for _, item := range expectedArr {
-		if err := ShouldContain(actual, item); err != "" {
+		if err := convey.ShouldContain(actual, item); err != "" {
 			return err
 		}
 	}
@@ -133,7 +133,6 @@ func ShouldBeCompilationError(actual any, expected ...any) string {
 			fmt.Println(err.Format())
 		}
 
-		break
 	case *ExpectedMultiError:
 		err, ok := actual.(*diagnostics.DiagnosticSet)
 

--- a/test/integration/base/exec.go
+++ b/test/integration/base/exec.go
@@ -11,6 +11,10 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
+type contextKey string
+
+const testSaltKey contextKey = "test-salt"
+
 func Compile(expression string) (*bytecode.Program, error) {
 	c := compiler.New(compiler.WithOptimizationLevel(compiler.O0))
 
@@ -23,7 +27,7 @@ func Run(p *bytecode.Program, opts ...vm.EnvironmentOption) ([]byte, error) {
 
 	type Salt struct{}
 
-	out, err := instance.Run(context.WithValue(context.Background(), "test-salt", &Salt{}), env)
+	out, err := instance.Run(context.WithValue(context.Background(), testSaltKey, &Salt{}), env)
 
 	if err != nil {
 		return nil, err

--- a/test/integration/base/setup.go
+++ b/test/integration/base/setup.go
@@ -36,7 +36,7 @@ func RunBenchmarkWith(b *testing.B, c *compiler.Compiler, expression string, opt
 
 	b.ResetTimer()
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		_, err := instance.Run(ctx, env)
 
 		if err != nil {

--- a/test/integration/base/test_case.go
+++ b/test/integration/base/test_case.go
@@ -3,25 +3,25 @@ package base
 import (
 	"strings"
 
-	. "github.com/smartystreets/goconvey/convey"
+	convey "github.com/smartystreets/goconvey/convey"
 )
 
 type TestCase struct {
 	Expression   string
 	Expected     any
-	PreAssertion Assertion
-	Assertions   []Assertion
+	PreAssertion convey.Assertion
+	Assertions   []convey.Assertion
 	Description  string
 	Skip         bool
 	RawOutput    bool
 	DebugOutput  bool
 }
 
-func NewCase(expression string, expected any, assertion Assertion, desc ...string) TestCase {
+func NewCase(expression string, expected any, assertion convey.Assertion, desc ...string) TestCase {
 	return TestCase{
 		Expression:  expression,
 		Expected:    expected,
-		Assertions:  []Assertion{assertion},
+		Assertions:  []convey.Assertion{assertion},
 		Description: strings.TrimSpace(strings.Join(desc, " ")),
 	}
 }
@@ -43,8 +43,8 @@ func (tc TestCase) String() string {
 	}
 
 	exp := strings.TrimSpace(tc.Expression)
-	exp = strings.Replace(exp, "\n", " ", -1)
-	exp = strings.Replace(exp, "\t", " ", -1)
+	exp = strings.ReplaceAll(exp, "\n", " ")
+	exp = strings.ReplaceAll(exp, "\t", " ")
 	// Replace multiple spaces with a single space
 	exp = strings.Join(strings.Fields(exp), " ")
 

--- a/test/integration/compiler/test_case.go
+++ b/test/integration/compiler/test_case.go
@@ -74,8 +74,8 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase) {
 			name = strings.TrimSpace(useCase.Expression)
 		}
 
-		name = strings.Replace(name, "\n", " ", -1)
-		name = strings.Replace(name, "\t", " ", -1)
+		name = strings.ReplaceAll(name, "\n", " ")
+		name = strings.ReplaceAll(name, "\t", " ")
 		// Replace multiple spaces with a single space
 		name = strings.Join(strings.Fields(name), " ")
 		skip := useCase.Skip

--- a/test/integration/optimization/assertions.go
+++ b/test/integration/optimization/assertions.go
@@ -59,8 +59,6 @@ func ShouldCheckOpcode(a any, e ...any) string {
 	default:
 		panic(fmt.Sprintf("unsupported opcode expectation type: %T", e[0]))
 	}
-
-	return ""
 }
 
 func shouldCheckOpcodeCount(actual *bytecode.Program, expected OpcodeCount) string {

--- a/test/integration/optimization/test_case.go
+++ b/test/integration/optimization/test_case.go
@@ -127,8 +127,8 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase) {
 			name = strings.TrimSpace(useCase.Expression)
 		}
 
-		name = strings.Replace(name, "\n", " ", -1)
-		name = strings.Replace(name, "\t", " ", -1)
+		name = strings.ReplaceAll(name, "\n", " ")
+		name = strings.ReplaceAll(name, "\t", " ")
 		// Replace multiple spaces with a single space
 		name = strings.Join(strings.Fields(name), " ")
 		skip := useCase.Skip

--- a/test/integration/vm/test_case.go
+++ b/test/integration/vm/test_case.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/MontFerret/ferret/v2/test/integration/base"
 
-	. "github.com/smartystreets/goconvey/convey"
+	convey "github.com/smartystreets/goconvey/convey"
 
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
 	"github.com/MontFerret/ferret/v2/pkg/vm"
 )
 
 func Case(expression string, expected any, desc ...string) UseCase {
-	return NewCase(expression, expected, ShouldEqual, desc...)
+	return NewCase(expression, expected, convey.ShouldEqual, desc...)
 }
 
 func DebugCase(expression string, expected any, desc ...string) UseCase {
@@ -29,7 +29,7 @@ func SkipCase(expression string, expected any, desc ...string) UseCase {
 }
 
 func CaseNil(expression string, desc ...string) UseCase {
-	return NewCase(expression, nil, ShouldBeNil, desc...)
+	return NewCase(expression, nil, convey.ShouldBeNil, desc...)
 }
 
 func SkipCaseNil(expression string, desc ...string) UseCase {
@@ -41,7 +41,7 @@ func DebugCaseNil(expression string, desc ...string) UseCase {
 }
 
 func CaseRuntimeError(expression string, desc ...string) UseCase {
-	return NewCase(expression, nil, ShouldBeError, desc...)
+	return NewCase(expression, nil, convey.ShouldBeError, desc...)
 }
 
 func CaseRuntimeErrorAs(expression string, expected error, desc ...string) UseCase {
@@ -73,7 +73,7 @@ func SkipCaseCompilationError(expression string, desc ...string) UseCase {
 }
 
 func CaseObject(expression string, expected map[string]any, desc ...string) UseCase {
-	uc := NewCase(expression, expected, ShouldEqualJSON, desc...)
+	uc := NewCase(expression, expected, convey.ShouldEqualJSON, desc...)
 	uc.RawOutput = true
 	return uc
 }
@@ -87,7 +87,7 @@ func DebugCaseObject(expression string, expected map[string]any, desc ...string)
 }
 
 func CaseArray(expression string, expected []any, desc ...string) UseCase {
-	uc := NewCase(expression, expected, ShouldEqualJSON, desc...)
+	uc := NewCase(expression, expected, convey.ShouldEqualJSON, desc...)
 	uc.RawOutput = true
 	return uc
 }
@@ -125,7 +125,7 @@ func DebugCaseItems(expression string, expected ...any) UseCase {
 }
 
 func CaseJSON(expression string, expected string, desc ...string) UseCase {
-	uc := NewCase(expression, expected, ShouldEqualJSON, desc...)
+	uc := NewCase(expression, expected, convey.ShouldEqualJSON, desc...)
 	uc.RawOutput = true
 	return uc
 }
@@ -153,7 +153,7 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase, opt
 				return
 			}
 
-			Convey(useCase.Expression, t, func() {
+			convey.Convey(useCase.Expression, t, func() {
 				prog, err := c.Compile(file.NewSource(name, useCase.Expression))
 
 				defer func() {
@@ -171,9 +171,9 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase, opt
 						}
 					}
 
-					So(err, ShouldBeNil)
+					convey.So(err, convey.ShouldBeNil)
 				} else {
-					So(err, ShouldBeError)
+					convey.So(err, convey.ShouldBeError)
 
 					return
 				}
@@ -192,12 +192,12 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase, opt
 
 				for _, assertion := range useCase.Assertions {
 					if base.ArePtrsEqual(assertion, ShouldBeRuntimeError) {
-						So(err, ShouldBeRuntimeError, expected)
+						convey.So(err, ShouldBeRuntimeError, expected)
 
 						return
 					}
 
-					if base.ArePtrsEqual(assertion, ShouldBeError) {
+					if base.ArePtrsEqual(assertion, convey.ShouldBeError) {
 						frmt, ok := err.(diagnostics.Formattable)
 
 						if ok {
@@ -205,32 +205,32 @@ func RunUseCasesWith(t *testing.T, c *compiler.Compiler, useCases []UseCase, opt
 						}
 
 						if expected != nil {
-							So(err, ShouldBeError, expected)
+							convey.So(err, convey.ShouldBeError, expected)
 						} else {
-							So(err, ShouldBeError)
+							convey.So(err, convey.ShouldBeError)
 						}
 
 						return
 					}
 
-					So(err, ShouldBeNil)
+					convey.So(err, convey.ShouldBeNil)
 
-					if base.ArePtrsEqual(assertion, ShouldEqualJSON) {
+					if base.ArePtrsEqual(assertion, convey.ShouldEqualJSON) {
 						expectedJ, err := j.Marshal(expected)
-						So(err, ShouldBeNil)
-						So(actual, ShouldEqualJSON, string(expectedJ))
+						convey.So(err, convey.ShouldBeNil)
+						convey.So(actual, convey.ShouldEqualJSON, string(expectedJ))
 					} else if base.ArePtrsEqual(assertion, base.ShouldHaveSameItems) {
-						So(actual, base.ShouldHaveSameItems, expected)
-					} else if base.ArePtrsEqual(assertion, ShouldBeNil) {
-						So(actual, ShouldBeNil)
+						convey.So(actual, base.ShouldHaveSameItems, expected)
+					} else if base.ArePtrsEqual(assertion, convey.ShouldBeNil) {
+						convey.So(actual, convey.ShouldBeNil)
 					} else {
-						So(actual, assertion, expected)
+						convey.So(actual, assertion, expected)
 					}
 				}
 
 				// If no assertions are provided, we check the expected value directly
 				if len(useCase.Assertions) == 0 {
-					So(actual, ShouldEqual, expected)
+					convey.So(actual, convey.ShouldEqual, expected)
 				}
 
 				if useCase.DebugOutput {


### PR DESCRIPTION
This pull request includes a mix of configuration, code quality, and code cleanup improvements, along with minor bug fixes and test updates. The main themes are improvements to linter configuration, code simplification and modernization, and minor refactors for clarity and correctness.

**Linter and Code Quality Improvements:**

* Updated `.golangci.yml` to enable versioning, disable the `unused` linter, and fine-tune `staticcheck` checks and issue exclusions for a more streamlined linting process. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R3) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R20-R30) [[3]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R40-R47)
* Updated the `lint` target in the `Makefile` to run `staticcheck` with the new configuration, disabling selected checks, and to run `revive` as before.

**Code Simplification and Refactoring:**

* Refactored code to use `fmt.Fprintf` with a `strings.Builder` instead of `fmt.Sprintf` + `sb.WriteString` in several places (`pkg/compiler/internal/optimization/analysis.go`, `pkg/compiler/internal/optimization/cfg.go`), resulting in more efficient and idiomatic string building. [[1]](diffhunk://#diff-a716166deed648af03c7bc5fb38fedcc4c3590a6d6856058960a4e1f8f1bd174L245-R255) [[2]](diffhunk://#diff-a716166deed648af03c7bc5fb38fedcc4c3590a6d6856058960a4e1f8f1bd174L269-R271) [[3]](diffhunk://#diff-7e9844c10786efc8f8ccd73b0f84720452f2de34130c8b5a16f8e6a230a9b88aL94-R106) [[4]](diffhunk://#diff-7e9844c10786efc8f8ccd73b0f84720452f2de34130c8b5a16f8e6a230a9b88aL121-R121)
* Replaced `else if`/`else` chains with `switch` statements for improved readability in operator handling and error hinting (`pkg/compiler/internal/expr.go`, `pkg/parser/diagnostics/match_error_waitfor.go`). [[1]](diffhunk://#diff-8933509822f2c1ec39a80f83a73147f9723915a2f9d1b86ffde9f0f65212cfa4L77-R82) [[2]](diffhunk://#diff-146e542db43a377c0b40906449f87a598ec5541806e741df3bea8fa30c9deff8L43-R48)
* Simplified boolean logic in `match_error_array_ops.go` by replacing grouped OR conditions with explicit ANDs for clarity. [[1]](diffhunk://#diff-ed76f09199fec1dd143a169451929dc8592c141496ff1188867c3062cbb20c0aL36-R36) [[2]](diffhunk://#diff-ed76f09199fec1dd143a169451929dc8592c141496ff1188867c3062cbb20c0aL168-R168) [[3]](diffhunk://#diff-ed76f09199fec1dd143a169451929dc8592c141496ff1188867c3062cbb20c0aL200-R200)

**Test and Code Modernization:**

* Updated tests to use `context.Background()` or `context.TODO()` instead of `nil` for context parameters, and modernized temporary file creation to use `os.CreateTemp` instead of deprecated `ioutil.TempFile`. [[1]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9R4) [[2]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L163-R164) [[3]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L178-R179) [[4]](diffhunk://#diff-aaf5efb0d050ab429c93cf31d0d5a4929ed1240db154f6b840f5b9e588d8c2f9L188-R189) [[5]](diffhunk://#diff-7b16312ff490054004f3487765d998616744f6bff80150e7012c5d65bcff06d0L4-R10)
* Cleaned up test code by removing redundant variable initializations and updating test assertions for error handling. [[1]](diffhunk://#diff-1f65a056145bde65d0b2f12a3c57a82cee33769510762f5b885a485b89ec6ac6L60-R60) [[2]](diffhunk://#diff-1f65a056145bde65d0b2f12a3c57a82cee33769510762f5b885a485b89ec6ac6L82-R82) [[3]](diffhunk://#diff-1f65a056145bde65d0b2f12a3c57a82cee33769510762f5b885a485b89ec6ac6L170-R170) [[4]](diffhunk://#diff-1f65a056145bde65d0b2f12a3c57a82cee33769510762f5b885a485b89ec6ac6L244-R244) [[5]](diffhunk://#diff-bac0b9be846790ce6de240716a3e5020740a59fade116d4747b6c8d2402eac6eR214) [[6]](diffhunk://#diff-bac0b9be846790ce6de240716a3e5020740a59fade116d4747b6c8d2402eac6eL243-R244) [[7]](diffhunk://#diff-bac0b9be846790ce6de240716a3e5020740a59fade116d4747b6c8d2402eac6eL319-R320) [[8]](diffhunk://#diff-f1837df226c7ab2e67ee0dd6da3ec69f907fd4697fce1e48fd2f1fa6950a661cL157-R157) [[9]](diffhunk://#diff-814af7a13cdd495ddfc3bb33e22b128ac070f3528ef2e4c74afeeb97193085f9L20-R20) [[10]](diffhunk://#diff-f897e15c4896506efee6158a082286a4d3f7190a8c1240b8a780f556c1c383cbL20-R20) [[11]](diffhunk://#diff-e4c04608f685d2ba1b6ae794d6965aa912d9fdc2fe620b7831cdd84d283bfd38L75-R75)

**Minor Bug Fixes and Cleanups:**

* Fixed a logic bug in `parseDurationLiteral` by initializing the `multiplier` variable correctly.
* Fixed method calls to use the correct receiver (`dt.GobEncode()` and `dt.Unix()`) for `DateTime` in runtime and tests. [[1]](diffhunk://#diff-81d31fb43943f0baa2bd7cd79f09e55b9158e887a48743de60763ba652b37729L75-R75) [[2]](diffhunk://#diff-bac0b9be846790ce6de240716a3e5020740a59fade116d4747b6c8d2402eac6eL243-R244) [[3]](diffhunk://#diff-bac0b9be846790ce6de240716a3e5020740a59fade116d4747b6c8d2402eac6eL319-R320)
* Simplified return logic in `Boolean.Hash()` and `Formatter.Format()`. [[1]](diffhunk://#diff-3eb4830c00ee0829a2516242a20cc1f4dc70e1d1e6a9679d0305e344facd4d0dL80-R82) [[2]](diffhunk://#diff-746cf5aeda505013e7d37a612d3c373ed2135cbd6a56334675089b8145fcf340L76-R76)

**Internal API Adjustments:**

* Changed the return types of `ShapeCache.Root()` and `ShapeCache.Transition()` to use the exported `Shape` type instead of the unexported `fastShape`.…code