### PR TITLE
Program serialization 

### DIFF
--- a/pkg/bytecode/aggregate_plan.go
+++ b/pkg/bytecode/aggregate_plan.go
@@ -15,9 +15,9 @@ const (
 )
 
 type AggregatePlan struct {
-	Keys  []runtime.String
-	Kinds []AggregateKind
-	Index map[string]int
+	Keys  []runtime.String `json:"keys"`
+	Kinds []AggregateKind  `json:"kinds"`
+	Index map[string]int   `json:"index"`
 }
 
 func NewAggregatePlan(keys []runtime.String, kinds []AggregateKind) AggregatePlan {

--- a/pkg/bytecode/encoding.go
+++ b/pkg/bytecode/encoding.go
@@ -24,7 +24,7 @@ type (
 		Registers  int            `json:"registers"`
 		Bytecode   []Instruction  `json:"bytecode"`
 		Constants  []constantJSON `json:"constants,omitempty"`
-		CatchTable []Catch        `json:"catch_table,omitempty"`
+		CatchTable []Catch        `json:"catchTable,omitempty"`
 		Params     []string       `json:"params,omitempty"`
 		Metadata   Metadata       `json:"metadata"`
 	}
@@ -34,67 +34,6 @@ type (
 		Value stdjson.RawMessage `json:"value,omitempty"`
 	}
 )
-
-func (p *Program) MarshalJSON() ([]byte, error) {
-	if p == nil {
-		return []byte("null"), nil
-	}
-
-	constants := make([]constantJSON, len(p.Constants))
-
-	for i, value := range p.Constants {
-		encoded, err := encodeConstant(value)
-
-		if err != nil {
-			return nil, fmt.Errorf("bytecode.Program: encode constant %d: %w", i, err)
-		}
-
-		constants[i] = encoded
-	}
-
-	payload := programJSON{
-		Source:     p.Source,
-		Registers:  p.Registers,
-		Bytecode:   p.Bytecode,
-		Constants:  constants,
-		CatchTable: p.CatchTable,
-		Params:     p.Params,
-		Metadata:   p.Metadata,
-	}
-
-	return json.Marshal(payload)
-}
-
-func (p *Program) UnmarshalJSON(data []byte) error {
-	if p == nil {
-		return fmt.Errorf("bytecode.Program: UnmarshalJSON on nil pointer")
-	}
-
-	var decoded programJSON
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
-	}
-
-	constants := make([]runtime.Value, len(decoded.Constants))
-	for i, value := range decoded.Constants {
-		decodedValue, err := decodeConstant(value)
-		if err != nil {
-			return fmt.Errorf("bytecode.Program: decode constant %d: %w", i, err)
-		}
-
-		constants[i] = decodedValue
-	}
-
-	p.Source = decoded.Source
-	p.Registers = decoded.Registers
-	p.Bytecode = decoded.Bytecode
-	p.Constants = constants
-	p.CatchTable = decoded.CatchTable
-	p.Params = decoded.Params
-	p.Metadata = decoded.Metadata
-
-	return nil
-}
 
 func encodeConstant(value runtime.Value) (constantJSON, error) {
 	if value == nil || value == runtime.None {

--- a/pkg/bytecode/instruction.go
+++ b/pkg/bytecode/instruction.go
@@ -1,8 +1,8 @@
 package bytecode
 
 type Instruction struct {
-	Opcode   Opcode
-	Operands [3]Operand
+	Opcode   Opcode     `json:"opcode"`
+	Operands [3]Operand `json:"operands"`
 }
 
 func NewInstruction(opcode Opcode, operands ...Operand) Instruction {

--- a/pkg/bytecode/program.go
+++ b/pkg/bytecode/program.go
@@ -9,10 +9,10 @@ type (
 	Catch [3]int
 
 	Metadata struct {
-		AggregatePlans []AggregatePlan
-		DebugSpans     []file.Span
-		Functions      map[string]int
-		Labels         map[int]string
+		AggregatePlans []AggregatePlan `json:"aggregatePlans"`
+		DebugSpans     []file.Span     `json:"debugSpans"`
+		Functions      map[string]int  `json:"functions"`
+		Labels         map[int]string  `json:"labels"`
 	}
 
 	Program struct {

--- a/pkg/bytecode/program.go
+++ b/pkg/bytecode/program.go
@@ -1,6 +1,10 @@
 package bytecode
 
 import (
+	"fmt"
+
+	"github.com/goccy/go-json"
+
 	"github.com/MontFerret/ferret/v2/pkg/file"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
@@ -25,3 +29,66 @@ type (
 		Metadata   Metadata
 	}
 )
+
+func (p *Program) MarshalJSON() ([]byte, error) {
+	if p == nil {
+		return []byte("null"), nil
+	}
+
+	constants := make([]constantJSON, len(p.Constants))
+
+	for i, value := range p.Constants {
+		encoded, err := encodeConstant(value)
+
+		if err != nil {
+			return nil, fmt.Errorf("bytecode.Program: encode constant %d: %w", i, err)
+		}
+
+		constants[i] = encoded
+	}
+
+	payload := programJSON{
+		Source:     p.Source,
+		Registers:  p.Registers,
+		Bytecode:   p.Bytecode,
+		Constants:  constants,
+		CatchTable: p.CatchTable,
+		Params:     p.Params,
+		Metadata:   p.Metadata,
+	}
+
+	return json.Marshal(payload)
+}
+
+func (p *Program) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return fmt.Errorf("bytecode.Program: UnmarshalJSON on nil pointer")
+	}
+
+	var decoded programJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	constants := make([]runtime.Value, len(decoded.Constants))
+
+	for i, value := range decoded.Constants {
+		decodedValue, err := decodeConstant(value)
+
+		if err != nil {
+			return fmt.Errorf("bytecode.Program: decode constant %d: %w", i, err)
+		}
+
+		constants[i] = decodedValue
+	}
+
+	p.Source = decoded.Source
+	p.Registers = decoded.Registers
+	p.Bytecode = decoded.Bytecode
+	p.Constants = constants
+	p.CatchTable = decoded.CatchTable
+	p.Params = decoded.Params
+	p.Metadata = decoded.Metadata
+
+	return nil
+}

--- a/pkg/bytecode/program_json.go
+++ b/pkg/bytecode/program_json.go
@@ -1,0 +1,259 @@
+package bytecode
+
+import (
+	"encoding/base64"
+	stdjson "encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+const (
+	aggregateKeyMarkerType = runtime.Type("agg_key_marker")
+)
+
+type (
+	programJSON struct {
+		Source     *file.Source   `json:"source,omitempty"`
+		Registers  int            `json:"registers"`
+		Bytecode   []Instruction  `json:"bytecode"`
+		Constants  []constantJSON `json:"constants,omitempty"`
+		CatchTable []Catch        `json:"catch_table,omitempty"`
+		Params     []string       `json:"params,omitempty"`
+		Metadata   Metadata       `json:"metadata"`
+	}
+
+	constantJSON struct {
+		Type  string             `json:"type"`
+		Value stdjson.RawMessage `json:"value,omitempty"`
+	}
+)
+
+func (p *Program) MarshalJSON() ([]byte, error) {
+	if p == nil {
+		return []byte("null"), nil
+	}
+
+	constants := make([]constantJSON, len(p.Constants))
+
+	for i, value := range p.Constants {
+		encoded, err := encodeConstant(value)
+
+		if err != nil {
+			return nil, fmt.Errorf("bytecode.Program: encode constant %d: %w", i, err)
+		}
+
+		constants[i] = encoded
+	}
+
+	payload := programJSON{
+		Source:     p.Source,
+		Registers:  p.Registers,
+		Bytecode:   p.Bytecode,
+		Constants:  constants,
+		CatchTable: p.CatchTable,
+		Params:     p.Params,
+		Metadata:   p.Metadata,
+	}
+
+	return json.Marshal(payload)
+}
+
+func (p *Program) UnmarshalJSON(data []byte) error {
+	if p == nil {
+		return fmt.Errorf("bytecode.Program: UnmarshalJSON on nil pointer")
+	}
+
+	var decoded programJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	constants := make([]runtime.Value, len(decoded.Constants))
+	for i, value := range decoded.Constants {
+		decodedValue, err := decodeConstant(value)
+		if err != nil {
+			return fmt.Errorf("bytecode.Program: decode constant %d: %w", i, err)
+		}
+
+		constants[i] = decodedValue
+	}
+
+	p.Source = decoded.Source
+	p.Registers = decoded.Registers
+	p.Bytecode = decoded.Bytecode
+	p.Constants = constants
+	p.CatchTable = decoded.CatchTable
+	p.Params = decoded.Params
+	p.Metadata = decoded.Metadata
+
+	return nil
+}
+
+func encodeConstant(value runtime.Value) (constantJSON, error) {
+	if value == nil || value == runtime.None {
+		return constantJSON{Type: encodeConstantType(runtime.TypeNone)}, nil
+	}
+
+	if value == AggregateKeyMarker {
+		return constantJSON{Type: encodeConstantType(aggregateKeyMarkerType)}, nil
+	}
+
+	switch v := value.(type) {
+	case runtime.Boolean:
+		if v {
+			return constantJSON{Type: encodeConstantType(runtime.TypeBoolean), Value: stdjson.RawMessage("true")}, nil
+		}
+
+		return constantJSON{Type: encodeConstantType(runtime.TypeBoolean), Value: stdjson.RawMessage("false")}, nil
+	case runtime.Int:
+		return constantJSON{Type: encodeConstantType(runtime.TypeInt), Value: stdjson.RawMessage(strconv.FormatInt(int64(v), 10))}, nil
+	case runtime.Float:
+		return constantJSON{Type: encodeConstantType(runtime.TypeFloat), Value: stdjson.RawMessage(strconv.FormatFloat(float64(v), 'g', -1, 64))}, nil
+	case runtime.String:
+		encoded, err := json.Marshal(string(v))
+
+		if err != nil {
+			return constantJSON{}, err
+		}
+
+		return constantJSON{Type: encodeConstantType(runtime.TypeString), Value: encoded}, nil
+	case runtime.Binary:
+		encoded, err := json.Marshal(base64.StdEncoding.EncodeToString([]byte(v)))
+
+		if err != nil {
+			return constantJSON{}, err
+		}
+
+		return constantJSON{Type: encodeConstantType(runtime.TypeBinary), Value: encoded}, nil
+	case runtime.DateTime:
+		encoded, err := json.Marshal(v.Time.Format(time.RFC3339Nano))
+
+		if err != nil {
+			return constantJSON{}, err
+		}
+
+		return constantJSON{Type: encodeConstantType(runtime.TypeDateTime), Value: encoded}, nil
+	default:
+		return constantJSON{}, fmt.Errorf("unsupported constant type %T", value)
+	}
+}
+
+func encodeConstantType(typ runtime.Type) string {
+	return strings.ToLower(typ.String())
+}
+
+func decodeConstant(frame constantJSON) (runtime.Value, error) {
+	dt, err := decodeConstantType(frame.Type)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch dt {
+	case runtime.TypeNone:
+		return runtime.None, nil
+	case aggregateKeyMarkerType:
+		return AggregateKeyMarker, nil
+	case runtime.TypeBoolean:
+		raw := strings.TrimSpace(string(frame.Value))
+		if raw == "" {
+			return runtime.False, fmt.Errorf("empty bool value")
+		}
+
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return runtime.False, err
+		}
+
+		return runtime.NewBoolean(value), nil
+	case runtime.TypeInt:
+		raw := strings.TrimSpace(string(frame.Value))
+		if raw == "" {
+			return runtime.ZeroInt, fmt.Errorf("empty int value")
+		}
+
+		value, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return runtime.ZeroInt, err
+		}
+
+		return runtime.NewInt64(value), nil
+	case runtime.TypeFloat:
+		raw := strings.TrimSpace(string(frame.Value))
+		if raw == "" {
+			return runtime.ZeroFloat, fmt.Errorf("empty float value")
+		}
+
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return runtime.ZeroFloat, err
+		}
+
+		return runtime.NewFloat(value), nil
+	case runtime.TypeString:
+		var value string
+
+		if err := json.Unmarshal(frame.Value, &value); err != nil {
+			return runtime.EmptyString, err
+		}
+
+		return runtime.NewString(value), nil
+	case runtime.TypeBinary:
+		var encoded string
+
+		if err := json.Unmarshal(frame.Value, &encoded); err != nil {
+			return nil, err
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, err
+		}
+
+		return runtime.NewBinary(decoded), nil
+	case runtime.TypeDateTime:
+		var encoded string
+		if err := json.Unmarshal(frame.Value, &encoded); err != nil {
+			return nil, err
+		}
+
+		parsed, err := time.Parse(time.RFC3339Nano, encoded)
+		if err != nil {
+			return nil, err
+		}
+
+		return runtime.NewDateTime(parsed), nil
+	default:
+		return nil, fmt.Errorf("unsupported constant type %q", frame.Type)
+	}
+}
+
+func decodeConstantType(typ string) (runtime.Type, error) {
+	switch typ {
+	case "none":
+		return runtime.TypeNone, nil
+	case "agg_key_marker":
+		return aggregateKeyMarkerType, nil
+	case "bool":
+		return runtime.TypeBoolean, nil
+	case "int":
+		return runtime.TypeInt, nil
+	case "float":
+		return runtime.TypeFloat, nil
+	case "string":
+		return runtime.TypeString, nil
+	case "binary":
+		return runtime.TypeBinary, nil
+	case "datetime":
+		return runtime.TypeDateTime, nil
+	default:
+		return "", fmt.Errorf("unsupported constant type %q", typ)
+	}
+}

--- a/pkg/file/source.go
+++ b/pkg/file/source.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -43,6 +44,10 @@ func (s *Source) MarshalJSON() ([]byte, error) {
 }
 
 func (s *Source) UnmarshalJSON(bytes []byte) error {
+	if s == nil {
+		return errors.New("source: UnmarshalJSON on nil source")
+	}
+
 	var data serializedSource
 
 	if err := json.Unmarshal(bytes, &data); err != nil {

--- a/pkg/file/source.go
+++ b/pkg/file/source.go
@@ -1,12 +1,24 @@
 package file
 
-import "strings"
+import (
+	"strings"
 
-type Source struct {
-	name  string
-	text  string
-	lines []string
-}
+	"github.com/goccy/go-json"
+)
+
+type (
+	Source struct {
+		name  string
+		text  string
+		lines []string
+	}
+
+	serializedSource struct {
+		Name  string   `json:"name"`
+		Text  string   `json:"text"`
+		Lines []string `json:"lines"`
+	}
+)
 
 func NewSource(name, text string) *Source {
 	lines := strings.Split(text, "\n")
@@ -20,6 +32,28 @@ func NewSource(name, text string) *Source {
 
 func NewAnonymousSource(text string) *Source {
 	return NewSource("anonymous", text)
+}
+
+func (s *Source) MarshalJSON() ([]byte, error) {
+	return json.Marshal(serializedSource{
+		Name:  s.Name(),
+		Text:  s.Content(),
+		Lines: s.lines,
+	})
+}
+
+func (s *Source) UnmarshalJSON(bytes []byte) error {
+	var data serializedSource
+
+	if err := json.Unmarshal(bytes, &data); err != nil {
+		return err
+	}
+
+	s.name = data.Name
+	s.text = data.Text
+	s.lines = data.Lines
+
+	return nil
 }
 
 func (s *Source) Name() string {

--- a/pkg/file/source.go
+++ b/pkg/file/source.go
@@ -14,7 +14,7 @@ type (
 		lines []string
 	}
 
-	serializedSource struct {
+	sourceJSON struct {
 		Name  string   `json:"name"`
 		Text  string   `json:"text"`
 		Lines []string `json:"lines"`
@@ -36,7 +36,7 @@ func NewAnonymousSource(text string) *Source {
 }
 
 func (s *Source) MarshalJSON() ([]byte, error) {
-	return json.Marshal(serializedSource{
+	return json.Marshal(sourceJSON{
 		Name:  s.Name(),
 		Text:  s.Content(),
 		Lines: s.lines,
@@ -48,7 +48,7 @@ func (s *Source) UnmarshalJSON(bytes []byte) error {
 		return errors.New("source: UnmarshalJSON on nil source")
 	}
 
-	var data serializedSource
+	var data sourceJSON
 
 	if err := json.Unmarshal(bytes, &data); err != nil {
 		return err

--- a/test/integration/vm/vm_program_json_roundtrip_test.go
+++ b/test/integration/vm/vm_program_json_roundtrip_test.go
@@ -1,0 +1,133 @@
+package vm_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/file"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/integration/base"
+)
+
+type roundTripQueryable struct{}
+
+func (q *roundTripQueryable) Query(_ context.Context, _ runtime.Query) (runtime.Value, error) {
+	return runtime.NewString("ok"), nil
+}
+
+func (q *roundTripQueryable) MarshalJSON() ([]byte, error) {
+	return json.Marshal("queryable")
+}
+
+func (q *roundTripQueryable) String() string {
+	return "queryable"
+}
+
+func (q *roundTripQueryable) Hash() uint64 {
+	return 0
+}
+
+func (q *roundTripQueryable) Copy() runtime.Value {
+	return q
+}
+
+type roundTripCase struct {
+	expression  string
+	expected    any
+	options     []vm.EnvironmentOption
+	description string
+}
+
+func (c roundTripCase) name() string {
+	if c.description != "" {
+		return c.description
+	}
+
+	return c.expression
+}
+
+func runProgramRoundTrip(t *testing.T, cases []roundTripCase) {
+	levels := []compiler.OptimizationLevel{compiler.O0, compiler.O1}
+
+	for _, level := range levels {
+		compilerInstance := compiler.New(compiler.WithOptimizationLevel(level))
+
+		for _, tc := range cases {
+			name := fmt.Sprintf("Program JSON RoundTrip: %s (O%d)", tc.name(), level)
+
+			t.Run(name, func(t *testing.T) {
+				convey.Convey(tc.expression, t, func() {
+					prog, err := compilerInstance.Compile(file.NewSource(name, tc.expression))
+					convey.So(err, convey.ShouldBeNil)
+
+					opts := []vm.EnvironmentOption{
+						vm.WithFunctions(base.Stdlib()),
+					}
+					opts = append(opts, tc.options...)
+
+					expectedJSON, err := json.Marshal(tc.expected)
+					convey.So(err, convey.ShouldBeNil)
+
+					originalOut, err := base.Run(prog, opts...)
+					convey.So(err, convey.ShouldBeNil)
+
+					encoded, err := json.Marshal(prog)
+					convey.So(err, convey.ShouldBeNil)
+
+					var decoded bytecode.Program
+					err = json.Unmarshal(encoded, &decoded)
+					convey.So(err, convey.ShouldBeNil)
+
+					roundTripOut, err := base.Run(&decoded, opts...)
+					convey.So(err, convey.ShouldBeNil)
+
+					convey.So(string(originalOut), convey.ShouldEqualJSON, string(expectedJSON))
+					convey.So(string(roundTripOut), convey.ShouldEqualJSON, string(expectedJSON))
+				})
+			})
+		}
+	}
+}
+
+func TestProgramJSONRoundTrip(t *testing.T) {
+	queryable := &roundTripQueryable{}
+
+	runProgramRoundTrip(t, []roundTripCase{
+		{
+			expression:  "RETURN TYPENAME(1.0)",
+			expected:    "Float",
+			description: "Float constants preserve type",
+		},
+		{
+			expression: `
+LET users = [
+  { gender: "m", age: 31 },
+  { gender: "f", age: 25 },
+  { gender: "m", age: 45 }
+]
+FOR u IN users
+  COLLECT gender = u.gender
+  AGGREGATE minAge = MIN(u.age)
+  RETURN { gender, minAge }
+`,
+			expected: []any{
+				map[string]any{"gender": "f", "minAge": 25},
+				map[string]any{"gender": "m", "minAge": 31},
+			},
+			description: "Grouped aggregate round-trip",
+		},
+		{
+			expression:  "RETURN @doc[~ text]",
+			expected:    "ok",
+			options:     []vm.EnvironmentOption{vm.WithParams(map[string]runtime.Value{"doc": queryable})},
+			description: "Query literal without params",
+		},
+	})
+}


### PR DESCRIPTION
This pull request adds support for JSON serialization and deserialization (marshalling and unmarshalling) of the bytecode `Program` and its related structures, ensuring that compiled programs can be round-tripped through JSON without loss of information. It also introduces a comprehensive integration test to verify this behavior and adds JSON marshalling for the `file.Source` type.

The most important changes are:

**JSON Serialization Support for Bytecode:**

* Added a new file `pkg/bytecode/program_json.go` implementing `MarshalJSON` and `UnmarshalJSON` for the `Program` type, including custom encoding/decoding logic for constants and support for all relevant fields.
* Added JSON struct tags to fields in `AggregatePlan`, `Instruction`, and `Metadata` to ensure correct JSON serialization. [[1]](diffhunk://#diff-e2066af60245a8e5e89bc8ef138fbe301f033102e6bafca1b32dc7f5e01f9b7eL18-R20) [[2]](diffhunk://#diff-3c29158563cd7cfac3cb17f1672188825b8060e09843bda0035ddec7119d0d4eL4-R5) [[3]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890L12-R15)

**JSON Serialization Support for Source Files:**

* Implemented `MarshalJSON` and `UnmarshalJSON` methods for the `file.Source` type, enabling source code information to be included in serialized programs. [[1]](diffhunk://#diff-b4c07853431679802ca1c47b0e18c3c07f254a3eb3bf2c9a9fd12daf44474341L3-R22) [[2]](diffhunk://#diff-b4c07853431679802ca1c47b0e18c3c07f254a3eb3bf2c9a9fd12daf44474341R37-R58)

**Testing:**

* Added a new integration test `test/integration/vm/vm_program_json_roundtrip_test.go` that compiles, serializes, deserializes, and executes programs to verify correctness of the JSON round-trip, including various edge cases.