### PR TITLE
Change Compare return type from int64 to int for consistency

### DIFF
--- a/pkg/runtime/array.go
+++ b/pkg/runtime/array.go
@@ -47,7 +47,7 @@ func (t *Array) String() string {
 	return b.String()
 }
 
-func (t *Array) Compare(other Value) int64 {
+func (t *Array) Compare(other Value) int {
 	otherArr, ok := other.(*Array)
 
 	if !ok {
@@ -69,7 +69,7 @@ func (t *Array) Compare(other Value) int64 {
 		return 1
 	}
 
-	var res int64
+	var res int
 
 	for i := 0; i < size; i++ {
 		thisVal := t.data[i]

--- a/pkg/runtime/binary.go
+++ b/pkg/runtime/binary.go
@@ -52,7 +52,7 @@ func (b Binary) Length(_ context.Context) (Int, error) {
 	return Int(len(b)), nil
 }
 
-func (b Binary) Compare(other Value) int64 {
+func (b Binary) Compare(other Value) int {
 	otherBin, ok := other.(Binary)
 
 	if !ok {

--- a/pkg/runtime/boolean.go
+++ b/pkg/runtime/boolean.go
@@ -84,7 +84,7 @@ func (t Boolean) Copy() Value {
 	return t
 }
 
-func (t Boolean) Compare(other Value) int64 {
+func (t Boolean) Compare(other Value) int {
 	otherBool, ok := other.(Boolean)
 
 	if !ok {

--- a/pkg/runtime/comparable.go
+++ b/pkg/runtime/comparable.go
@@ -2,13 +2,13 @@ package runtime
 
 type (
 	Comparable interface {
-		Compare(other Value) int64
+		Compare(other Value) int
 	}
 
-	Comparator = func(first, second Value) int64
+	Comparator = func(first, second Value) int
 )
 
-func CompareValues(a, b Value) int64 {
+func CompareValues(a, b Value) int {
 	aComparable, ok := a.(Comparable)
 
 	if ok {

--- a/pkg/runtime/date_time.go
+++ b/pkg/runtime/date_time.go
@@ -85,7 +85,7 @@ func (dt DateTime) Copy() Value {
 	return NewDateTime(dt.Time)
 }
 
-func (dt DateTime) Compare(other Value) int64 {
+func (dt DateTime) Compare(other Value) int {
 	otherDt, ok := other.(DateTime)
 
 	if !ok {

--- a/pkg/runtime/float.go
+++ b/pkg/runtime/float.go
@@ -97,7 +97,7 @@ func (f Float) Copy() Value {
 	return f
 }
 
-func (f Float) Compare(other Value) int64 {
+func (f Float) Compare(other Value) int {
 	switch otherVal := other.(type) {
 	case Float:
 		if f == otherVal {

--- a/pkg/runtime/int.go
+++ b/pkg/runtime/int.go
@@ -77,7 +77,7 @@ func (i Int) Copy() Value {
 	return i
 }
 
-func (i Int) Compare(other Value) int64 {
+func (i Int) Compare(other Value) int {
 	switch otherVal := other.(type) {
 	case Int:
 		if i == otherVal {

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -48,7 +48,7 @@ func (t *Object) String() string {
 // Compare compares the source object with other core.Value
 // The behavior of the Compare is similar
 // to the comparison of objects in ArangoDB
-func (t *Object) Compare(other Value) int64 {
+func (t *Object) Compare(other Value) int {
 	otherObject, ok := other.(*Object)
 
 	if !ok {
@@ -70,7 +70,7 @@ func (t *Object) Compare(other Value) int64 {
 		return 1
 	}
 
-	var res int64
+	var res int
 
 	tKeys := make([]string, 0, size)
 

--- a/pkg/runtime/sortable.go
+++ b/pkg/runtime/sortable.go
@@ -48,7 +48,7 @@ func SortListDesc(ctx context.Context, values List) error {
 
 // SortList sorts the given List using the stable Sort algorithm
 func SortList(ctx context.Context, values List, ascending Boolean) error {
-	var pivot int64 = -1
+	pivot := -1
 
 	if ascending {
 		pivot = 1
@@ -105,13 +105,13 @@ func SortListWith(ctx context.Context, values List, comparator Comparator) error
 }
 
 func SortSlice(values []Value, ascending Boolean) {
-	var pivot int64 = -1
+	pivot := -1
 
 	if ascending {
 		pivot = 1
 	}
 
-	SortSliceWith(values, func(first, second Value) int64 {
+	SortSliceWith(values, func(first, second Value) int {
 		comp := CompareValues(first, second)
 
 		return pivot * comp

--- a/pkg/runtime/string.go
+++ b/pkg/runtime/string.go
@@ -85,14 +85,14 @@ func (s String) Copy() Value {
 	return s
 }
 
-func (s String) Compare(other Value) int64 {
+func (s String) Compare(other Value) int {
 	otherString, ok := other.(String)
 
 	if !ok {
 		return CompareTypes(s, other)
 	}
 
-	return int64(strings.Compare(string(s), string(otherString)))
+	return strings.Compare(string(s), string(otherString))
 }
 
 func (s String) Length(_ context.Context) (Int, error) {

--- a/pkg/runtime/type_helpers.go
+++ b/pkg/runtime/type_helpers.go
@@ -15,7 +15,7 @@ func TypeName(t Type) string {
 	return t.Name()
 }
 
-func typeRank(value Value) int64 {
+func typeRank(value Value) int {
 	if value == None || value == nil {
 		return 0
 	}
@@ -43,7 +43,7 @@ func typeRank(value Value) int64 {
 }
 
 // CompareTypes compares the types of two values and returns -1 if a < b, 0 if a == b, and 1 if a > b.
-func CompareTypes(a, b Value) int64 {
+func CompareTypes(a, b Value) int {
 	aRank := typeRank(a)
 	bRank := typeRank(b)
 

--- a/pkg/sdk/proxy.go
+++ b/pkg/sdk/proxy.go
@@ -105,7 +105,7 @@ func (p *Proxy[T]) Hash() uint64 {
 	return uint64(reflect.ValueOf(p.target).Pointer())
 }
 
-func (p *Proxy[T]) Compare(other runtime.Value) int64 {
+func (p *Proxy[T]) Compare(other runtime.Value) int {
 	comp, ok := p.target.(runtime.Comparable)
 
 	if ok {

--- a/pkg/sdk/proxy_slice.go
+++ b/pkg/sdk/proxy_slice.go
@@ -96,7 +96,7 @@ func (p *ProxySlice[T]) sort(ascending bool) {
 	})
 }
 
-func (p *ProxySlice[T]) compare(a, b T) int64 {
+func (p *ProxySlice[T]) compare(a, b T) int {
 	if comparableA, ok := any(a).(runtime.Comparable); ok {
 		return comparableA.Compare(p.itemToProxy(b))
 	}

--- a/pkg/vm/internal/data/collector_aggregate_group.go
+++ b/pkg/vm/internal/data/collector_aggregate_group.go
@@ -235,11 +235,11 @@ func (c *GroupedAggregateCollector) valueFor(state aggregateState, kind bytecode
 }
 
 func (c *GroupedAggregateCollector) sort(ctx context.Context) error {
-	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int64 {
+	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int {
 		firstKV, firstOk := first.(*KV)
 		secondKV, secondOk := second.(*KV)
 
-		var comp int64
+		var comp int
 
 		if firstOk && secondOk {
 			comp = runtime.CompareValues(firstKV.Key, secondKV.Key)

--- a/pkg/vm/internal/data/collector_key_counter.go
+++ b/pkg/vm/internal/data/collector_key_counter.go
@@ -45,11 +45,11 @@ func (c *KeyCounterCollector) Iterate(ctx context.Context) (runtime.Iterator, er
 }
 
 func (c *KeyCounterCollector) sort(ctx context.Context) error {
-	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int64 {
+	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int {
 		firstKV, firstOk := first.(*KV)
 		secondKV, secondOk := second.(*KV)
 
-		var comp int64
+		var comp int
 
 		if firstOk && secondOk {
 			comp = runtime.CompareValues(firstKV.Key, secondKV.Key)

--- a/pkg/vm/internal/data/collector_key_group.go
+++ b/pkg/vm/internal/data/collector_key_group.go
@@ -104,11 +104,11 @@ func (c *KeyGroupCollector) Set(ctx context.Context, key, value runtime.Value) e
 }
 
 func (c *KeyGroupCollector) sort(ctx context.Context) error {
-	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int64 {
+	return runtime.SortListWith(ctx, c.Value, func(first, second runtime.Value) int {
 		firstKV, firstOk := first.(*KV)
 		secondKV, secondOk := second.(*KV)
 
-		var comp int64
+		var comp int
 
 		if firstOk && secondOk {
 			comp = runtime.CompareValues(firstKV.Key, secondKV.Key)

--- a/pkg/vm/internal/data/dataset.go
+++ b/pkg/vm/internal/data/dataset.go
@@ -66,7 +66,7 @@ func (ds *DataSet) Copy() runtime.Value {
 	return ds
 }
 
-func (ds *DataSet) Compare(other runtime.Value) int64 {
+func (ds *DataSet) Compare(other runtime.Value) int {
 	return ds.values.Compare(other)
 }
 

--- a/pkg/vm/internal/data/fast_object.go
+++ b/pkg/vm/internal/data/fast_object.go
@@ -172,7 +172,7 @@ func (t *FastObject) String() string {
 	return string(marshaled)
 }
 
-func (t *FastObject) Compare(other runtime.Value) int64 {
+func (t *FastObject) Compare(other runtime.Value) int {
 	otherObject, ok := other.(*FastObject)
 
 	if !ok {
@@ -204,7 +204,7 @@ func (t *FastObject) Compare(other runtime.Value) int64 {
 	otherKeys := otherObject.keys()
 	sort.Strings(otherKeys)
 
-	var res int64
+	var res int
 
 	for i := 0; i < len(tKeys) && res == 0; i++ {
 		tKey, otherKey := tKeys[i], otherKeys[i]

--- a/pkg/vm/internal/data/range.go
+++ b/pkg/vm/internal/data/range.go
@@ -84,7 +84,7 @@ func (r *Range) MarshalJSON() ([]byte, error) {
 	return jettison.MarshalOpts(arr, jettison.NoHTMLEscaping())
 }
 
-func (r *Range) Compare(_ context.Context, other runtime.Value) (int64, error) {
+func (r *Range) Compare(_ context.Context, other runtime.Value) (int, error) {
 	otherRange, ok := other.(*Range)
 
 	if !ok {

--- a/pkg/vm/internal/data/regexp.go
+++ b/pkg/vm/internal/data/regexp.go
@@ -54,14 +54,14 @@ func (r *Regexp) Copy() runtime.Value {
 	return copied
 }
 
-func (r *Regexp) Compare(_ context.Context, other runtime.Value) (int64, error) {
+func (r *Regexp) Compare(_ context.Context, other runtime.Value) (int, error) {
 	otherRegexp, ok := other.(*Regexp)
 
 	if !ok {
 		return runtime.CompareTypes(r, other), nil
 	}
 
-	return int64(strings.Compare(r.String(), otherRegexp.String())), nil
+	return strings.Compare(r.String(), otherRegexp.String()), nil
 }
 
 func (r *Regexp) Match(value runtime.Value) runtime.Boolean {

--- a/pkg/vm/internal/data/sorter.go
+++ b/pkg/vm/internal/data/sorter.go
@@ -45,7 +45,7 @@ func (s *Sorter) Set(ctx context.Context, key, value runtime.Value) error {
 }
 
 func (s *Sorter) sort(ctx context.Context) error {
-	return runtime.SortListWith(ctx, s.Value, func(first, second runtime.Value) int64 {
+	return runtime.SortListWith(ctx, s.Value, func(first, second runtime.Value) int {
 		firstKV := first.(*KV)
 		secondKV := second.(*KV)
 

--- a/pkg/vm/internal/data/sorter_multi.go
+++ b/pkg/vm/internal/data/sorter_multi.go
@@ -44,7 +44,7 @@ func (s *MultiSorter) Set(ctx context.Context, key, value runtime.Value) error {
 }
 
 func (s *MultiSorter) sort(ctx context.Context) error {
-	return runtime.SortListWith(ctx, s.Value, func(first, second runtime.Value) int64 {
+	return runtime.SortListWith(ctx, s.Value, func(first, second runtime.Value) int {
 		firstKV := first.(*KV)
 		secondKV := second.(*KV)
 


### PR DESCRIPTION
This pull request refactors the comparison methods across the runtime and VM internal data packages to consistently use the `int` type instead of `int64` for comparison results. This change simplifies the codebase and improves type consistency, particularly in sorting and comparison operations. The update affects core data types, sorting functions, and comparator interfaces.

Type consistency improvements:

* Updated the `Compare` method signatures for core types (e.g., `Array`, `Binary`, `Boolean`, `DateTime`, `Float`, `Int`, `Object`, `String`, `Proxy`, `ProxySlice`, `DataSet`, `FastObject`, `Range`, `Regexp`) from returning `int64` to `int`, ensuring uniformity across the codebase. [[1]](diffhunk://#diff-b0203a18b3b2587bb72538b483ee843fb534888992f9e84f0c0c05f7cab2f55aL50-R50) [[2]](diffhunk://#diff-6b2d2d99c0523d8b0d581969b596c0e5b467c6dd7c9763fe2314acae9b065263L55-R55) [[3]](diffhunk://#diff-3eb4830c00ee0829a2516242a20cc1f4dc70e1d1e6a9679d0305e344facd4d0dL87-R87) [[4]](diffhunk://#diff-81d31fb43943f0baa2bd7cd79f09e55b9158e887a48743de60763ba652b37729L88-R88) [[5]](diffhunk://#diff-8f6fd8a1b6c4a2a09513726a75992045b86e53a0775d85646e969dd2c05f261cL100-R100) [[6]](diffhunk://#diff-04a256b363591d0d45683e28a7298c7d0b502e449b681afa6d96ed82bcb960f3L80-R80) [[7]](diffhunk://#diff-b653d7b84163744d5a969766abd6abffe8770984a946e9c7cb04c72a4cc66449L51-R51) [[8]](diffhunk://#diff-47790eaed5e9b4a99bec706fee08fbfa46343449984dae15a93d6c3f60b36719L88-R95) [[9]](diffhunk://#diff-c675befe40bea3aa8253b841d73256ce35f479c5fc1aa0b5dbbebbc6d98736feL108-R108) [[10]](diffhunk://#diff-9c937a1efa934ceabdf8460b8416661dcb075980584d134136f765fdd532bffdL99-R99) [[11]](diffhunk://#diff-06c106ef4366b39ee52fa1555eaa86f18c2c8fc53b6dcec290284bd65c0e661aL69-R69) [[12]](diffhunk://#diff-22669dd2aef21ebf241d72e690c7e93d848932690a134f5aa37bc08f116d4dddL175-R175) [[13]](diffhunk://#diff-c19577ae324320df3e56a29e0ee3aaf945b3e19d47e03d897368a0cb32aa59e4L87-R87) [[14]](diffhunk://#diff-bc891a36965f31c1fc15f4ce954f62c93a50c9d8a1de2091af145b2433cbecbfL57-R64)
* Changed the `Comparable` interface and `Comparator` type definition in `pkg/runtime/comparable.go` to use `int` instead of `int64`.

Sorting and comparison logic updates:

* Refactored sorting functions and related callbacks (e.g., `SortList`, `SortSlice`, `SortListWith`, and collector sorting functions) to use `int` for comparison values and pivot variables. [[1]](diffhunk://#diff-b4ce614730c5cee14f66c1b10c63b161398d04098692e561919f73519c943965L51-R51) [[2]](diffhunk://#diff-b4ce614730c5cee14f66c1b10c63b161398d04098692e561919f73519c943965L108-R114) [[3]](diffhunk://#diff-05599addb32d082d5dc81ccd336be81de3c13f74fcc54524217c7a6643f51ff6L238-R242) [[4]](diffhunk://#diff-997962e20b898ebb86002ddebc30dcd667e9471a4aa8d3b4632aa280466792ebL48-R52) [[5]](diffhunk://#diff-333cd586101a29deeda71a97a428c829fe7be146a3485f487ec973e3b576be85L107-R111)
* Updated the `CompareTypes` and `typeRank` functions to return `int` instead of `int64`, aligning type usage in type comparison logic. [[1]](diffhunk://#diff-990b415df19291d94a6f9b64a24522d97974659472d03dcb5b91df43a089cd5dL18-R18) [[2]](diffhunk://#diff-990b415df19291d94a6f9b64a24522d97974659472d03dcb5b91df43a089cd5dL46-R46)

Internal implementation changes:

* Adjusted internal variables used in comparison (e.g., `res`, `comp`, `pivot`) from `int64` to `int` in affected methods. [[1]](diffhunk://#diff-b0203a18b3b2587bb72538b483ee843fb534888992f9e84f0c0c05f7cab2f55aL72-R72) [[2]](diffhunk://#diff-b653d7b84163744d5a969766abd6abffe8770984a946e9c7cb04c72a4cc66449L73-R73) [[3]](diffhunk://#diff-22669dd2aef21ebf241d72e690c7e93d848932690a134f5aa37bc08f116d4dddL207-R207) [[4]](diffhunk://#diff-05599addb32d082d5dc81ccd336be81de3c13f74fcc54524217c7a6643f51ff6L238-R242) [[5]](diffhunk://#diff-997962e20b898ebb86002ddebc30dcd667e9471a4aa8d3b4632aa280466792ebL48-R52) [[6]](diffhunk://#diff-333cd586101a29deeda71a97a428c829fe7be146a3485f487ec973e3b576be85L107-R111) [[7]](diffhunk://#diff-b4ce614730c5cee14f66c1b10c63b161398d04098692e561919f73519c943965L51-R51) [[8]](diffhunk://#diff-b4ce614730c5cee14f66c1b10c63b161398d04098692e561919f73519c943965L108-R114)

These updates collectively improve code clarity, reduce unnecessary type conversions, and make the comparison operations more idiomatic for Go.