### PR TITLE
feat: support binding and encoding of anonymous embedded structs

### DIFF
--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -376,15 +376,28 @@ func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowe
 				continue
 			}
 
-			elem := reflect.New(fieldType.Elem())
-			subMatched, err := bindStructEntries(elem.Elem(), entries, lowerKeys, used)
+			if fieldVal.IsNil() {
+				elem := reflect.New(fieldType.Elem())
+				subMatched, err := bindStructEntries(elem.Elem(), entries, lowerKeys, used)
 
+				if err != nil {
+					return false, err
+				}
+
+				if subMatched {
+					fieldVal.Set(elem)
+					matched = true
+				}
+
+				break
+			}
+
+			subMatched, err := bindStructEntries(fieldVal.Elem(), entries, lowerKeys, used)
 			if err != nil {
 				return false, err
 			}
 
 			if subMatched {
-				fieldVal.Set(elem)
 				matched = true
 			}
 		default:

--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -315,13 +315,26 @@ func bindStruct(src runtime.Value, dst reflect.Value) error {
 
 	lowerKeys := buildLowerKeyMap(entries)
 	used := make(map[string]struct{}, len(entries))
+	visiting := make(map[reflect.Type]int)
 
-	_, err = bindStructEntries(dst, entries, lowerKeys, used)
+	_, err = bindStructEntries(dst, entries, lowerKeys, used, visiting)
 	return err
 }
 
-func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowerKeys map[string]string, used map[string]struct{}) (bool, error) {
+func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowerKeys map[string]string, used map[string]struct{}, visiting map[reflect.Type]int) (bool, error) {
 	dstType := dst.Type()
+	if visiting[dstType] > 0 {
+		return false, nil
+	}
+
+	visiting[dstType]++
+	defer func() {
+		visiting[dstType]--
+		if visiting[dstType] == 0 {
+			delete(visiting, dstType)
+		}
+	}()
+
 	matched := false
 
 	for i := 0; i < dstType.NumField(); i++ {
@@ -364,7 +377,7 @@ func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowe
 
 		switch fieldType.Kind() {
 		case reflect.Struct:
-			subMatched, err := bindStructEntries(fieldVal, entries, lowerKeys, used)
+			subMatched, err := bindStructEntries(fieldVal, entries, lowerKeys, used, visiting)
 			if err != nil {
 				return false, err
 			}
@@ -376,9 +389,13 @@ func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowe
 				continue
 			}
 
+			if visiting[fieldType.Elem()] > 0 {
+				continue
+			}
+
 			if fieldVal.IsNil() {
 				elem := reflect.New(fieldType.Elem())
-				subMatched, err := bindStructEntries(elem.Elem(), entries, lowerKeys, used)
+				subMatched, err := bindStructEntries(elem.Elem(), entries, lowerKeys, used, visiting)
 
 				if err != nil {
 					return false, err
@@ -392,7 +409,7 @@ func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowe
 				break
 			}
 
-			subMatched, err := bindStructEntries(fieldVal.Elem(), entries, lowerKeys, used)
+			subMatched, err := bindStructEntries(fieldVal.Elem(), entries, lowerKeys, used, visiting)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -256,10 +256,6 @@ func bindArray(src runtime.Value, dst reflect.Value) (retErr error) {
 	index := 0
 
 	for {
-		if index >= dst.Len() {
-			return runtime.Error(runtime.ErrInvalidArgumentType, "source has more elements than target array")
-		}
-
 		val, _, err := iter.Next(ctx)
 		if errors.Is(err, io.EOF) || errors.Is(err, runtime.ErrTimeout) {
 			break
@@ -267,6 +263,10 @@ func bindArray(src runtime.Value, dst reflect.Value) (retErr error) {
 
 		if err != nil {
 			return err
+		}
+
+		if index >= dst.Len() {
+			return runtime.Error(runtime.ErrInvalidArgumentType, "source has more elements than target array")
 		}
 
 		elem := reflect.New(elemType).Elem()

--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -40,6 +40,7 @@ func bindValue(src runtime.Value, dst reflect.Value) error {
 
 	if src == runtime.None {
 		dst.Set(reflect.Zero(dst.Type()))
+
 		return nil
 	}
 
@@ -59,6 +60,7 @@ func bindValue(src runtime.Value, dst reflect.Value) error {
 func bindPointer(src runtime.Value, dst reflect.Value) error {
 	if src == runtime.None {
 		dst.Set(reflect.Zero(dst.Type()))
+
 		return nil
 	}
 
@@ -67,7 +69,9 @@ func bindPointer(src runtime.Value, dst reflect.Value) error {
 		if err := bindValue(src, elem.Elem()); err != nil {
 			return err
 		}
+
 		dst.Set(elem)
+
 		return nil
 	}
 
@@ -78,17 +82,23 @@ func bindScalar(src runtime.Value, dst reflect.Value) (bool, error) {
 	switch dst.Kind() {
 	case reflect.Bool:
 		val, ok := src.(runtime.Boolean)
+
 		if !ok {
 			return true, bindTypeError(src, dst.Type())
 		}
+
 		dst.SetBool(bool(val))
+
 		return true, nil
 	case reflect.String:
 		val, ok := src.(runtime.String)
+
 		if !ok {
 			return true, bindTypeError(src, dst.Type())
 		}
+
 		dst.SetString(val.String())
+
 		return true, nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		switch v := src.(type) {
@@ -135,6 +145,7 @@ func bindComposite(src runtime.Value, dst reflect.Value) error {
 	case reflect.Struct:
 		if dt, ok := src.(runtime.DateTime); ok && dst.Type() == timeType {
 			dst.Set(reflect.ValueOf(dt.Time))
+
 			return nil
 		}
 
@@ -148,8 +159,10 @@ func bindComposite(src runtime.Value, dst reflect.Value) error {
 
 func bindInterface(src runtime.Value, dst reflect.Value) error {
 	srcVal := reflect.ValueOf(src)
+
 	if srcVal.IsValid() && srcVal.Type().AssignableTo(dst.Type()) {
 		dst.Set(srcVal)
+
 		return nil
 	}
 
@@ -207,6 +220,7 @@ func bindSlice(src runtime.Value, dst reflect.Value) error {
 		if errors.Is(err, io.EOF) || errors.Is(err, runtime.ErrTimeout) {
 			break
 		}
+
 		if err != nil {
 			return err
 		}
@@ -220,6 +234,7 @@ func bindSlice(src runtime.Value, dst reflect.Value) error {
 	}
 
 	dst.Set(out)
+
 	return nil
 }
 
@@ -247,6 +262,7 @@ func bindArray(src runtime.Value, dst reflect.Value) error {
 		if errors.Is(err, io.EOF) || errors.Is(err, runtime.ErrTimeout) {
 			break
 		}
+
 		if err != nil {
 			return err
 		}
@@ -278,6 +294,7 @@ func bindMap(src runtime.Value, dst reflect.Value) error {
 
 	for key, value := range entries {
 		elem := reflect.New(elemType).Elem()
+
 		if err := bindValue(value, elem); err != nil {
 			return err
 		}
@@ -286,6 +303,7 @@ func bindMap(src runtime.Value, dst reflect.Value) error {
 	}
 
 	dst.Set(out)
+
 	return nil
 }
 
@@ -295,17 +313,20 @@ func bindStruct(src runtime.Value, dst reflect.Value) error {
 		return err
 	}
 
-	lowerKeys := make(map[string]string, len(entries))
-	for key := range entries {
-		lower := strings.ToLower(key)
-		if _, exists := lowerKeys[lower]; !exists {
-			lowerKeys[lower] = key
-		}
-	}
+	lowerKeys := buildLowerKeyMap(entries)
+	used := make(map[string]struct{}, len(entries))
 
+	_, err = bindStructEntries(dst, entries, lowerKeys, used)
+	return err
+}
+
+func bindStructEntries(dst reflect.Value, entries map[string]runtime.Value, lowerKeys map[string]string, used map[string]struct{}) (bool, error) {
 	dstType := dst.Type()
+	matched := false
+
 	for i := 0; i < dstType.NumField(); i++ {
 		field := dstType.Field(i)
+
 		if field.PkgPath != "" {
 			continue
 		}
@@ -315,24 +336,93 @@ func bindStruct(src runtime.Value, dst reflect.Value) error {
 			continue
 		}
 
-		value, ok := entries[name]
-		if !ok {
-			if original, found := lowerKeys[strings.ToLower(name)]; found {
-				value = entries[original]
-				ok = true
-			}
-		}
-
+		value, key, ok := lookupEntry(name, entries, lowerKeys, used)
 		if !ok {
 			continue
 		}
 
 		if err := bindValue(value, dst.Field(i)); err != nil {
-			return err
+			return false, err
+		}
+
+		used[key] = struct{}{}
+		matched = true
+	}
+
+	for i := 0; i < dstType.NumField(); i++ {
+		field := dstType.Field(i)
+		if field.PkgPath != "" || !field.Anonymous {
+			continue
+		}
+
+		if _, ok := Tag(field); ok {
+			continue
+		}
+
+		fieldVal := dst.Field(i)
+		fieldType := fieldVal.Type()
+
+		switch fieldType.Kind() {
+		case reflect.Struct:
+			subMatched, err := bindStructEntries(fieldVal, entries, lowerKeys, used)
+			if err != nil {
+				return false, err
+			}
+			if subMatched {
+				matched = true
+			}
+		case reflect.Pointer:
+			if fieldType.Elem().Kind() != reflect.Struct {
+				continue
+			}
+
+			elem := reflect.New(fieldType.Elem())
+			subMatched, err := bindStructEntries(elem.Elem(), entries, lowerKeys, used)
+
+			if err != nil {
+				return false, err
+			}
+
+			if subMatched {
+				fieldVal.Set(elem)
+				matched = true
+			}
+		default:
+			continue
 		}
 	}
 
-	return nil
+	return matched, nil
+}
+
+func buildLowerKeyMap(entries map[string]runtime.Value) map[string]string {
+	lowerKeys := make(map[string]string, len(entries))
+	for key := range entries {
+		lower := strings.ToLower(key)
+
+		if _, exists := lowerKeys[lower]; !exists {
+			lowerKeys[lower] = key
+		}
+	}
+
+	return lowerKeys
+}
+
+func lookupEntry(name string, entries map[string]runtime.Value, lowerKeys map[string]string, used map[string]struct{}) (runtime.Value, string, bool) {
+	if _, taken := used[name]; !taken {
+		if value, ok := entries[name]; ok {
+			return value, name, true
+		}
+	}
+
+	lower := strings.ToLower(name)
+	if original, ok := lowerKeys[lower]; ok {
+		if _, taken := used[original]; !taken {
+			return entries[original], original, true
+		}
+	}
+
+	return nil, "", false
 }
 
 func collectEntries(src runtime.Value) (map[string]runtime.Value, error) {
@@ -353,6 +443,7 @@ func collectEntries(src runtime.Value) (map[string]runtime.Value, error) {
 	}
 
 	out := make(map[string]runtime.Value)
+
 	for {
 		keyVal, _, err := iter.Next(ctx)
 		if errors.Is(err, io.EOF) || errors.Is(err, runtime.ErrTimeout) {

--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -200,7 +200,7 @@ func bindUnwrapped(src runtime.Value, dst reflect.Value, allowConvert bool) erro
 	return bindTypeError(src, dst.Type())
 }
 
-func bindSlice(src runtime.Value, dst reflect.Value) error {
+func bindSlice(src runtime.Value, dst reflect.Value) (retErr error) {
 	iterable, ok := src.(runtime.Iterable)
 	if !ok {
 		return bindTypeError(src, dst.Type())
@@ -211,6 +211,7 @@ func bindSlice(src runtime.Value, dst reflect.Value) error {
 	if err != nil {
 		return err
 	}
+	defer closeIterOnReturn(iter, &retErr)
 
 	elemType := dst.Type().Elem()
 	out := reflect.MakeSlice(dst.Type(), 0, 0)
@@ -238,7 +239,7 @@ func bindSlice(src runtime.Value, dst reflect.Value) error {
 	return nil
 }
 
-func bindArray(src runtime.Value, dst reflect.Value) error {
+func bindArray(src runtime.Value, dst reflect.Value) (retErr error) {
 	iterable, ok := src.(runtime.Iterable)
 	if !ok {
 		return bindTypeError(src, dst.Type())
@@ -249,6 +250,7 @@ func bindArray(src runtime.Value, dst reflect.Value) error {
 	if err != nil {
 		return err
 	}
+	defer closeIterOnReturn(iter, &retErr)
 
 	elemType := dst.Type().Elem()
 	index := 0
@@ -455,7 +457,7 @@ func lookupEntry(name string, entries map[string]runtime.Value, lowerKeys map[st
 	return nil, "", false
 }
 
-func collectEntries(src runtime.Value) (map[string]runtime.Value, error) {
+func collectEntries(src runtime.Value) (out map[string]runtime.Value, retErr error) {
 	m, ok := src.(runtime.Map)
 	if !ok {
 		return nil, bindTypeError(src, reflect.TypeOf(map[string]any{}))
@@ -471,8 +473,9 @@ func collectEntries(src runtime.Value) (map[string]runtime.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer closeIterOnReturn(iter, &retErr)
 
-	out := make(map[string]runtime.Value)
+	out = make(map[string]runtime.Value)
 
 	for {
 		keyVal, _, err := iter.Next(ctx)
@@ -542,6 +545,20 @@ func setUint(dst reflect.Value, value int64) error {
 
 func bindTypeError(src runtime.Value, target reflect.Type) error {
 	return runtime.Errorf(runtime.ErrInvalidArgumentType, "cannot bind %s to %s", runtime.TypeOf(src), target.String())
+}
+
+func closeIter(iter runtime.Iterator) error {
+	if closable, ok := iter.(io.Closer); ok {
+		return closable.Close()
+	}
+
+	return nil
+}
+
+func closeIterOnReturn(iter runtime.Iterator, retErr *error) {
+	if err := closeIter(iter); *retErr == nil && err != nil {
+		*retErr = err
+	}
 }
 
 func normalizeSrc(src runtime.Value) runtime.Value {

--- a/pkg/sdk/decode_test.go
+++ b/pkg/sdk/decode_test.go
@@ -328,6 +328,27 @@ func TestDecode(t *testing.T) {
 		So(closed, ShouldBeTrue)
 	})
 
+	Convey("Should decode arrays with exact source length and reject overflow", t, func() {
+		Convey("exact length succeeds", func() {
+			src := runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2))
+			var out [2]int
+
+			err := sdk.Decode(src, &out)
+
+			So(err, ShouldBeNil)
+			So(out, ShouldResemble, [2]int{1, 2})
+		})
+
+		Convey("overflow fails", func() {
+			src := runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2))
+			var out [1]int
+
+			err := sdk.Decode(src, &out)
+
+			So(err, ShouldNotBeNil)
+		})
+	})
+
 	Convey("Should reject non-pointer targets", t, func() {
 		obj := runtime.NewObject()
 		var out bindParams

--- a/pkg/sdk/decode_test.go
+++ b/pkg/sdk/decode_test.go
@@ -62,6 +62,9 @@ type (
 		*EmbeddedParams
 		Driver string `json:"driver"`
 	}
+	EmbeddedNode struct {
+		*EmbeddedNode
+	}
 )
 
 func TestDecode(t *testing.T) {
@@ -246,6 +249,16 @@ func TestDecode(t *testing.T) {
 			},
 			Driver: "old-driver",
 		})
+	})
+
+	Convey("Should avoid infinite recursion on self-embedded pointers", t, func() {
+		obj := runtime.NewObject()
+
+		var out EmbeddedNode
+		err := sdk.Decode(obj, &out)
+
+		So(err, ShouldBeNil)
+		So(out.EmbeddedNode, ShouldBeNil)
 	})
 
 	Convey("Should reject non-pointer targets", t, func() {

--- a/pkg/sdk/decode_test.go
+++ b/pkg/sdk/decode_test.go
@@ -3,6 +3,7 @@ package sdk_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -45,6 +46,21 @@ type (
 		Profile nestedProfile  `ferret:"profile"`
 		Matrix  [][]int        `ferret:"matrix"`
 		Friends []nestedFriend `ferret:"friends"`
+	}
+	EmbeddedParams struct {
+		URL         string `json:"url"`
+		UserAgent   string `json:"userAgent"`
+		KeepCookies bool   `json:"keepCookies"`
+		Charset     string `json:"charset"`
+	}
+	EmbeddedPageLoadParams struct {
+		EmbeddedParams
+		Driver  string        `json:"driver"`
+		Timeout time.Duration `json:"timeout"`
+	}
+	EmbeddedOuterPointer struct {
+		*EmbeddedParams
+		Driver string `json:"driver"`
 	}
 )
 
@@ -139,6 +155,67 @@ func TestDecode(t *testing.T) {
 					Meta: &nestedFriendMeta{Active: false},
 				},
 			},
+		})
+	})
+
+	Convey("Should bind anonymous embedded structs inline", t, func() {
+		obj := runtime.NewObjectWith(map[string]runtime.Value{
+			"url":         runtime.NewString("https://example.test"),
+			"userAgent":   runtime.NewString("agent"),
+			"keepCookies": runtime.NewBoolean(true),
+			"charset":     runtime.NewString("utf-8"),
+			"driver":      runtime.NewString("chrome"),
+			"timeout":     runtime.NewInt(42),
+		})
+
+		var out EmbeddedPageLoadParams
+		err := sdk.Decode(obj, &out)
+
+		So(err, ShouldBeNil)
+		So(out, ShouldResemble, EmbeddedPageLoadParams{
+			EmbeddedParams: EmbeddedParams{
+				URL:         "https://example.test",
+				UserAgent:   "agent",
+				KeepCookies: true,
+				Charset:     "utf-8",
+			},
+			Driver:  "chrome",
+			Timeout: 42,
+		})
+	})
+
+	Convey("Should allocate embedded pointers only when matched", t, func() {
+		Convey("no matching keys keeps pointer nil", func() {
+			obj := runtime.NewObjectWith(map[string]runtime.Value{
+				"driver": runtime.NewString("chrome"),
+			})
+
+			var out EmbeddedOuterPointer
+			err := sdk.Decode(obj, &out)
+
+			So(err, ShouldBeNil)
+			So(out, ShouldResemble, EmbeddedOuterPointer{
+				EmbeddedParams: nil,
+				Driver:         "chrome",
+			})
+		})
+
+		Convey("matching key allocates pointer", func() {
+			obj := runtime.NewObjectWith(map[string]runtime.Value{
+				"url":    runtime.NewString("https://example.test"),
+				"driver": runtime.NewString("chrome"),
+			})
+
+			var out EmbeddedOuterPointer
+			err := sdk.Decode(obj, &out)
+
+			So(err, ShouldBeNil)
+			So(out, ShouldResemble, EmbeddedOuterPointer{
+				EmbeddedParams: &EmbeddedParams{
+					URL: "https://example.test",
+				},
+				Driver: "chrome",
+			})
 		})
 	})
 

--- a/pkg/sdk/decode_test.go
+++ b/pkg/sdk/decode_test.go
@@ -219,6 +219,35 @@ func TestDecode(t *testing.T) {
 		})
 	})
 
+	Convey("Should not overwrite existing embedded pointer fields on partial update", t, func() {
+		obj := runtime.NewObjectWith(map[string]runtime.Value{
+			"url": runtime.NewString("new-url"),
+		})
+
+		out := EmbeddedOuterPointer{
+			EmbeddedParams: &EmbeddedParams{
+				URL:         "old",
+				UserAgent:   "ua",
+				KeepCookies: true,
+				Charset:     "utf-8",
+			},
+			Driver: "old-driver",
+		}
+
+		err := sdk.Decode(obj, &out)
+
+		So(err, ShouldBeNil)
+		So(out, ShouldResemble, EmbeddedOuterPointer{
+			EmbeddedParams: &EmbeddedParams{
+				URL:         "new-url",
+				UserAgent:   "ua",
+				KeepCookies: true,
+				Charset:     "utf-8",
+			},
+			Driver: "old-driver",
+		})
+	})
+
 	Convey("Should reject non-pointer targets", t, func() {
 		obj := runtime.NewObject()
 		var out bindParams

--- a/pkg/sdk/decode_test.go
+++ b/pkg/sdk/decode_test.go
@@ -2,6 +2,7 @@ package sdk_test
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -65,7 +66,55 @@ type (
 	EmbeddedNode struct {
 		*EmbeddedNode
 	}
+	closableIterable struct {
+		values []runtime.Value
+		closed *bool
+	}
+	closableIterator struct {
+		values []runtime.Value
+		index  int
+		closed *bool
+	}
 )
+
+func (c closableIterable) String() string {
+	return "closableIterable"
+}
+
+func (c closableIterable) Hash() uint64 {
+	return 0
+}
+
+func (c closableIterable) Copy() runtime.Value {
+	return c
+}
+
+func (c closableIterable) Iterate(_ context.Context) (runtime.Iterator, error) {
+	return &closableIterator{
+		values: c.values,
+		closed: c.closed,
+	}, nil
+}
+
+func (it *closableIterator) Next(_ context.Context) (runtime.Value, runtime.Value, error) {
+	if it.index >= len(it.values) {
+		return runtime.None, runtime.None, io.EOF
+	}
+
+	index := it.index
+	value := it.values[index]
+	it.index++
+
+	return value, runtime.NewInt(index), nil
+}
+
+func (it *closableIterator) Close() error {
+	if it.closed != nil {
+		*it.closed = true
+	}
+
+	return nil
+}
 
 func TestDecode(t *testing.T) {
 	Convey("Should bind values into a struct", t, func() {
@@ -259,6 +308,24 @@ func TestDecode(t *testing.T) {
 
 		So(err, ShouldBeNil)
 		So(out.EmbeddedNode, ShouldBeNil)
+	})
+
+	Convey("Should close iterators when decoding slices", t, func() {
+		closed := false
+		source := closableIterable{
+			values: []runtime.Value{
+				runtime.NewString("a"),
+				runtime.NewString("b"),
+			},
+			closed: &closed,
+		}
+
+		var out []string
+		err := sdk.Decode(source, &out)
+
+		So(err, ShouldBeNil)
+		So(out, ShouldResemble, []string{"a", "b"})
+		So(closed, ShouldBeTrue)
 	})
 
 	Convey("Should reject non-pointer targets", t, func() {

--- a/pkg/sdk/encode.go
+++ b/pkg/sdk/encode.go
@@ -2,6 +2,8 @@ package sdk
 
 import (
 	"context"
+	"errors"
+	"io"
 	"reflect"
 	"time"
 
@@ -92,9 +94,11 @@ func encodeScalar(v reflect.Value) (runtime.Value, bool) {
 		return runtime.NewInt64(v.Int()), true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		u := v.Uint()
+
 		if u > maxInt64 {
 			return runtime.None, true
 		}
+
 		return runtime.NewInt64(int64(u)), true
 	case reflect.Float32, reflect.Float64:
 		return runtime.NewFloat(v.Float()), true
@@ -144,6 +148,7 @@ func encodeStruct(v reflect.Value) runtime.Value {
 	obj := runtime.NewObject()
 	ctx := context.Background()
 	t := v.Type()
+	used := make(map[string]struct{}, t.NumField())
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
@@ -157,7 +162,80 @@ func encodeStruct(v reflect.Value) runtime.Value {
 		}
 
 		_ = obj.Set(ctx, runtime.NewString(name), encodeValue(v.Field(i)))
+		used[name] = struct{}{}
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" || !field.Anonymous {
+			continue
+		}
+
+		if _, ok := Tag(field); ok {
+			continue
+		}
+
+		fieldVal := v.Field(i)
+		switch fieldVal.Kind() {
+		case reflect.Struct:
+			mergeObject(obj, encodeStruct(fieldVal), used)
+		case reflect.Pointer:
+			if fieldVal.IsNil() || fieldVal.Elem().Kind() != reflect.Struct {
+				continue
+			}
+
+			mergeObject(obj, encodeStruct(fieldVal.Elem()), used)
+		default:
+			continue
+		}
 	}
 
 	return obj
+}
+
+func mergeObject(dst *runtime.Object, src runtime.Value, used map[string]struct{}) {
+	m, ok := src.(runtime.Map)
+	if !ok {
+		return
+	}
+
+	ctx := context.Background()
+	keys, err := m.Keys(ctx)
+	if err != nil {
+		return
+	}
+
+	iter, err := keys.Iterate(ctx)
+	if err != nil {
+		return
+	}
+
+	for {
+		keyVal, _, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) || errors.Is(err, runtime.ErrTimeout) {
+			break
+		}
+
+		if err != nil {
+			return
+		}
+
+		key, ok := keyVal.(runtime.String)
+		if !ok {
+			continue
+		}
+
+		keyStr := key.String()
+		if _, exists := used[keyStr]; exists {
+			continue
+		}
+
+		val, err := m.Get(ctx, keyVal)
+		if err != nil {
+			return
+		}
+
+		_ = dst.Set(ctx, runtime.NewString(keyStr), val)
+		used[keyStr] = struct{}{}
+	}
 }

--- a/pkg/sdk/encode.go
+++ b/pkg/sdk/encode.go
@@ -145,9 +145,25 @@ func encodeMap(v reflect.Value) runtime.Value {
 }
 
 func encodeStruct(v reflect.Value) runtime.Value {
+	return encodeStructWithVisit(v, make(map[reflect.Type]int))
+}
+
+func encodeStructWithVisit(v reflect.Value, visiting map[reflect.Type]int) runtime.Value {
 	obj := runtime.NewObject()
 	ctx := context.Background()
 	t := v.Type()
+	if visiting[t] > 0 {
+		return obj
+	}
+
+	visiting[t]++
+	defer func() {
+		visiting[t]--
+		if visiting[t] == 0 {
+			delete(visiting, t)
+		}
+	}()
+
 	used := make(map[string]struct{}, t.NumField())
 
 	for i := 0; i < t.NumField(); i++ {
@@ -178,13 +194,17 @@ func encodeStruct(v reflect.Value) runtime.Value {
 		fieldVal := v.Field(i)
 		switch fieldVal.Kind() {
 		case reflect.Struct:
-			mergeObject(obj, encodeStruct(fieldVal), used)
+			mergeObject(obj, encodeStructWithVisit(fieldVal, visiting), used)
 		case reflect.Pointer:
 			if fieldVal.IsNil() || fieldVal.Elem().Kind() != reflect.Struct {
 				continue
 			}
 
-			mergeObject(obj, encodeStruct(fieldVal.Elem()), used)
+			if visiting[fieldVal.Elem().Type()] > 0 {
+				continue
+			}
+
+			mergeObject(obj, encodeStructWithVisit(fieldVal.Elem(), visiting), used)
 		default:
 			continue
 		}

--- a/pkg/sdk/encode.go
+++ b/pkg/sdk/encode.go
@@ -14,6 +14,18 @@ const maxInt64 = ^uint64(0) >> 1
 
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
+type encodeState struct {
+	embedVisiting map[reflect.Type]int
+	ptrVisiting   map[uintptr]int
+}
+
+func newEncodeState() *encodeState {
+	return &encodeState{
+		embedVisiting: make(map[reflect.Type]int),
+		ptrVisiting:   make(map[uintptr]int),
+	}
+}
+
 // Encode converts a Go value into a runtime Value.
 // It handles basic types, slices, maps, and structs (using tags for field names).
 // If the input is already a runtime Value, it returns it directly.
@@ -27,19 +39,54 @@ func Encode(input any) runtime.Value {
 		return value
 	}
 
-	return encodeValue(reflect.ValueOf(input))
+	return encodeValueWithState(reflect.ValueOf(input), newEncodeState())
 }
 
-func encodeValue(v reflect.Value) runtime.Value {
+func encodeValueWithState(v reflect.Value, state *encodeState) runtime.Value {
 	if !v.IsValid() {
 		return runtime.None
 	}
 
-	v, ok := derefValue(v)
-	if !ok {
-		return runtime.None
+	visitedPtrs := make([]uintptr, 0, 2)
+
+	defer func() {
+		for i := len(visitedPtrs) - 1; i >= 0; i-- {
+			ptr := visitedPtrs[i]
+			state.ptrVisiting[ptr]--
+
+			if state.ptrVisiting[ptr] == 0 {
+				delete(state.ptrVisiting, ptr)
+			}
+		}
+	}()
+
+	for {
+		switch v.Kind() {
+		case reflect.Interface:
+			if v.IsNil() {
+				return runtime.None
+			}
+
+			v = v.Elem()
+		case reflect.Pointer:
+			if v.IsNil() {
+				return runtime.None
+			}
+
+			ptr := v.Pointer()
+			if state.ptrVisiting[ptr] > 0 {
+				return runtime.None
+			}
+
+			state.ptrVisiting[ptr]++
+			visitedPtrs = append(visitedPtrs, ptr)
+			v = v.Elem()
+		default:
+			goto resolved
+		}
 	}
 
+resolved:
 	if v.CanInterface() {
 		if value, ok := v.Interface().(runtime.Value); ok {
 			return value
@@ -54,19 +101,7 @@ func encodeValue(v reflect.Value) runtime.Value {
 		return value
 	}
 
-	return encodeComposite(v)
-}
-
-func derefValue(v reflect.Value) (reflect.Value, bool) {
-	switch v.Kind() {
-	case reflect.Interface, reflect.Ptr:
-		if v.IsNil() {
-			return reflect.Value{}, false
-		}
-		return derefValue(v.Elem())
-	default:
-		return v, true
-	}
+	return encodeComposite(v, state)
 }
 
 func encodeSpecial(v reflect.Value) (runtime.Value, bool) {
@@ -107,63 +142,51 @@ func encodeScalar(v reflect.Value) (runtime.Value, bool) {
 	}
 }
 
-func encodeComposite(v reflect.Value) runtime.Value {
+func encodeComposite(v reflect.Value, state *encodeState) runtime.Value {
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
-		return encodeArrayLike(v)
+		return encodeArrayLike(v, state)
 	case reflect.Map:
-		return encodeMap(v)
+		return encodeMap(v, state)
 	case reflect.Struct:
-		return encodeStruct(v)
+		return encodeStruct(v, state)
 	default:
 		return runtime.None
 	}
 }
 
-func encodeArrayLike(v reflect.Value) runtime.Value {
+func encodeArrayLike(v reflect.Value, state *encodeState) runtime.Value {
 	size := v.Len()
 	arr := runtime.NewArray(size)
 	ctx := context.Background()
 
 	for i := 0; i < size; i++ {
-		_ = arr.Append(ctx, encodeValue(v.Index(i)))
+		_ = arr.Append(ctx, encodeValueWithState(v.Index(i), state))
 	}
 
 	return arr
 }
 
-func encodeMap(v reflect.Value) runtime.Value {
+func encodeMap(v reflect.Value, state *encodeState) runtime.Value {
 	obj := runtime.NewObject()
 	ctx := context.Background()
 
 	for _, key := range v.MapKeys() {
-		keyVal := encodeValue(key)
-		_ = obj.Set(ctx, runtime.NewString(keyVal.String()), encodeValue(v.MapIndex(key)))
+		keyVal := encodeValueWithState(key, state)
+		_ = obj.Set(ctx, runtime.NewString(keyVal.String()), encodeValueWithState(v.MapIndex(key), state))
 	}
 
 	return obj
 }
 
-func encodeStruct(v reflect.Value) runtime.Value {
-	return encodeStructWithVisit(v, make(map[reflect.Type]int))
+func encodeStruct(v reflect.Value, state *encodeState) runtime.Value {
+	return encodeStructWithVisit(v, state)
 }
 
-func encodeStructWithVisit(v reflect.Value, visiting map[reflect.Type]int) runtime.Value {
+func encodeStructWithVisit(v reflect.Value, state *encodeState) runtime.Value {
 	obj := runtime.NewObject()
 	ctx := context.Background()
 	t := v.Type()
-	if visiting[t] > 0 {
-		return obj
-	}
-
-	visiting[t]++
-	defer func() {
-		visiting[t]--
-		if visiting[t] == 0 {
-			delete(visiting, t)
-		}
-	}()
-
 	used := make(map[string]struct{}, t.NumField())
 
 	for i := 0; i < t.NumField(); i++ {
@@ -177,7 +200,7 @@ func encodeStructWithVisit(v reflect.Value, visiting map[reflect.Type]int) runti
 			continue
 		}
 
-		_ = obj.Set(ctx, runtime.NewString(name), encodeValue(v.Field(i)))
+		_ = obj.Set(ctx, runtime.NewString(name), encodeValueWithState(v.Field(i), state))
 		used[name] = struct{}{}
 	}
 
@@ -192,22 +215,18 @@ func encodeStructWithVisit(v reflect.Value, visiting map[reflect.Type]int) runti
 		}
 
 		fieldVal := v.Field(i)
-		switch fieldVal.Kind() {
-		case reflect.Struct:
-			mergeObject(obj, encodeStructWithVisit(fieldVal, visiting), used)
-		case reflect.Pointer:
-			if fieldVal.IsNil() || fieldVal.Elem().Kind() != reflect.Struct {
-				continue
-			}
-
-			if visiting[fieldVal.Elem().Type()] > 0 {
-				continue
-			}
-
-			mergeObject(obj, encodeStructWithVisit(fieldVal.Elem(), visiting), used)
-		default:
+		embedded, ok := resolveEmbeddedStruct(fieldVal)
+		if !ok {
 			continue
 		}
+
+		embedType := embedded.Type()
+		if !enterTypeVisit(state.embedVisiting, embedType) {
+			continue
+		}
+
+		mergeObject(obj, encodeStructWithVisit(embedded, state), used)
+		leaveTypeVisit(state.embedVisiting, embedType)
 	}
 
 	return obj
@@ -229,6 +248,10 @@ func mergeObject(dst *runtime.Object, src runtime.Value, used map[string]struct{
 	if err != nil {
 		return
 	}
+
+	defer func() {
+		_ = closeIter(iter)
+	}()
 
 	for {
 		keyVal, _, err := iter.Next(ctx)
@@ -257,5 +280,37 @@ func mergeObject(dst *runtime.Object, src runtime.Value, used map[string]struct{
 
 		_ = dst.Set(ctx, runtime.NewString(keyStr), val)
 		used[keyStr] = struct{}{}
+	}
+}
+
+func resolveEmbeddedStruct(fieldVal reflect.Value) (reflect.Value, bool) {
+	switch fieldVal.Kind() {
+	case reflect.Struct:
+		return fieldVal, true
+	case reflect.Pointer:
+		if fieldVal.IsNil() || fieldVal.Elem().Kind() != reflect.Struct {
+			return reflect.Value{}, false
+		}
+
+		return fieldVal.Elem(), true
+	default:
+		return reflect.Value{}, false
+	}
+}
+
+func enterTypeVisit(visiting map[reflect.Type]int, t reflect.Type) bool {
+	if visiting[t] > 0 {
+		return false
+	}
+
+	visiting[t]++
+	return true
+}
+
+func leaveTypeVisit(visiting map[reflect.Type]int, t reflect.Type) {
+	visiting[t]--
+
+	if visiting[t] == 0 {
+		delete(visiting, t)
 	}
 }

--- a/pkg/sdk/encode_test.go
+++ b/pkg/sdk/encode_test.go
@@ -65,6 +65,10 @@ type EncodeEmbeddedPageLoadParams struct {
 	URL    string `json:"url"`
 }
 
+type EncodeEmbeddedNode struct {
+	*EncodeEmbeddedNode
+}
+
 func TestEncode(t *testing.T) {
 	Convey("Should encode tagged fields only", t, func() {
 		input := encodeParams{
@@ -181,6 +185,15 @@ func TestEncode(t *testing.T) {
 		)
 
 		So(out, ShouldResemble, expected)
+	})
+
+	Convey("Should avoid infinite recursion on self-embedded pointers", t, func() {
+		node := EncodeEmbeddedNode{}
+		node.EncodeEmbeddedNode = &node
+
+		out := sdk.Encode(node)
+
+		So(out, ShouldResemble, runtime.NewObject())
 	})
 
 	Convey("Should encode nested tagged structs", t, func() {

--- a/pkg/sdk/encode_test.go
+++ b/pkg/sdk/encode_test.go
@@ -54,6 +54,17 @@ type encodeNestedPayload struct {
 	Friends []encodeNestedFriend `ferret:"friends"`
 }
 
+type EncodeEmbeddedParams struct {
+	URL       string `json:"url"`
+	UserAgent string `json:"userAgent"`
+}
+
+type EncodeEmbeddedPageLoadParams struct {
+	EncodeEmbeddedParams
+	Driver string `json:"driver"`
+	URL    string `json:"url"`
+}
+
 func TestEncode(t *testing.T) {
 	Convey("Should encode tagged fields only", t, func() {
 		input := encodeParams{
@@ -143,6 +154,29 @@ func TestEncode(t *testing.T) {
 						},
 					),
 				),
+			},
+		)
+
+		So(out, ShouldResemble, expected)
+	})
+
+	Convey("Should encode anonymous embedded structs inline", t, func() {
+		input := EncodeEmbeddedPageLoadParams{
+			EncodeEmbeddedParams: EncodeEmbeddedParams{
+				URL:       "https://example.test",
+				UserAgent: "agent",
+			},
+			Driver: "chrome",
+			URL:    "parent-url",
+		}
+
+		out := sdk.Encode(input)
+
+		expected := runtime.NewObjectWith(
+			map[string]runtime.Value{
+				"driver":    runtime.NewString("chrome"),
+				"url":       runtime.NewString("parent-url"),
+				"userAgent": runtime.NewString("agent"),
 			},
 		)
 

--- a/pkg/sdk/encode_test.go
+++ b/pkg/sdk/encode_test.go
@@ -69,6 +69,11 @@ type EncodeEmbeddedNode struct {
 	*EncodeEmbeddedNode
 }
 
+type encodeTaggedNode struct {
+	Value string            `json:"value"`
+	Next  *encodeTaggedNode `json:"next"`
+}
+
 func TestEncode(t *testing.T) {
 	Convey("Should encode tagged fields only", t, func() {
 		input := encodeParams{
@@ -194,6 +199,44 @@ func TestEncode(t *testing.T) {
 		out := sdk.Encode(node)
 
 		So(out, ShouldResemble, runtime.NewObject())
+	})
+
+	Convey("Should encode tagged pointer cycles as none", t, func() {
+		node := &encodeTaggedNode{
+			Value: "root",
+		}
+		node.Next = node
+
+		out := sdk.Encode(node)
+
+		expected := runtime.NewObjectWith(map[string]runtime.Value{
+			"value": runtime.NewString("root"),
+			"next":  runtime.None,
+		})
+
+		So(out, ShouldResemble, expected)
+	})
+
+	Convey("Should encode tagged pointer chains without cycles", t, func() {
+		tail := &encodeTaggedNode{
+			Value: "tail",
+		}
+		head := &encodeTaggedNode{
+			Value: "head",
+			Next:  tail,
+		}
+
+		out := sdk.Encode(head)
+
+		expected := runtime.NewObjectWith(map[string]runtime.Value{
+			"value": runtime.NewString("head"),
+			"next": runtime.NewObjectWith(map[string]runtime.Value{
+				"value": runtime.NewString("tail"),
+				"next":  runtime.None,
+			}),
+		})
+
+		So(out, ShouldResemble, expected)
 	})
 
 	Convey("Should encode nested tagged structs", t, func() {


### PR DESCRIPTION
This pull request significantly improves the handling of anonymous embedded structs and pointers in the SDK's decoding and encoding logic. The changes ensure that embedded structs are properly bound and encoded inline, and that embedded pointers are only allocated when matching input keys are present. Comprehensive tests have been added to verify these behaviors.

**Decoding improvements:**
- Enhanced the `bindStruct` logic to recursively bind anonymous embedded structs and pointers, ensuring fields from embedded structs are matched inline and pointers are only allocated if a match occurs. Helper functions `bindStructEntries`, `buildLowerKeyMap`, and `lookupEntry` were introduced for cleaner and more robust field matching. [[1]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L298-R329) [[2]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L318-R425)
- Added extensive tests for decoding structs with anonymous embedded structs and pointers, verifying correct inline binding and pointer allocation only when necessary. [[1]](diffhunk://#diff-99faf46323771fa11d22be55292f9f6a50e3795ffbb8196bfebb3a2208510807R50-R64) [[2]](diffhunk://#diff-99faf46323771fa11d22be55292f9f6a50e3795ffbb8196bfebb3a2208510807R161-R221)

**Encoding improvements:**
- Updated `encodeStruct` to recursively merge fields from anonymous embedded structs and pointers into the parent object, avoiding duplicate keys and ensuring correct inline representation. Introduced the `mergeObject` helper function.
- Added tests to verify that encoding of structs with anonymous embedded structs results in a flat object with all embedded fields included, respecting field precedence. [[1]](diffhunk://#diff-825f591c9e546fb12461259a6cdd1cb402112eda245a37fc6eb9bdb961a27d8cR57-R67) [[2]](diffhunk://#diff-825f591c9e546fb12461259a6cdd1cb402112eda245a37fc6eb9bdb961a27d8cR163-R185)

**General code quality:**
- Minor improvements such as additional blank lines for clarity and minor refactoring in both `decode.go` and `encode.go` for readability and maintainability. [[1]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R43) [[2]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R63) [[3]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R72-R74) [[4]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R85-R101) [[5]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R148) [[6]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R162-R165) [[7]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R223) [[8]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R237) [[9]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R265) [[10]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R297) [[11]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R306) [[12]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R446) [[13]](diffhunk://#diff-d67c6033bfeb8385a9d7df9d3854b65e7f6d87631d7caee2765dee309444fd41R97-R101) [[14]](diffhunk://#diff-d67c6033bfeb8385a9d7df9d3854b65e7f6d87631d7caee2765dee309444fd41R151)

These changes collectively make the SDK's struct (de)serialization more robust and idiomatic in handling Go's anonymous embedded types.