### PR TITLE
Next opcode normalization

### DIFF
--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -293,12 +293,27 @@ func disasmLine(ip int, instr bytecode.Instruction, p *bytecode.Program, labels 
 		}
 	}
 
+	if isHostCallOpcode(opcode) {
+		if comment := hostCallComment(p, instr, prev); comment != "" {
+			out += formatComment(comment)
+		}
+	}
+
 	return out
 }
 
 func isUdfCallOpcode(op bytecode.Opcode) bool {
 	switch op {
 	case bytecode.OpCall, bytecode.OpProtectedCall, bytecode.OpTailCall:
+		return true
+	default:
+		return false
+	}
+}
+
+func isHostCallOpcode(op bytecode.Opcode) bool {
+	switch op {
+	case bytecode.OpHCall, bytecode.OpProtectedHCall:
 		return true
 	default:
 		return false
@@ -338,4 +353,34 @@ func udfCallComment(p *bytecode.Program, instr bytecode.Instruction, prev *bytec
 	}
 
 	return fmt.Sprintf("udf %s", p.Functions.UserDefined[id].Name)
+}
+
+func hostCallComment(p *bytecode.Program, instr bytecode.Instruction, prev *bytecode.Instruction) string {
+	if p == nil || prev == nil {
+		return ""
+	}
+
+	if prev.Opcode != bytecode.OpLoadConst {
+		return ""
+	}
+
+	if prev.Operands[0] != instr.Operands[0] {
+		return ""
+	}
+
+	if !prev.Operands[1].IsConstant() {
+		return ""
+	}
+
+	idx := prev.Operands[1].Constant()
+	if idx < 0 || idx >= len(p.Constants) {
+		return ""
+	}
+
+	name, ok := p.Constants[idx].(runtime.String)
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("host %s", name)
 }

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -30,37 +30,66 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	// Header: version and source info
 	_, _ = fmt.Fprintf(w, ".isa %s\n", formatVersionNum(p.ISAVersion))
 	_, _ = fmt.Fprintf(w, ".asm %s\n", formatVersionNum(Version))
-	_, _ = fmt.Fprintf(w, ".meta compiler %s\n", formatVersion(p.Metadata.CompilerVersion))
-	_, _ = fmt.Fprintf(w, ".meta opt O%d\n", p.Metadata.OptimizationLevel)
+
+	_, _ = fmt.Fprintln(w)
+
+	_, _ = fmt.Fprintln(w, ".meta")
+	_, _ = fmt.Fprintf(w, "  %s\n", formatMetaCompilerRow(p.Metadata.CompilerVersion))
+	_, _ = fmt.Fprintf(w, "  %s\n", formatMetaOptimizationRow(p.Metadata.OptimizationLevel))
 
 	_, _ = fmt.Fprintln(w)
 
 	// Header: program info
 	_, _ = fmt.Fprintln(w, formatProgram(p))
 
-	// Header: functions
-	for name, args := range p.Functions.Host {
-		_, _ = fmt.Fprintln(w, formatFunctionHeader(name, args))
-	}
+	writeSection := func(name string, rows []string) {
+		if len(rows) == 0 {
+			return
+		}
 
-	// Header: UDFs
-	for id, udf := range p.Functions.UserDefined {
-		_, _ = fmt.Fprintln(w, formatUdfHeader(id, udf))
-	}
-
-	// Header: params
-	for _, name := range p.Params {
-		_, _ = fmt.Fprintln(w, formatParamHeader(name))
-	}
-
-	// Header: constants
-	for _, constant := range p.Constants {
-		_, _ = fmt.Fprintln(w, formatConstant(constant))
-	}
-
-	if buf.Len() > 0 {
 		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, name)
+
+		for _, row := range rows {
+			_, _ = fmt.Fprintf(w, "  %s\n", row)
+		}
 	}
+
+	paramRows := make([]string, 0, len(p.Params))
+	for _, name := range p.Params {
+		paramRows = append(paramRows, formatParamRow(name))
+	}
+
+	constRows := make([]string, 0, len(p.Constants))
+	for _, constant := range p.Constants {
+		constRows = append(constRows, formatConstantRow(constant))
+	}
+
+	udfRows := make([]string, 0, len(p.Functions.UserDefined))
+	for id, udf := range p.Functions.UserDefined {
+		udfRows = append(udfRows, formatUdfRow(id, udf))
+	}
+
+	funcRows := make([]string, 0, len(p.Functions.Host))
+	if len(p.Functions.Host) > 0 {
+		names := make([]string, 0, len(p.Functions.Host))
+		for name := range p.Functions.Host {
+			names = append(names, name)
+		}
+
+		sort.Strings(names)
+
+		for _, name := range names {
+			funcRows = append(funcRows, formatFunctionRow(name, p.Functions.Host[name]))
+		}
+	}
+
+	writeSection(".params", paramRows)
+	writeSection(".consts", constRows)
+	writeSection(".udf", udfRows)
+	writeSection(".func", funcRows)
+
+	_, _ = fmt.Fprintln(w)
 
 	// Body: disassembly
 	bodyStarted := false

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -96,9 +96,12 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 				_, _ = fmt.Fprintln(w)
 			}
 
+			formatted := make([]string, 0, len(ipLabels))
 			for _, label := range ipLabels {
-				_, _ = fmt.Fprintf(w, "%s\n", formatLabelDefinition(label))
+				formatted = append(formatted, formatLabelDefinition(label))
 			}
+
+			_, _ = fmt.Fprintf(w, "%s\n", strings.Join(formatted, ", "))
 		}
 
 		var prev *bytecode.Instruction

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
@@ -96,7 +97,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 			}
 
 			for _, label := range ipLabels {
-				_, _ = fmt.Fprintf(w, "%s\n", label)
+				_, _ = fmt.Fprintf(w, "%s\n", formatLabelDefinition(label))
 			}
 		}
 
@@ -140,6 +141,11 @@ func collectLabels(instructions []bytecode.Instruction, names map[int]string) ma
 	}
 
 	return labels
+}
+
+// formatLabelDefinition strips the label-reference prefix from label definitions.
+func formatLabelDefinition(label string) string {
+	return strings.TrimPrefix(label, "@")
 }
 
 type udfBoundaryLabels struct {

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -9,6 +9,8 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
+const Version = 1
+
 // Disassemble returns a human-readable disassembly of the given program.
 func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, error) {
 	if p == nil {
@@ -22,22 +24,30 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
 
+	// Header: version and source info
+	_, _ = fmt.Fprintf(w, ".isa %s\n", formatVersionNum(p.ISAVersion))
+	_, _ = fmt.Fprintf(w, ".asm %s\n", formatVersionNum(Version))
+	_, _ = fmt.Fprintf(w, ".meta compiler %s\n", formatVersion(p.Metadata.CompilerVersion))
+	_, _ = fmt.Fprintf(w, ".meta opt O%d\n", p.Metadata.OptimizationLevel)
+
+	_, _ = fmt.Fprintln(w)
+
 	// Header: program info
 	_, _ = fmt.Fprintln(w, formatProgram(p))
 
 	// Header: functions
 	for name, args := range p.Functions.Host {
-		_, _ = fmt.Fprintln(w, formatFunction(name, args))
+		_, _ = fmt.Fprintln(w, formatFunctionHeader(name, args))
 	}
 
 	// Header: UDFs
 	for id, udf := range p.Functions.UserDefined {
-		_, _ = fmt.Fprintln(w, formatUdf(id, udf))
+		_, _ = fmt.Fprintln(w, formatUdfHeader(id, udf))
 	}
 
 	// Header: params
 	for _, name := range p.Params {
-		_, _ = fmt.Fprintln(w, formatParam(name))
+		_, _ = fmt.Fprintln(w, formatParamHeader(name))
 	}
 
 	// Header: constants
@@ -133,7 +143,7 @@ func disasmLine(ip int, instr bytecode.Instruction, p *bytecode.Program, labels 
 		if ops[2].IsConstant() {
 			cIdx := ops[2].Constant()
 			comment := constValue(p, cIdx)
-			out = fmt.Sprintf("%d: %s %s %s %s ; %s", ip, opcode, formatOperand(ops[0]), formatOperand(ops[1]), formatOperand(ops[2]), comment)
+			out = fmt.Sprintf("%d: %s %s %s %s %s", ip, opcode, formatOperand(ops[0]), formatOperand(ops[1]), formatOperand(ops[2]), formatComment(comment))
 		} else {
 			out = fmt.Sprintf("%d: %s %s %s %s", ip, opcode, formatOperand(ops[0]), formatOperand(ops[1]), formatOperand(ops[2]))
 		}
@@ -142,7 +152,7 @@ func disasmLine(ip int, instr bytecode.Instruction, p *bytecode.Program, labels 
 	case bytecode.OpLoadConst, bytecode.OpLoadParam:
 		cIdx := ops[1].Constant()
 		comment := constValue(p, cIdx)
-		out = fmt.Sprintf("%d: %s %s %s ; %s", ip, opcode, formatOperand(ops[0]), formatOperand(ops[1]), comment)
+		out = fmt.Sprintf("%d: %s %s %s %s", ip, opcode, formatOperand(ops[0]), formatOperand(ops[1]), formatComment(comment))
 
 	// Op R R
 	case bytecode.OpMove, bytecode.OpLength, bytecode.OpType, bytecode.OpExists,
@@ -163,12 +173,8 @@ func disasmLine(ip int, instr bytecode.Instruction, p *bytecode.Program, labels 
 
 	if isUdfCallOpcode(opcode) {
 		if comment := udfCallComment(p, instr, prev); comment != "" {
-			out += " ; " + comment
+			out += formatComment(comment)
 		}
-	}
-
-	if loc := formatLocation(p, ip); loc != "" {
-		out += " " + loc
 	}
 
 	return out

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -62,11 +62,13 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	}
 
 	// Body: disassembly
+	bodyStarted := false
 	for ip, instr := range p.Bytecode {
 		emitted := make(map[string]struct{}, 4)
+		ipLabels := make([]string, 0, 4)
 
 		if label, ok := labels[ip]; ok {
-			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			ipLabels = append(ipLabels, label)
 			emitted[label] = struct{}{}
 		}
 
@@ -75,7 +77,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 				continue
 			}
 
-			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			ipLabels = append(ipLabels, label)
 			emitted[label] = struct{}{}
 		}
 
@@ -84,8 +86,18 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 				continue
 			}
 
-			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			ipLabels = append(ipLabels, label)
 			emitted[label] = struct{}{}
+		}
+
+		if len(ipLabels) > 0 {
+			if bodyStarted {
+				_, _ = fmt.Fprintln(w)
+			}
+
+			for _, label := range ipLabels {
+				_, _ = fmt.Fprintf(w, "%s\n", label)
+			}
 		}
 
 		var prev *bytecode.Instruction
@@ -94,6 +106,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 		}
 
 		_, _ = fmt.Fprintf(w, "\t%s\n", disasmLine(ip, instr, p, labels, prev))
+		bodyStarted = true
 	}
 
 	_ = w.Flush()

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -89,7 +89,10 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	writeSection(".udf", udfRows)
 	writeSection(".func", funcRows)
 
-	_, _ = fmt.Fprintln(w)
+	if len(p.Bytecode) > 0 {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, ".entry")
+	}
 
 	// Body: disassembly
 	bodyStarted := false

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -22,7 +22,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	newDisassemblerOptions(options...)
 
 	labels := collectLabels(p.Bytecode, p.Metadata.Labels)
-	udfLabels := collectUdfBoundaryLabels(p)
+	udfLabels := collectUdfEntryLabels(p)
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
@@ -105,16 +105,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 			emitted[label] = struct{}{}
 		}
 
-		for _, label := range udfLabels.starts[ip] {
-			if _, ok := emitted[label]; ok {
-				continue
-			}
-
-			ipLabels = append(ipLabels, label)
-			emitted[label] = struct{}{}
-		}
-
-		for _, label := range udfLabels.ends[ip] {
+		for _, label := range udfLabels.entries[ip] {
 			if _, ok := emitted[label]; ok {
 				continue
 			}
@@ -183,15 +174,13 @@ func formatLabelDefinition(label string) string {
 	return strings.TrimPrefix(label, "@")
 }
 
-type udfBoundaryLabels struct {
-	starts map[int][]string
-	ends   map[int][]string
+type udfEntryLabels struct {
+	entries map[int][]string
 }
 
-func collectUdfBoundaryLabels(p *bytecode.Program) udfBoundaryLabels {
-	result := udfBoundaryLabels{
-		starts: make(map[int][]string),
-		ends:   make(map[int][]string),
+func collectUdfEntryLabels(p *bytecode.Program) udfEntryLabels {
+	result := udfEntryLabels{
+		entries: make(map[int][]string),
 	}
 
 	if p == nil || len(p.Bytecode) == 0 || len(p.Functions.UserDefined) == 0 {
@@ -229,26 +218,10 @@ func collectUdfBoundaryLabels(p *bytecode.Program) udfBoundaryLabels {
 		return entries[i].entry < entries[j].entry
 	})
 
-	lastIdx := len(p.Bytecode) - 1
 	for i := range entries {
 		cur := entries[i]
-		end := lastIdx
-
-		for j := i + 1; j < len(entries); j++ {
-			next := entries[j]
-			if next.entry <= cur.entry {
-				continue
-			}
-
-			end = next.entry - 1
-			break
-		}
-
-		startLabel := fmt.Sprintf("@udf.%d.%s.start", cur.id, cur.name)
-		endLabel := fmt.Sprintf("@udf.%d.%s.end", cur.id, cur.name)
-
-		result.starts[cur.entry] = append(result.starts[cur.entry], startLabel)
-		result.ends[end] = append(result.ends[end], endLabel)
+		entryLabel := fmt.Sprintf("@udf.%d.%s", cur.id, cur.name)
+		result.entries[cur.entry] = append(result.entries[cur.entry], entryLabel)
 	}
 
 	return result

--- a/pkg/asm/disassembler.go
+++ b/pkg/asm/disassembler.go
@@ -3,6 +3,7 @@ package asm
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"text/tabwriter"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
@@ -20,6 +21,7 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 	newDisassemblerOptions(options...)
 
 	labels := collectLabels(p.Bytecode, p.Metadata.Labels)
+	udfLabels := collectUdfBoundaryLabels(p)
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
@@ -61,8 +63,29 @@ func Disassemble(p *bytecode.Program, options ...DisassemblerOption) (string, er
 
 	// Body: disassembly
 	for ip, instr := range p.Bytecode {
+		emitted := make(map[string]struct{}, 4)
+
 		if label, ok := labels[ip]; ok {
 			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			emitted[label] = struct{}{}
+		}
+
+		for _, label := range udfLabels.starts[ip] {
+			if _, ok := emitted[label]; ok {
+				continue
+			}
+
+			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			emitted[label] = struct{}{}
+		}
+
+		for _, label := range udfLabels.ends[ip] {
+			if _, ok := emitted[label]; ok {
+				continue
+			}
+
+			_, _ = fmt.Fprintf(w, "%s:\n", label)
+			emitted[label] = struct{}{}
 		}
 
 		var prev *bytecode.Instruction
@@ -104,6 +127,77 @@ func collectLabels(instructions []bytecode.Instruction, names map[int]string) ma
 	}
 
 	return labels
+}
+
+type udfBoundaryLabels struct {
+	starts map[int][]string
+	ends   map[int][]string
+}
+
+func collectUdfBoundaryLabels(p *bytecode.Program) udfBoundaryLabels {
+	result := udfBoundaryLabels{
+		starts: make(map[int][]string),
+		ends:   make(map[int][]string),
+	}
+
+	if p == nil || len(p.Bytecode) == 0 || len(p.Functions.UserDefined) == 0 {
+		return result
+	}
+
+	type udfEntry struct {
+		id    int
+		name  string
+		entry int
+	}
+
+	entries := make([]udfEntry, 0, len(p.Functions.UserDefined))
+	for id, udf := range p.Functions.UserDefined {
+		if udf.Entry < 0 || udf.Entry >= len(p.Bytecode) {
+			continue
+		}
+
+		entries = append(entries, udfEntry{
+			id:    id,
+			name:  udf.Name,
+			entry: udf.Entry,
+		})
+	}
+
+	if len(entries) == 0 {
+		return result
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].entry == entries[j].entry {
+			return entries[i].id < entries[j].id
+		}
+
+		return entries[i].entry < entries[j].entry
+	})
+
+	lastIdx := len(p.Bytecode) - 1
+	for i := range entries {
+		cur := entries[i]
+		end := lastIdx
+
+		for j := i + 1; j < len(entries); j++ {
+			next := entries[j]
+			if next.entry <= cur.entry {
+				continue
+			}
+
+			end = next.entry - 1
+			break
+		}
+
+		startLabel := fmt.Sprintf("@udf.%d.%s.start", cur.id, cur.name)
+		endLabel := fmt.Sprintf("@udf.%d.%s.end", cur.id, cur.name)
+
+		result.starts[cur.entry] = append(result.starts[cur.entry], startLabel)
+		result.ends[end] = append(result.ends[end], endLabel)
+	}
+
+	return result
 }
 
 // disasmLine renders a single instruction into text, with optional constants and location info.

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -154,7 +154,7 @@ func TestDisassemble_EntryOmittedWhenNoBytecode(t *testing.T) {
 	}
 }
 
-func TestDisassemble_UDFStartEndLabels(t *testing.T) {
+func TestDisassemble_UDFEntryLabels(t *testing.T) {
 	prog := &bytecode.Program{
 		ISAVersion: bytecode.Version,
 		Bytecode: []bytecode.Instruction{
@@ -183,19 +183,21 @@ func TestDisassemble_UDFStartEndLabels(t *testing.T) {
 	}
 
 	expected := []string{
-		"udf.0.A.start",
-		"udf.0.A.end",
-		"udf.1.B.start",
-		"udf.1.B.end",
+		"udf.0.A",
+		"udf.1.B",
 	}
 	for _, label := range expected {
 		if !strings.Contains(out, label) {
 			t.Fatalf("missing label %q in output:\n%s", label, out)
 		}
 	}
+
+	if strings.Contains(out, "udf.0.A.start") || strings.Contains(out, "udf.0.A.end") || strings.Contains(out, "udf.1.B.start") || strings.Contains(out, "udf.1.B.end") {
+		t.Fatalf("did not expect UDF boundary label suffixes in output:\n%s", out)
+	}
 }
 
-func TestDisassemble_UDFEndLabelOnTailCall(t *testing.T) {
+func TestDisassemble_UDFLabelAtEntryForTailCallBody(t *testing.T) {
 	prog := &bytecode.Program{
 		ISAVersion: bytecode.Version,
 		Bytecode: []bytecode.Instruction{
@@ -220,19 +222,23 @@ func TestDisassemble_UDFEndLabelOnTailCall(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	endPos := strings.Index(out, "udf.0.OUTER.end")
-	tailPos := strings.Index(out, "4: TAILCALL")
+	udfPos := strings.Index(out, "udf.0.OUTER")
+	entryInstrPos := strings.Index(out, "3: LOADC")
 
-	if endPos < 0 {
-		t.Fatalf("missing UDF end label in output:\n%s", out)
+	if udfPos < 0 {
+		t.Fatalf("missing UDF entry label in output:\n%s", out)
 	}
 
-	if tailPos < 0 {
-		t.Fatalf("missing TAILCALL instruction in output:\n%s", out)
+	if entryInstrPos < 0 {
+		t.Fatalf("missing UDF entry instruction in output:\n%s", out)
 	}
 
-	if endPos > tailPos {
-		t.Fatalf("UDF end label must appear before tail call line:\n%s", out)
+	if udfPos > entryInstrPos {
+		t.Fatalf("UDF entry label must appear before entry instruction:\n%s", out)
+	}
+
+	if strings.Contains(out, "udf.0.OUTER.end") {
+		t.Fatalf("did not expect UDF end label in output:\n%s", out)
 	}
 }
 
@@ -266,9 +272,9 @@ func TestDisassemble_UDFLabelsCoexistWithMetadataLabels(t *testing.T) {
 	}
 
 	canonicalPos := strings.Index(out, "loop.1.1.start")
-	udfPos := strings.Index(out, "udf.0.F.start")
+	udfPos := strings.Index(out, "udf.0.F")
 	insPos := strings.Index(out, "2: LOADC")
-	combined := "loop.1.1.start, udf.0.F.start"
+	combined := "loop.1.1.start, udf.0.F"
 
 	if canonicalPos < 0 || udfPos < 0 {
 		t.Fatalf("expected both canonical and udf labels at ip 2:\n%s", out)
@@ -316,19 +322,19 @@ func TestDisassemble_UDFLabelsIgnoreInvalidEntries(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	if !strings.Contains(out, "udf.0.VALID.start") {
+	if !strings.Contains(out, "udf.0.VALID") {
 		t.Fatalf("missing label for valid udf:\n%s", out)
 	}
 
-	if !strings.Contains(out, "udf.0.VALID.end") {
-		t.Fatalf("missing end label for valid udf:\n%s", out)
+	if strings.Contains(out, "udf.0.VALID.start") || strings.Contains(out, "udf.0.VALID.end") {
+		t.Fatalf("did not expect UDF boundary label suffixes for valid udf:\n%s", out)
 	}
 
-	if strings.Contains(out, "udf.1.NEG.start") || strings.Contains(out, "udf.1.NEG.end") {
+	if strings.Contains(out, "udf.1.NEG") {
 		t.Fatalf("invalid negative entry must not produce boundary labels:\n%s", out)
 	}
 
-	if strings.Contains(out, "udf.2.BIG.start") || strings.Contains(out, "udf.2.BIG.end") {
+	if strings.Contains(out, "udf.2.BIG") {
 		t.Fatalf("out-of-range entry must not produce boundary labels:\n%s", out)
 	}
 }
@@ -407,7 +413,7 @@ func TestDisassemble_LabelDefinitionWithoutAt_LabelReferenceWithAt(t *testing.T)
 	}
 }
 
-func TestDisassemble_StackedUDFStartEndSingleInstruction(t *testing.T) {
+func TestDisassemble_UDFSingleInstructionEntryOnlyLabel(t *testing.T) {
 	prog := &bytecode.Program{
 		ISAVersion: bytecode.Version,
 		Bytecode: []bytecode.Instruction{
@@ -425,9 +431,12 @@ func TestDisassemble_StackedUDFStartEndSingleInstruction(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	expected := "udf.0.ONE.start, udf.0.ONE.end"
-	if !strings.Contains(out, expected) {
-		t.Fatalf("expected stacked UDF start/end labels on one line %q:\n%s", expected, out)
+	if !strings.Contains(out, "udf.0.ONE") {
+		t.Fatalf("expected UDF entry label in output:\n%s", out)
+	}
+
+	if strings.Contains(out, "udf.0.ONE.start") || strings.Contains(out, "udf.0.ONE.end") {
+		t.Fatalf("did not expect UDF boundary label suffixes for single-instruction udf:\n%s", out)
 	}
 }
 

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -1,0 +1,183 @@
+package asm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+func TestDisassemble_UDFStartEndLabels(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(1)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewInt(1),
+			runtime.NewInt(2),
+		},
+		Functions: bytecode.Functions{
+			UserDefined: []bytecode.UDF{
+				{Name: "A", Entry: 2, Registers: 2, Params: 0},
+				{Name: "B", Entry: 4, Registers: 2, Params: 0},
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	expected := []string{
+		"@udf.0.A.start:",
+		"@udf.0.A.end:",
+		"@udf.1.B.start:",
+		"@udf.1.B.end:",
+	}
+	for _, label := range expected {
+		if !strings.Contains(out, label) {
+			t.Fatalf("missing label %q in output:\n%s", label, out)
+		}
+	}
+}
+
+func TestDisassemble_UDFEndLabelOnTailCall(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpCall, bytecode.NewRegister(1)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpTailCall, bytecode.NewRegister(1)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewInt(0),
+		},
+		Functions: bytecode.Functions{
+			UserDefined: []bytecode.UDF{
+				{Name: "OUTER", Entry: 3, Registers: 2, Params: 0},
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	endPos := strings.Index(out, "@udf.0.OUTER.end:")
+	tailPos := strings.Index(out, "4: TAILCALL")
+
+	if endPos < 0 {
+		t.Fatalf("missing UDF end label in output:\n%s", out)
+	}
+
+	if tailPos < 0 {
+		t.Fatalf("missing TAILCALL instruction in output:\n%s", out)
+	}
+
+	if endPos > tailPos {
+		t.Fatalf("UDF end label must appear before tail call line:\n%s", out)
+	}
+}
+
+func TestDisassemble_UDFLabelsCoexistWithMetadataLabels(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewInt(1),
+		},
+		Functions: bytecode.Functions{
+			UserDefined: []bytecode.UDF{
+				{Name: "F", Entry: 2, Registers: 2, Params: 0},
+			},
+		},
+		Metadata: bytecode.Metadata{
+			Labels: map[int]string{
+				2: "loop.1.1.start",
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	canonicalPos := strings.Index(out, "@loop.1.1.start:")
+	udfPos := strings.Index(out, "@udf.0.F.start:")
+	insPos := strings.Index(out, "2: LOADC")
+
+	if canonicalPos < 0 || udfPos < 0 {
+		t.Fatalf("expected both canonical and udf labels at ip 2:\n%s", out)
+	}
+
+	if insPos < 0 {
+		t.Fatalf("missing instruction line at ip 2:\n%s", out)
+	}
+
+	if canonicalPos > udfPos {
+		t.Fatalf("canonical label must be printed before udf labels:\n%s", out)
+	}
+
+	if udfPos > insPos {
+		t.Fatalf("labels must be printed before instruction:\n%s", out)
+	}
+}
+
+func TestDisassemble_UDFLabelsIgnoreInvalidEntries(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(1)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewInt(1),
+		},
+		Functions: bytecode.Functions{
+			UserDefined: []bytecode.UDF{
+				{Name: "VALID", Entry: 1, Registers: 2, Params: 0},
+				{Name: "NEG", Entry: -1, Registers: 2, Params: 0},
+				{Name: "BIG", Entry: 10, Registers: 2, Params: 0},
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "@udf.0.VALID.start:") {
+		t.Fatalf("missing label for valid udf:\n%s", out)
+	}
+
+	if !strings.Contains(out, "@udf.0.VALID.end:") {
+		t.Fatalf("missing end label for valid udf:\n%s", out)
+	}
+
+	if strings.Contains(out, "@udf.1.NEG.start:") || strings.Contains(out, "@udf.1.NEG.end:") {
+		t.Fatalf("invalid negative entry must not produce boundary labels:\n%s", out)
+	}
+
+	if strings.Contains(out, "@udf.2.BIG.start:") || strings.Contains(out, "@udf.2.BIG.end:") {
+		t.Fatalf("out-of-range entry must not produce boundary labels:\n%s", out)
+	}
+}

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -122,9 +122,14 @@ func TestDisassemble_UDFLabelsCoexistWithMetadataLabels(t *testing.T) {
 	canonicalPos := strings.Index(out, "loop.1.1.start")
 	udfPos := strings.Index(out, "udf.0.F.start")
 	insPos := strings.Index(out, "2: LOADC")
+	combined := "loop.1.1.start, udf.0.F.start"
 
 	if canonicalPos < 0 || udfPos < 0 {
 		t.Fatalf("expected both canonical and udf labels at ip 2:\n%s", out)
+	}
+
+	if !strings.Contains(out, combined) {
+		t.Fatalf("expected stacked labels on one line %q:\n%s", combined, out)
 	}
 
 	if insPos < 0 {
@@ -253,5 +258,29 @@ func TestDisassemble_LabelDefinitionWithoutAt_LabelReferenceWithAt(t *testing.T)
 
 	if !strings.Contains(out, "JMP @loop.1.1.end") {
 		t.Fatalf("expected jump operand to keep '@' reference style:\n%s", out)
+	}
+}
+
+func TestDisassemble_StackedUDFStartEndSingleInstruction(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Functions: bytecode.Functions{
+			UserDefined: []bytecode.UDF{
+				{Name: "ONE", Entry: 0, Registers: 1, Params: 0},
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	expected := "udf.0.ONE.start, udf.0.ONE.end"
+	if !strings.Contains(out, expected) {
+		t.Fatalf("expected stacked UDF start/end labels on one line %q:\n%s", expected, out)
 	}
 }

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -37,10 +37,10 @@ func TestDisassemble_UDFStartEndLabels(t *testing.T) {
 	}
 
 	expected := []string{
-		"@udf.0.A.start",
-		"@udf.0.A.end",
-		"@udf.1.B.start",
-		"@udf.1.B.end",
+		"udf.0.A.start",
+		"udf.0.A.end",
+		"udf.1.B.start",
+		"udf.1.B.end",
 	}
 	for _, label := range expected {
 		if !strings.Contains(out, label) {
@@ -74,7 +74,7 @@ func TestDisassemble_UDFEndLabelOnTailCall(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	endPos := strings.Index(out, "@udf.0.OUTER.end")
+	endPos := strings.Index(out, "udf.0.OUTER.end")
 	tailPos := strings.Index(out, "4: TAILCALL")
 
 	if endPos < 0 {
@@ -119,8 +119,8 @@ func TestDisassemble_UDFLabelsCoexistWithMetadataLabels(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	canonicalPos := strings.Index(out, "@loop.1.1.start")
-	udfPos := strings.Index(out, "@udf.0.F.start")
+	canonicalPos := strings.Index(out, "loop.1.1.start")
+	udfPos := strings.Index(out, "udf.0.F.start")
 	insPos := strings.Index(out, "2: LOADC")
 
 	if canonicalPos < 0 || udfPos < 0 {
@@ -165,19 +165,19 @@ func TestDisassemble_UDFLabelsIgnoreInvalidEntries(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	if !strings.Contains(out, "@udf.0.VALID.start") {
+	if !strings.Contains(out, "udf.0.VALID.start") {
 		t.Fatalf("missing label for valid udf:\n%s", out)
 	}
 
-	if !strings.Contains(out, "@udf.0.VALID.end") {
+	if !strings.Contains(out, "udf.0.VALID.end") {
 		t.Fatalf("missing end label for valid udf:\n%s", out)
 	}
 
-	if strings.Contains(out, "@udf.1.NEG.start") || strings.Contains(out, "@udf.1.NEG.end") {
+	if strings.Contains(out, "udf.1.NEG.start") || strings.Contains(out, "udf.1.NEG.end") {
 		t.Fatalf("invalid negative entry must not produce boundary labels:\n%s", out)
 	}
 
-	if strings.Contains(out, "@udf.2.BIG.start") || strings.Contains(out, "@udf.2.BIG.end") {
+	if strings.Contains(out, "udf.2.BIG.start") || strings.Contains(out, "udf.2.BIG.end") {
 		t.Fatalf("out-of-range entry must not produce boundary labels:\n%s", out)
 	}
 }
@@ -203,13 +203,55 @@ func TestDisassemble_LabelFormatting_NoColonAndBlankLineBetweenBlocks(t *testing
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	if !strings.Contains(out, "\n\n@loop.1.1.end\n") {
+	if !strings.Contains(out, "\n\nloop.1.1.end\n") {
 		t.Fatalf("expected blank line before second label block:\n%s", out)
 	}
 
+	definitionCount := 0
 	for _, line := range strings.Split(out, "\n") {
+		if line == "loop.1.1.start" || line == "loop.1.1.end" {
+			definitionCount++
+		}
+
+		if strings.HasPrefix(line, "@") {
+			t.Fatalf("label definition must not start with '@', got line %q\n%s", line, out)
+		}
+
 		if strings.HasPrefix(line, "@") && strings.HasSuffix(line, ":") {
 			t.Fatalf("label definition must not end with colon, got line %q\n%s", line, out)
 		}
+	}
+
+	if definitionCount == 0 {
+		t.Fatalf("expected at least one label definition line in output:\n%s", out)
+	}
+}
+
+func TestDisassemble_LabelDefinitionWithoutAt_LabelReferenceWithAt(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpJump, bytecode.Operand(2)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			Labels: map[int]string{
+				2: "loop.1.1.end",
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "\nloop.1.1.end\n") {
+		t.Fatalf("expected label definition without '@':\n%s", out)
+	}
+
+	if !strings.Contains(out, "JMP @loop.1.1.end") {
+		t.Fatalf("expected jump operand to keep '@' reference style:\n%s", out)
 	}
 }

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -284,3 +284,91 @@ func TestDisassemble_StackedUDFStartEndSingleInstruction(t *testing.T) {
 		t.Fatalf("expected stacked UDF start/end labels on one line %q:\n%s", expected, out)
 	}
 }
+
+func TestDisassemble_HCallCommentWithHostFunctionName(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpHCall, bytecode.NewRegister(1), bytecode.NewRegister(2), bytecode.NewRegister(2)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewString("X::DO"),
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "1: HCALL R1 R2 R2 ; host X::DO") {
+		t.Fatalf("expected HCALL host comment in output:\n%s", out)
+	}
+}
+
+func TestDisassemble_ProtectedHCallCommentWithHostFunctionName(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpProtectedHCall, bytecode.NewRegister(1), bytecode.NewRegister(2), bytecode.NewRegister(2)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewString("X::SAFE"),
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "1: PHCALL R1 R2 R2 ; host X::SAFE") {
+		t.Fatalf("expected protected HCALL host comment in output:\n%s", out)
+	}
+}
+
+func TestDisassemble_HCallCommentMissingWhenNoMatchingLoadConst(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(2), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpHCall, bytecode.NewRegister(1), bytecode.NewRegister(2), bytecode.NewRegister(2)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewString("X::DO"),
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if strings.Contains(out, "; host X::DO") {
+		t.Fatalf("did not expect host comment when LOADC register does not match HCALL register:\n%s", out)
+	}
+}
+
+func TestDisassemble_HCallCommentMissingWhenConstantIsNotString(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(1), bytecode.NewConstant(0)),
+			bytecode.NewInstruction(bytecode.OpHCall, bytecode.NewRegister(1), bytecode.NewRegister(2), bytecode.NewRegister(2)),
+		},
+		Constants: []runtime.Value{
+			runtime.NewInt(42),
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if strings.Contains(out, "; host ") {
+		t.Fatalf("did not expect host comment when function-name constant is not a string:\n%s", out)
+	}
+}

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -37,10 +37,10 @@ func TestDisassemble_UDFStartEndLabels(t *testing.T) {
 	}
 
 	expected := []string{
-		"@udf.0.A.start:",
-		"@udf.0.A.end:",
-		"@udf.1.B.start:",
-		"@udf.1.B.end:",
+		"@udf.0.A.start",
+		"@udf.0.A.end",
+		"@udf.1.B.start",
+		"@udf.1.B.end",
 	}
 	for _, label := range expected {
 		if !strings.Contains(out, label) {
@@ -74,7 +74,7 @@ func TestDisassemble_UDFEndLabelOnTailCall(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	endPos := strings.Index(out, "@udf.0.OUTER.end:")
+	endPos := strings.Index(out, "@udf.0.OUTER.end")
 	tailPos := strings.Index(out, "4: TAILCALL")
 
 	if endPos < 0 {
@@ -119,8 +119,8 @@ func TestDisassemble_UDFLabelsCoexistWithMetadataLabels(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	canonicalPos := strings.Index(out, "@loop.1.1.start:")
-	udfPos := strings.Index(out, "@udf.0.F.start:")
+	canonicalPos := strings.Index(out, "@loop.1.1.start")
+	udfPos := strings.Index(out, "@udf.0.F.start")
 	insPos := strings.Index(out, "2: LOADC")
 
 	if canonicalPos < 0 || udfPos < 0 {
@@ -165,19 +165,51 @@ func TestDisassemble_UDFLabelsIgnoreInvalidEntries(t *testing.T) {
 		t.Fatalf("Disassemble() error: %v", err)
 	}
 
-	if !strings.Contains(out, "@udf.0.VALID.start:") {
+	if !strings.Contains(out, "@udf.0.VALID.start") {
 		t.Fatalf("missing label for valid udf:\n%s", out)
 	}
 
-	if !strings.Contains(out, "@udf.0.VALID.end:") {
+	if !strings.Contains(out, "@udf.0.VALID.end") {
 		t.Fatalf("missing end label for valid udf:\n%s", out)
 	}
 
-	if strings.Contains(out, "@udf.1.NEG.start:") || strings.Contains(out, "@udf.1.NEG.end:") {
+	if strings.Contains(out, "@udf.1.NEG.start") || strings.Contains(out, "@udf.1.NEG.end") {
 		t.Fatalf("invalid negative entry must not produce boundary labels:\n%s", out)
 	}
 
-	if strings.Contains(out, "@udf.2.BIG.start:") || strings.Contains(out, "@udf.2.BIG.end:") {
+	if strings.Contains(out, "@udf.2.BIG.start") || strings.Contains(out, "@udf.2.BIG.end") {
 		t.Fatalf("out-of-range entry must not produce boundary labels:\n%s", out)
+	}
+}
+
+func TestDisassemble_LabelFormatting_NoColonAndBlankLineBetweenBlocks(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			Labels: map[int]string{
+				0: "loop.1.1.start",
+				2: "loop.1.1.end",
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "\n\n@loop.1.1.end\n") {
+		t.Fatalf("expected blank line before second label block:\n%s", out)
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "@") && strings.HasSuffix(line, ":") {
+			t.Fatalf("label definition must not end with colon, got line %q\n%s", line, out)
+		}
 	}
 }

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -46,13 +46,14 @@ func TestDisassemble_HeaderSectionsStackedLayout(t *testing.T) {
 	constsPos := strings.Index(out, "\n.consts\n")
 	udfPos := strings.Index(out, "\n.udf\n")
 	funcPos := strings.Index(out, "\n.func\n")
+	entryPos := strings.Index(out, "\n.entry\n")
 	bodyPos := strings.Index(out, "0: RET R0")
 
-	if metaPos < 0 || paramsPos < 0 || constsPos < 0 || udfPos < 0 || funcPos < 0 || bodyPos < 0 {
+	if metaPos < 0 || paramsPos < 0 || constsPos < 0 || udfPos < 0 || funcPos < 0 || entryPos < 0 || bodyPos < 0 {
 		t.Fatalf("expected stacked header sections and body in output:\n%s", out)
 	}
 
-	if !(metaPos < paramsPos && paramsPos < constsPos && constsPos < udfPos && udfPos < funcPos && funcPos < bodyPos) {
+	if !(metaPos < paramsPos && paramsPos < constsPos && constsPos < udfPos && udfPos < funcPos && funcPos < entryPos && entryPos < bodyPos) {
 		t.Fatalf("unexpected section order in output:\n%s", out)
 	}
 
@@ -99,6 +100,57 @@ func TestDisassemble_HeaderSections_OmitEmptySections(t *testing.T) {
 
 	if strings.Contains(out, "\n.params\n") || strings.Contains(out, "\n.consts\n") || strings.Contains(out, "\n.udf\n") || strings.Contains(out, "\n.func\n") {
 		t.Fatalf("expected empty sections to be omitted:\n%s", out)
+	}
+}
+
+func TestDisassemble_EntryBeforeFirstLabelAndInstruction(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			Labels: map[int]string{
+				0: "match.start",
+			},
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	entryPos := strings.Index(out, "\n.entry\n")
+	labelPos := strings.Index(out, "\nmatch.start\n")
+	insPos := strings.Index(out, "0: RET R0")
+
+	if entryPos < 0 || labelPos < 0 || insPos < 0 {
+		t.Fatalf("expected .entry, label, and first instruction in output:\n%s", out)
+	}
+
+	if !(entryPos < labelPos && labelPos < insPos) {
+		t.Fatalf("expected .entry before label and label before instruction:\n%s", out)
+	}
+}
+
+func TestDisassemble_EntryOmittedWhenNoBytecode(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Registers:  1,
+		Metadata: bytecode.Metadata{
+			CompilerVersion:   "2.0.0",
+			OptimizationLevel: 0,
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if strings.Contains(out, "\n.entry\n") {
+		t.Fatalf("expected .entry to be omitted for empty bytecode:\n%s", out)
 	}
 }
 

--- a/pkg/asm/disassembler_test.go
+++ b/pkg/asm/disassembler_test.go
@@ -8,6 +8,100 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
+func TestDisassemble_HeaderSectionsStackedLayout(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Registers:  4,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Params: []string{"value"},
+		Constants: []runtime.Value{
+			runtime.NewString("value"),
+			runtime.NewInt(0),
+			runtime.NewInt(1),
+			runtime.NewString("X::DO"),
+		},
+		Functions: bytecode.Functions{
+			Host: map[string]int{
+				"X::DO": 1,
+			},
+			UserDefined: []bytecode.UDF{
+				{Name: "FACT", Entry: 0, Registers: 10, Params: 1},
+			},
+		},
+		Metadata: bytecode.Metadata{
+			CompilerVersion:   "2.0.0",
+			OptimizationLevel: 1,
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	metaPos := strings.Index(out, "\n.meta\n")
+	paramsPos := strings.Index(out, "\n.params\n")
+	constsPos := strings.Index(out, "\n.consts\n")
+	udfPos := strings.Index(out, "\n.udf\n")
+	funcPos := strings.Index(out, "\n.func\n")
+	bodyPos := strings.Index(out, "0: RET R0")
+
+	if metaPos < 0 || paramsPos < 0 || constsPos < 0 || udfPos < 0 || funcPos < 0 || bodyPos < 0 {
+		t.Fatalf("expected stacked header sections and body in output:\n%s", out)
+	}
+
+	if !(metaPos < paramsPos && paramsPos < constsPos && constsPos < udfPos && udfPos < funcPos && funcPos < bodyPos) {
+		t.Fatalf("unexpected section order in output:\n%s", out)
+	}
+
+	expectedRows := []string{
+		"\n  compiler 2.0.0\n",
+		"\n  opt O1\n",
+		"\n  value\n",
+		"\n  \"value\"\n",
+		"\n  0\n",
+		"\n  1\n",
+		"\n  \"X::DO\"\n",
+		"\n  0 FACT 0 10 1  ; id name entry registers params\n",
+		"\n  X::DO 1 ; name params\n",
+	}
+
+	for _, row := range expectedRows {
+		if !strings.Contains(out, row) {
+			t.Fatalf("missing expected row %q in output:\n%s", row, out)
+		}
+	}
+}
+
+func TestDisassemble_HeaderSections_OmitEmptySections(t *testing.T) {
+	prog := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Registers:  1,
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			CompilerVersion:   "2.0.0",
+			OptimizationLevel: 0,
+		},
+	}
+
+	out, err := Disassemble(prog)
+	if err != nil {
+		t.Fatalf("Disassemble() error: %v", err)
+	}
+
+	if !strings.Contains(out, "\n.meta\n") {
+		t.Fatalf("expected .meta section in output:\n%s", out)
+	}
+
+	if strings.Contains(out, "\n.params\n") || strings.Contains(out, "\n.consts\n") || strings.Contains(out, "\n.udf\n") || strings.Contains(out, "\n.func\n") {
+		t.Fatalf("expected empty sections to be omitted:\n%s", out)
+	}
+}
+
 func TestDisassemble_UDFStartEndLabels(t *testing.T) {
 	prog := &bytecode.Program{
 		ISAVersion: bytecode.Version,

--- a/pkg/asm/formatter.go
+++ b/pkg/asm/formatter.go
@@ -16,6 +16,10 @@ func labelOrAddr(pos int, labels map[int]string) string {
 	return fmt.Sprintf("%d", pos)
 }
 
+func formatComment(comment string) string {
+	return fmt.Sprintf(" ; %s", comment)
+}
+
 // constantAsText formats a constant value as a string.
 func constantAsText(constant runtime.Value) string {
 	if runtime.IsNumber(constant) {
@@ -35,33 +39,41 @@ func constValue(p *bytecode.Program, idx int) string {
 }
 
 func formatProgram(p *bytecode.Program) string {
-	return fmt.Sprintf(".prog %d %d %d", p.Registers, len(p.Constants), len(p.Params))
+	comment := "regs consts params"
+
+	return fmt.Sprintf(".prog %d %d %d %s", p.Registers, len(p.Constants), len(p.Params), formatComment(comment))
 }
 
-// formatLocation returns a line/col comment if available for the given instruction.
-func formatLocation(p *bytecode.Program, ip int) string {
-	//if ip < len(p.Locations) {
-	//	loc := p.Locations[ip]
-	//
-	//	return fmt.Sprintf("; line %d col %d", loc.Line, loc.Column)
-	//}
+func formatVersion(v string) string {
+	if v == "" {
+		return "-"
+	}
 
-	return ""
+	return v
 }
 
-// formatParam generates comments mapping register indices to parameter names.
-func formatParam(name string) string {
+func formatVersionNum(v int) string {
+	if v <= 0 {
+		return formatVersion("")
+	}
+
+	return formatVersion(fmt.Sprintf("%d", v))
+}
+
+// formatParamHeader generates comments mapping register indices to parameter names.
+func formatParamHeader(name string) string {
 	return fmt.Sprintf(".param %s", name)
 }
 
-// formatFunction generates comments for the functions defined in the program.
-func formatFunction(name string, args int) string {
-	return fmt.Sprintf(".func %s %d", name, args)
+// formatFunctionHeader generates comments for the functions defined in the program.
+func formatFunctionHeader(name string, args int) string {
+	return fmt.Sprintf(".func %s %d ; name params", name, args)
 }
 
-// formatUdf generates comments for the UDF table entries.
-func formatUdf(id int, udf bytecode.UDF) string {
-	return fmt.Sprintf(".udf %d %s %d %d %d", id, udf.Name, udf.Entry, udf.Registers, udf.Params)
+// formatUdfHeader generates comments for the UDF table entries.
+func formatUdfHeader(id int, udf bytecode.UDF) string {
+	comment := "id name entry registers params"
+	return fmt.Sprintf(".udf %d %s %d %d %d %s", id, udf.Name, udf.Entry, udf.Registers, udf.Params, formatComment(comment))
 }
 
 // formatConstant generates a comment for a constant value in the program.

--- a/pkg/asm/formatter.go
+++ b/pkg/asm/formatter.go
@@ -60,25 +60,49 @@ func formatVersionNum(v int) string {
 	return formatVersion(fmt.Sprintf("%d", v))
 }
 
-// formatParamHeader generates comments mapping register indices to parameter names.
-func formatParamHeader(name string) string {
-	return fmt.Sprintf(".param %s", name)
+func formatMetaCompilerRow(version string) string {
+	return fmt.Sprintf("compiler %s", formatVersion(version))
 }
 
-// formatFunctionHeader generates comments for the functions defined in the program.
-func formatFunctionHeader(name string, args int) string {
-	return fmt.Sprintf(".func %s %d ; name params", name, args)
+func formatMetaOptimizationRow(level int) string {
+	return fmt.Sprintf("opt O%d", level)
 }
 
-// formatUdfHeader generates comments for the UDF table entries.
-func formatUdfHeader(id int, udf bytecode.UDF) string {
+func formatParamRow(name string) string {
+	return name
+}
+
+func formatFunctionRow(name string, args int) string {
+	return fmt.Sprintf("%s %d ; name params", name, args)
+}
+
+func formatUdfRow(id int, udf bytecode.UDF) string {
 	comment := "id name entry registers params"
-	return fmt.Sprintf(".udf %d %s %d %d %d %s", id, udf.Name, udf.Entry, udf.Registers, udf.Params, formatComment(comment))
+	return fmt.Sprintf("%d %s %d %d %d %s", id, udf.Name, udf.Entry, udf.Registers, udf.Params, formatComment(comment))
 }
 
-// formatConstant generates a comment for a constant value in the program.
+func formatConstantRow(constant runtime.Value) string {
+	return constantAsText(constant)
+}
+
+// formatParamHeader is a legacy single-line header helper.
+func formatParamHeader(name string) string {
+	return fmt.Sprintf(".param %s", formatParamRow(name))
+}
+
+// formatFunctionHeader is a legacy single-line header helper.
+func formatFunctionHeader(name string, args int) string {
+	return fmt.Sprintf(".func %s", formatFunctionRow(name, args))
+}
+
+// formatUdfHeader is a legacy single-line header helper.
+func formatUdfHeader(id int, udf bytecode.UDF) string {
+	return fmt.Sprintf(".udf %s", formatUdfRow(id, udf))
+}
+
+// formatConstant is a legacy single-line header helper.
 func formatConstant(constant runtime.Value) string {
-	return fmt.Sprintf(".const %s", constantAsText(constant))
+	return fmt.Sprintf(".const %s", formatConstantRow(constant))
 }
 
 func formatOperand(op bytecode.Operand) string {

--- a/pkg/bytecode/encoding.go
+++ b/pkg/bytecode/encoding.go
@@ -16,7 +16,7 @@ import (
 
 type (
 	programJSON struct {
-		Version    int            `json:"version,omitempty"`
+		ISAVersion int            `json:"isaversion,omitempty"`
 		Source     *file.Source   `json:"source,omitempty"`
 		Registers  int            `json:"registers"`
 		Bytecode   []Instruction  `json:"bytecode"`

--- a/pkg/bytecode/opcode.go
+++ b/pkg/bytecode/opcode.go
@@ -218,7 +218,7 @@ func (op Opcode) String() string {
 	case OpLoadPropertyOptionalConst:
 		return "LOADPROC"
 	case OpApplyQuery:
-		return "APPLYQ"
+		return "QRY"
 	case OpLoadProperty:
 		return "LOADPR"
 	case OpLoadPropertyOptional:
@@ -264,7 +264,7 @@ func (op Opcode) String() string {
 
 	// Comparison Operations
 	case OpCmp:
-		return "COMP"
+		return "CMP"
 	case OpNot:
 		return "NOT"
 	case OpEq:
@@ -346,7 +346,7 @@ func (op Opcode) String() string {
 	case OpRand:
 		return "RAND"
 	case OpDispatch:
-		return "DSCH"
+		return "DISP"
 
 	// Host Function Operations
 	case OpHCall:
@@ -386,7 +386,7 @@ func (op Opcode) String() string {
 	case OpStream:
 		return "STRM"
 	case OpStreamIter:
-		return "STRMITER"
+		return "STRMI"
 
 	// Iterator Operations
 	case OpIter:
@@ -398,9 +398,9 @@ func (op Opcode) String() string {
 	case OpIterKey:
 		return "ITKEY"
 	case OpIterLimit:
-		return "ITLIMIT"
+		return "ITLIM"
 	case OpIterSkip:
-		return "ITSKIP"
+		return "ITSKP"
 	case OpFlatten:
 		return "FLATTEN"
 

--- a/pkg/bytecode/program.go
+++ b/pkg/bytecode/program.go
@@ -9,17 +9,21 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
+const Version = 1
+
 type (
 	Catch [3]int
 
 	Metadata struct {
-		AggregatePlans []AggregatePlan `json:"aggregatePlans"`
-		DebugSpans     []file.Span     `json:"debugSpans"`
-		Labels         map[int]string  `json:"labels"`
+		CompilerVersion   string          `json:"compilerVersion"`
+		OptimizationLevel int             `json:"optimizationLevel"`
+		AggregatePlans    []AggregatePlan `json:"aggregatePlans"`
+		DebugSpans        []file.Span     `json:"debugSpans"`
+		Labels            map[int]string  `json:"labels"`
 	}
 
 	Program struct {
-		Version    int
+		ISAVersion int
 		Source     *file.Source
 		Registers  int
 		Bytecode   []Instruction
@@ -30,8 +34,6 @@ type (
 		Metadata   Metadata
 	}
 )
-
-const ProgramVersion = 2
 
 func (p *Program) MarshalJSON() ([]byte, error) {
 	if p == nil {
@@ -51,7 +53,7 @@ func (p *Program) MarshalJSON() ([]byte, error) {
 	}
 
 	payload := programJSON{
-		Version:    p.Version,
+		ISAVersion: p.ISAVersion,
 		Source:     p.Source,
 		Registers:  p.Registers,
 		Bytecode:   p.Bytecode,
@@ -88,7 +90,7 @@ func (p *Program) UnmarshalJSON(data []byte) error {
 	}
 
 	p.Source = decoded.Source
-	p.Version = decoded.Version
+	p.ISAVersion = decoded.ISAVersion
 	p.Registers = decoded.Registers
 	p.Bytecode = decoded.Bytecode
 	p.Constants = constants

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -15,6 +15,8 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/parser"
 )
 
+const Version = "2.0.0"
+
 type Compiler struct {
 	opts *options
 }
@@ -93,15 +95,17 @@ func (c *Compiler) Compile(src *file.Source) (program *bytecode.Program, err err
 	}
 
 	program = &bytecode.Program{
-		Version: bytecode.ProgramVersion,
+		ISAVersion: bytecode.Version,
 		Functions: bytecode.Functions{
 			Host:        l.Ctx.Symbols.Functions(),
 			UserDefined: udfs,
 		},
 		Metadata: bytecode.Metadata{
-			AggregatePlans: l.Ctx.AggregatePlans(),
-			DebugSpans:     l.Ctx.Emitter.Spans(),
-			Labels:         l.Ctx.Emitter.Labels(),
+			CompilerVersion:   Version,
+			OptimizationLevel: int(c.opts.Level),
+			AggregatePlans:    l.Ctx.AggregatePlans(),
+			DebugSpans:        l.Ctx.Emitter.Spans(),
+			Labels:            l.Ctx.Emitter.Labels(),
 		},
 		Source:     src,
 		Bytecode:   l.Ctx.Emitter.Bytecode(),

--- a/pkg/vm/validation.go
+++ b/pkg/vm/validation.go
@@ -20,7 +20,7 @@ func validateProgramVersion(program *bytecode.Program) error {
 		return runtime.Error(runtime.ErrInvalidOperation, "unsupported bytecode version; recompile query")
 	}
 
-	if program.Version != bytecode.ProgramVersion {
+	if program.ISAVersion != bytecode.Version {
 		return runtime.Error(runtime.ErrInvalidOperation, "unsupported bytecode version; recompile query")
 	}
 

--- a/pkg/vm/vm_query_test.go
+++ b/pkg/vm/vm_query_test.go
@@ -44,8 +44,8 @@ func (q *queryStub) Copy() runtime.Value {
 
 func programWithApplyQueryConstSource(src runtime.Value) *bytecode.Program {
 	return &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Registers: 1,
+		ISAVersion: bytecode.Version,
+		Registers:  1,
 		Bytecode: []bytecode.Instruction{
 			bytecode.NewInstruction(bytecode.OpApplyQuery, bytecode.NewRegister(0), bytecode.NewConstant(0), bytecode.NewConstant(1)),
 			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -647,7 +647,6 @@ func analyzeQuery(query *file.Source) error {
 	}
 
 	c := compiler.New(compiler.WithOptimizationLevel(optLevel))
-	fmt.Printf("Optimization level: O%d\n", optLevel)
 
 	fullProf := *profiler
 

--- a/test/integration/optimization/op_concat_addconst_test.go
+++ b/test/integration/optimization/op_concat_addconst_test.go
@@ -138,7 +138,7 @@ func TestOpAddConst(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			program := &bytecode.Program{
-				Version: bytecode.ProgramVersion,
+				ISAVersion: bytecode.Version,
 				Constants: []runtime.Value{
 					tc.left,
 					tc.right,
@@ -185,10 +185,10 @@ func buildConcatProgram(values []runtime.Value, startReg, count int) *bytecode.P
 	instructions = append(instructions, bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(dst)))
 
 	return &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Constants: values,
-		Bytecode:  instructions,
-		Registers: dst + 1,
+		ISAVersion: bytecode.Version,
+		Constants:  values,
+		Bytecode:   instructions,
+		Registers:  dst + 1,
 	}
 }
 

--- a/test/integration/optimization/op_exists_test.go
+++ b/test/integration/optimization/op_exists_test.go
@@ -107,17 +107,17 @@ func programWithConst(value runtime.Value, ops ...bytecode.Instruction) *bytecod
 	instructions = append(instructions, ops...)
 
 	return &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Bytecode:  instructions,
-		Constants: []runtime.Value{value},
-		Registers: 3,
+		ISAVersion: bytecode.Version,
+		Bytecode:   instructions,
+		Constants:  []runtime.Value{value},
+		Registers:  3,
 	}
 }
 
 func programWithOps(ops ...bytecode.Instruction) *bytecode.Program {
 	return &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Bytecode:  ops,
-		Registers: 3,
+		ISAVersion: bytecode.Version,
+		Bytecode:   ops,
+		Registers:  3,
 	}
 }

--- a/test/integration/vm/vm_bytecode_validation_test.go
+++ b/test/integration/vm/vm_bytecode_validation_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestRejectsUnsupportedBytecodeVersion(t *testing.T) {
 	program := &bytecode.Program{
-		Version:   1,
-		Bytecode:  []bytecode.Instruction{bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0))},
-		Registers: 1,
+		ISAVersion: 0,
+		Bytecode:   []bytecode.Instruction{bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0))},
+		Registers:  1,
 	}
 
 	_, err := vm.New(program).Run(context.Background(), vm.NewDefaultEnvironment())
@@ -30,9 +30,9 @@ func TestRejectsUnsupportedBytecodeVersion(t *testing.T) {
 func TestFailsOnUnknownOpcode(t *testing.T) {
 	unknown := bytecode.Opcode(255)
 	program := &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Bytecode:  []bytecode.Instruction{bytecode.NewInstruction(unknown)},
-		Registers: 1,
+		ISAVersion: bytecode.Version,
+		Bytecode:   []bytecode.Instruction{bytecode.NewInstruction(unknown)},
+		Registers:  1,
 	}
 
 	_, err := vm.New(program).Run(context.Background(), vm.NewDefaultEnvironment())

--- a/test/integration/vm/vm_query_operand_test.go
+++ b/test/integration/vm/vm_query_operand_test.go
@@ -45,8 +45,8 @@ func (q *integrationQueryStub) Copy() runtime.Value {
 
 func programWithApplyQueryConstSource(src runtime.Value) *bytecode.Program {
 	return &bytecode.Program{
-		Version:   bytecode.ProgramVersion,
-		Registers: 1,
+		ISAVersion: bytecode.Version,
+		Registers:  1,
 		Bytecode: []bytecode.Instruction{
 			bytecode.NewInstruction(bytecode.OpApplyQuery, bytecode.NewRegister(0), bytecode.NewConstant(0), bytecode.NewConstant(1)),
 			bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the disassembler output, program metadata, and opcode naming conventions in the Ferret VM. The changes improve the clarity, structure, and extensibility of the disassembler output, unify versioning across the codebase, and standardize opcode mnemonics. The most important changes are grouped below by theme.

**Disassembler Output and Metadata Improvements:**

* Refactored the disassembler (`pkg/asm/disassembler.go`) to emit a structured, multi-section output including ISA and assembler version headers, metadata (compiler version, optimization level), and clearly separated sections for parameters, constants, user-defined functions (UDFs), and host functions. Added new helpers for formatting these sections and improved label handling for UDF entry points. [[1]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285R25-R127) [[2]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285R172-R229) [[3]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285R136)
* Added comments to disassembled program lines for constants, UDF calls, and now also for host function calls, making the output more informative. Introduced a `formatComment` helper for consistent comment formatting. [[1]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285L136-R267) [[2]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285L145-R276) [[3]](diffhunk://#diff-b05198d1190e64efe303de1c989335fb599cca3c3377594682d72a7e60fab285L166-R304) [[4]](diffhunk://#diff-148946c5e708553857852a09851086dffb7b0ae5c028250139a22ff0585090d4R19-R22)
* Added a `.meta` section with compiler version and optimization level, and improved program info comments (e.g., "regs consts params").

**Versioning and Metadata Unification:**

* Replaced the previous `Version` field with `ISAVersion` in `bytecode.Program`, and unified version constants and propagation throughout the codebase. The assembler version is now tracked separately. Compiler version and optimization level are now included in program metadata. [[1]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890R12-R26) [[2]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890L34-L35) [[3]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890L54-R56) [[4]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890L91-R93) [[5]](diffhunk://#diff-cc3debf20c35952d55c9b14d02264e3844ab54b046315c643108bbbc0d39f0d5R18-R19) [[6]](diffhunk://#diff-cc3debf20c35952d55c9b14d02264e3844ab54b046315c643108bbbc0d39f0d5L96-R105)
* Updated validation, serialization, and test code to use the new `ISAVersion` field and metadata structure. [[1]](diffhunk://#diff-db31ec7cc2d1424d832f4a34268f2dbd809f2f4b76d927aab5cc3c0eedc0f844L19-R19) [[2]](diffhunk://#diff-e82ad29484937724b2029397e7d4778b0538f4621171dcb7e9807ee7a002f2b7L23-R23) [[3]](diffhunk://#diff-7d764a0cb41a64b86ce4e1b45b41f00e4fb5a86a5e20435c9576497c7a2c197aL47-R47) [[4]](diffhunk://#diff-87afa0d1c6d274eea1ccea56256d3fe268f68ad5730c6196c74ce08d80dd9c61L141-R141)

**Opcode Mnemonic Updates:**

* Standardized and shortened opcode string representations for better readability in disassembly (e.g., `APPLYQ` → `QRY`, `COMP` → `CMP`, `DSCH` → `DISP`, `STRMITER` → `STRMI`, `ITLIMIT` → `ITLIM`, `ITSKIP` → `ITSKP`). [[1]](diffhunk://#diff-07cd3998a30901aab5af9ba2a09f8e5ec1d2ce9f09915bb0a7de86151b1447fcL221-R221) [[2]](diffhunk://#diff-07cd3998a30901aab5af9ba2a09f8e5ec1d2ce9f09915bb0a7de86151b1447fcL267-R267) [[3]](diffhunk://#diff-07cd3998a30901aab5af9ba2a09f8e5ec1d2ce9f09915bb0a7de86151b1447fcL349-R349) [[4]](diffhunk://#diff-07cd3998a30901aab5af9ba2a09f8e5ec1d2ce9f09915bb0a7de86151b1447fcL389-R389) [[5]](diffhunk://#diff-07cd3998a30901aab5af9ba2a09f8e5ec1d2ce9f09915bb0a7de86151b1447fcL401-R403)

**Other:**

* Removed a redundant CLI print statement for optimization level.

These changes collectively improve the maintainability, extensibility, and usability of the disassembler and bytecode handling in Ferret.