### PR TITLE
Chore/arg errors

### DIFF
--- a/pkg/bytecode/internal/persist/frame.go
+++ b/pkg/bytecode/internal/persist/frame.go
@@ -78,6 +78,7 @@ type (
 		CompilerVersion        string               `json:"compilerVersion,omitempty" msgpack:"compilerVersion,omitempty"`
 		AggregatePlans         []AggregatePlanFrame `json:"aggregatePlans,omitempty" msgpack:"aggregatePlans,omitempty"`
 		AggregateSelectorSlots []int                `json:"aggregateSelectorSlots,omitempty" msgpack:"aggregateSelectorSlots,omitempty"`
+		CallArgumentSpans      [][]SpanFrame        `json:"callArgumentSpans,omitempty" msgpack:"callArgumentSpans,omitempty"`
 		MatchFailTargets       []int                `json:"matchFailTargets,omitempty" msgpack:"matchFailTargets,omitempty"`
 		DebugSpans             []SpanFrame          `json:"debugSpans,omitempty" msgpack:"debugSpans,omitempty"`
 		OptimizationLevel      int                  `json:"optimizationLevel" msgpack:"optimizationLevel"`
@@ -196,6 +197,21 @@ func FromProgram(program *bytecode.Program) (ProgramFrame, error) {
 		}
 	}
 
+	callArgumentSpans := make([][]SpanFrame, len(program.Metadata.CallArgumentSpans))
+	for i, spans := range program.Metadata.CallArgumentSpans {
+		if len(spans) == 0 {
+			continue
+		}
+
+		callArgumentSpans[i] = make([]SpanFrame, len(spans))
+		for j, span := range spans {
+			callArgumentSpans[i][j] = SpanFrame{
+				Start: span.Start,
+				End:   span.End,
+			}
+		}
+	}
+
 	labels := make([]LabelFrame, 0, len(program.Metadata.Labels))
 	if len(program.Metadata.Labels) > 0 {
 		pcs := make([]int, 0, len(program.Metadata.Labels))
@@ -241,6 +257,7 @@ func FromProgram(program *bytecode.Program) (ProgramFrame, error) {
 			CompilerVersion:        program.Metadata.CompilerVersion,
 			AggregatePlans:         aggregatePlans,
 			AggregateSelectorSlots: append([]int(nil), program.Metadata.AggregateSelectorSlots...),
+			CallArgumentSpans:      callArgumentSpans,
 			MatchFailTargets:       append([]int(nil), program.Metadata.MatchFailTargets...),
 			DebugSpans:             debugSpans,
 			OptimizationLevel:      program.Metadata.OptimizationLevel,
@@ -343,6 +360,21 @@ func ToProgram(frame ProgramFrame) (*bytecode.Program, error) {
 		}
 	}
 
+	callArgumentSpans := make([][]source.Span, len(frame.Metadata.CallArgumentSpans))
+	for i, spans := range frame.Metadata.CallArgumentSpans {
+		if len(spans) == 0 {
+			continue
+		}
+
+		callArgumentSpans[i] = make([]source.Span, len(spans))
+		for j, span := range spans {
+			callArgumentSpans[i][j] = source.Span{
+				Start: span.Start,
+				End:   span.End,
+			}
+		}
+	}
+
 	var labels map[int]string
 	if len(frame.Metadata.Labels) > 0 {
 		labels = make(map[int]string, len(frame.Metadata.Labels))
@@ -376,6 +408,7 @@ func ToProgram(frame ProgramFrame) (*bytecode.Program, error) {
 			CompilerVersion:        frame.Metadata.CompilerVersion,
 			AggregatePlans:         aggregatePlans,
 			AggregateSelectorSlots: append([]int(nil), frame.Metadata.AggregateSelectorSlots...),
+			CallArgumentSpans:      callArgumentSpans,
 			MatchFailTargets:       append([]int(nil), frame.Metadata.MatchFailTargets...),
 			DebugSpans:             debugSpans,
 			OptimizationLevel:      frame.Metadata.OptimizationLevel,

--- a/pkg/bytecode/program.go
+++ b/pkg/bytecode/program.go
@@ -21,6 +21,7 @@ type (
 		CompilerVersion        string          `json:"compilerVersion"`
 		AggregatePlans         []AggregatePlan `json:"aggregatePlans"`
 		AggregateSelectorSlots []int           `json:"aggregateSelectorSlots,omitempty"`
+		CallArgumentSpans      [][]source.Span `json:"callArgumentSpans,omitempty"`
 		MatchFailTargets       []int           `json:"matchFailTargets,omitempty"`
 		DebugSpans             []source.Span   `json:"debugSpans"`
 		OptimizationLevel      int             `json:"optimizationLevel"`

--- a/pkg/bytecode/validation.go
+++ b/pkg/bytecode/validation.go
@@ -86,6 +86,24 @@ func validateMetadata(program *Program) error {
 		}
 	}
 
+	if len(program.Metadata.CallArgumentSpans) > 0 {
+		if len(program.Metadata.CallArgumentSpans) != bytecodeLen {
+			return fmt.Errorf("%w: call argument span metadata length %d does not match bytecode length %d", ErrInvalidProgram, len(program.Metadata.CallArgumentSpans), bytecodeLen)
+		}
+
+		for pc, spans := range program.Metadata.CallArgumentSpans {
+			for _, span := range spans {
+				if span.Start == -1 && span.End == -1 {
+					continue
+				}
+
+				if span.Start < 0 || span.End < span.Start {
+					return fmt.Errorf("%w: invalid call argument span at pc %d", ErrInvalidProgram, pc)
+				}
+			}
+		}
+	}
+
 	if len(program.Metadata.MatchFailTargets) > 0 {
 		if len(program.Metadata.MatchFailTargets) != bytecodeLen {
 			return fmt.Errorf("%w: match fail target metadata length %d does not match bytecode length %d", ErrInvalidProgram, len(program.Metadata.MatchFailTargets), bytecodeLen)

--- a/pkg/bytecode/validation_test.go
+++ b/pkg/bytecode/validation_test.go
@@ -51,6 +51,15 @@ func TestValidateProgram(t *testing.T) {
 			target: ErrInvalidProgram,
 		},
 		{
+			name: "invalid_call_argument_span_metadata",
+			program: withProgramMutation(func(program *Program) {
+				program.Metadata.CallArgumentSpans = [][]source.Span{
+					{{Start: 0, End: 1}},
+				}
+			}),
+			target: ErrInvalidProgram,
+		},
+		{
 			name: "required_constant_type_check",
 			program: withProgramMutation(func(program *Program) {
 				program.Bytecode[0] = NewInstruction(OpFail, NewConstant(0))
@@ -154,6 +163,7 @@ func validValidationProgram() *Program {
 			CompilerVersion:        "test",
 			AggregatePlans:         []AggregatePlan{NewAggregatePlan([]runtime.String{runtime.NewString("group")}, []AggregateKind{AggregateCount}, false)},
 			AggregateSelectorSlots: []int{-1, -1},
+			CallArgumentSpans:      nil,
 			MatchFailTargets:       []int{-1, -1},
 			DebugSpans:             []source.Span{{Start: 0, End: 6}, {Start: 7, End: 8}},
 			OptimizationLevel:      1,

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -114,6 +114,7 @@ func (c *Compiler) Compile(src *source.Source) (program *bytecode.Program, err e
 			OptimizationLevel:      int(c.opts.Level),
 			AggregatePlans:         l.Session.Program.AggregatePlans(),
 			AggregateSelectorSlots: l.Session.Program.Emitter.AggregateSelectorSlots(),
+			CallArgumentSpans:      l.Session.Program.Emitter.CallArgumentSpans(),
 			MatchFailTargets:       l.Session.Program.Emitter.MatchFailTargets(),
 			DebugSpans:             l.Session.Program.Emitter.Spans(),
 			Labels:                 l.Session.Program.Emitter.Labels(),

--- a/pkg/compiler/internal/core/emitter.go
+++ b/pkg/compiler/internal/core/emitter.go
@@ -8,15 +8,16 @@ import (
 )
 
 type Emitter struct {
-	labels           map[labelID]Label
-	patches          map[labelID][]labelRef
-	matchFailPatches map[labelID][]int
-	instructions     []bytecode.Instruction
-	selectorSlots    []int
-	matchFailTargets []int
-	spans            []source.Span
-	currentSpan      source.Span
-	nextLabelID      labelID
+	labels            map[labelID]Label
+	patches           map[labelID][]labelRef
+	matchFailPatches  map[labelID][]int
+	instructions      []bytecode.Instruction
+	selectorSlots     []int
+	matchFailTargets  []int
+	callArgumentSpans [][]source.Span
+	spans             []source.Span
+	currentSpan       source.Span
+	nextLabelID       labelID
 }
 
 func NewEmitter() *Emitter {
@@ -48,6 +49,20 @@ func (e *Emitter) AggregateSelectorSlots() []int {
 
 	out := make([]int, len(e.selectorSlots))
 	copy(out, e.selectorSlots)
+
+	return out
+}
+
+func (e *Emitter) CallArgumentSpans() [][]source.Span {
+	if len(e.callArgumentSpans) == 0 {
+		return nil
+	}
+
+	out := make([][]source.Span, len(e.callArgumentSpans))
+
+	for i, spans := range e.callArgumentSpans {
+		out[i] = e.copyCallArgumentSpans(spans)
+	}
 
 	return out
 }
@@ -200,6 +215,23 @@ func (e *Emitter) EmitAs(op bytecode.Opcode, dest bytecode.Operand, seq Register
 	}
 }
 
+func (e *Emitter) EmitAsWithCallArgumentSpans(op bytecode.Opcode, dest bytecode.Operand, seq RegisterSequence, spans []source.Span) {
+	if len(seq) > 0 {
+		src1 := seq[0]
+		src2 := seq[len(seq)-1]
+		e.emitInstructionWithMetadata(bytecode.Instruction{
+			Opcode:   op,
+			Operands: [3]bytecode.Operand{dest, src1, src2},
+		}, -1, -1, spans)
+		return
+	}
+
+	e.emitInstructionWithMetadata(bytecode.Instruction{
+		Opcode:   op,
+		Operands: [3]bytecode.Operand{dest, 0, 0},
+	}, -1, -1, spans)
+}
+
 // EmitABx emits an opcode with a destination and source value and a custom argument.
 func (e *Emitter) EmitABx(op bytecode.Opcode, dest bytecode.Operand, src bytecode.Operand, arg int) {
 	e.EmitABC(op, dest, src, bytecode.Operand(arg))
@@ -214,22 +246,34 @@ func (e *Emitter) EmitABC(op bytecode.Opcode, dest, src1, src2 bytecode.Operand)
 }
 
 func (e *Emitter) emitInstruction(ins bytecode.Instruction) {
-	e.emitInstructionWithMetadata(ins, -1, -1)
+	e.emitInstructionWithMetadata(ins, -1, -1, nil)
 }
 
 func (e *Emitter) emitInstructionWithSelectorSlot(ins bytecode.Instruction, selectorSlot int) {
-	e.emitInstructionWithMetadata(ins, selectorSlot, -1)
+	e.emitInstructionWithMetadata(ins, selectorSlot, -1, nil)
 }
 
 func (e *Emitter) emitInstructionWithMatchFailTarget(ins bytecode.Instruction, matchFailTarget int) {
-	e.emitInstructionWithMetadata(ins, -1, matchFailTarget)
+	e.emitInstructionWithMetadata(ins, -1, matchFailTarget, nil)
 }
 
-func (e *Emitter) emitInstructionWithMetadata(ins bytecode.Instruction, selectorSlot, matchFailTarget int) {
+func (e *Emitter) emitInstructionWithMetadata(ins bytecode.Instruction, selectorSlot, matchFailTarget int, callArgumentSpans []source.Span) {
 	e.instructions = append(e.instructions, ins)
 	e.selectorSlots = append(e.selectorSlots, selectorSlot)
 	e.matchFailTargets = append(e.matchFailTargets, matchFailTarget)
+	e.callArgumentSpans = append(e.callArgumentSpans, e.copyCallArgumentSpans(callArgumentSpans))
 	e.spans = append(e.spans, e.currentSpan)
+}
+
+func (e *Emitter) copyCallArgumentSpans(spans []source.Span) []source.Span {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	out := make([]source.Span, len(spans))
+	copy(out, spans)
+
+	return out
 }
 
 // SwapAB modifies an instruction at the given position to swap operands and update its operation and destination.
@@ -341,6 +385,7 @@ func (e *Emitter) swapInstructionWithSelectorSlot(label Label, ins bytecode.Inst
 	e.instructions[pos] = ins
 	e.selectorSlots[pos] = selectorSlot
 	e.matchFailTargets[pos] = -1
+	e.callArgumentSpans[pos] = nil
 }
 
 // swapInstruction swaps the operands of an instruction at a given position.
@@ -364,6 +409,9 @@ func (e *Emitter) insertInstructionWithSelectorSlot(label Label, ins bytecode.In
 	)
 	e.matchFailTargets = append(e.matchFailTargets[:pos],
 		append([]int{-1}, e.matchFailTargets[pos:]...)...,
+	)
+	e.callArgumentSpans = append(e.callArgumentSpans[:pos],
+		append([][]source.Span{nil}, e.callArgumentSpans[pos:]...)...,
 	)
 	e.spans = append(e.spans[:pos],
 		append([]source.Span{e.currentSpan}, e.spans[pos:]...)...,

--- a/pkg/compiler/internal/expr_call_compiler.go
+++ b/pkg/compiler/internal/expr_call_compiler.go
@@ -165,12 +165,15 @@ func (c *exprCallCompiler) compileFunctionCallWith(ctx fql.IFunctionCallContext,
 func (c *exprCallCompiler) compileFunctionCallByNameWith(ctx fql.IFunctionCallContext, name runtime.String, protected bool, seq core.RegisterSequence) bytecode.Operand {
 	nameStr := name.String()
 	builtinName := strings.ToUpper(nameStr)
+	argSpans := c.argumentSpansFromList(nil)
 
 	namespaced := strings.Contains(nameStr, runtime.NamespaceSeparator)
 	if ctx != nil {
 		if ns := ctx.Namespace(); ns != nil && ns.GetText() != "" {
 			namespaced = true
 		}
+
+		argSpans = c.argumentSpansFromList(ctx.ArgumentList())
 	}
 
 	var callCtx antlr.ParserRuleContext
@@ -182,7 +185,7 @@ func (c *exprCallCompiler) compileFunctionCallByNameWith(ctx fql.IFunctionCallCo
 
 	if !namespaced && c.ctx.Program.UDFs != nil && c.ctx.Function.UDFScope != nil {
 		if fn, ok := c.calls.ResolveUDF(ctx); ok {
-			return c.compileUdfCallWith(fn, protected, seq, callCtx)
+			return c.compileUdfCallWith(fn, protected, seq, callCtx, argSpans)
 		}
 	}
 
@@ -219,7 +222,7 @@ func (c *exprCallCompiler) compileFunctionCallByNameWith(ctx fql.IFunctionCallCo
 		}
 	}
 
-	return c.compileHostFunctionCallWith(name, protected, seq)
+	return c.compileHostFunctionCallWith(name, protected, seq, argSpans)
 }
 
 func (c *exprCallCompiler) reportFunctionArityError(ctx antlr.ParserRuleContext, name string, expected, got int) bytecode.Operand {
@@ -236,7 +239,7 @@ func (c *exprCallCompiler) reportFunctionArityError(ctx antlr.ParserRuleContext,
 	return bytecode.NoopOperand
 }
 
-func (c *exprCallCompiler) compileHostFunctionCallWith(name runtime.String, protected bool, seq core.RegisterSequence) bytecode.Operand {
+func (c *exprCallCompiler) compileHostFunctionCallWith(name runtime.String, protected bool, seq core.RegisterSequence, argSpans []source.Span) bytecode.Operand {
 	dest := c.ctx.Function.Registers.Allocate()
 	c.ctx.Program.Emitter.EmitLoadConst(dest, c.ctx.Function.Symbols.AddConstant(name))
 	c.ctx.Program.HostFunctions.Bind(name.String(), len(seq))
@@ -246,14 +249,14 @@ func (c *exprCallCompiler) compileHostFunctionCallWith(name runtime.String, prot
 		opcode = bytecode.OpProtectedHCall
 	}
 
-	c.ctx.Program.Emitter.EmitAs(opcode, dest, seq)
+	c.ctx.Program.Emitter.EmitAsWithCallArgumentSpans(opcode, dest, seq, argSpans)
 
 	c.ctx.Function.Types.Set(dest, core.TypeAny)
 
 	return dest
 }
 
-func (c *exprCallCompiler) compileUdfCallWith(fn *core.UDFInfo, protected bool, seq core.RegisterSequence, callCtx antlr.ParserRuleContext) bytecode.Operand {
+func (c *exprCallCompiler) compileUdfCallWith(fn *core.UDFInfo, protected bool, seq core.RegisterSequence, callCtx antlr.ParserRuleContext, argSpans []source.Span) bytecode.Operand {
 	args := c.prepareUdfCallArgs(fn, seq, callCtx)
 
 	dest := c.ctx.Function.Registers.Allocate()
@@ -264,7 +267,7 @@ func (c *exprCallCompiler) compileUdfCallWith(fn *core.UDFInfo, protected bool, 
 		opcode = bytecode.OpProtectedCall
 	}
 
-	c.ctx.Program.Emitter.EmitAs(opcode, dest, args)
+	c.ctx.Program.Emitter.EmitAsWithCallArgumentSpans(opcode, dest, args, argSpans)
 
 	c.ctx.Function.Types.Set(dest, core.TypeAny)
 
@@ -273,11 +276,12 @@ func (c *exprCallCompiler) compileUdfCallWith(fn *core.UDFInfo, protected bool, 
 
 func (c *exprCallCompiler) emitUdfTailCall(fn *core.UDFInfo, seq core.RegisterSequence, callCtx antlr.ParserRuleContext) {
 	args := c.prepareUdfCallArgs(fn, seq, callCtx)
+	argSpans := c.argumentSpansFromCall(callCtx)
 
 	dest := c.ctx.Function.Registers.Allocate()
 	c.ctx.Program.Emitter.EmitLoadConst(dest, c.ctx.Function.Symbols.AddConstant(runtime.NewInt(fn.ID)))
 
-	c.ctx.Program.Emitter.EmitAs(bytecode.OpTailCall, dest, args)
+	c.ctx.Program.Emitter.EmitAsWithCallArgumentSpans(bytecode.OpTailCall, dest, args, argSpans)
 }
 
 func (c *exprCallCompiler) prepareUdfCallArgs(fn *core.UDFInfo, seq core.RegisterSequence, callCtx antlr.ParserRuleContext) core.RegisterSequence {
@@ -372,6 +376,41 @@ func (c *exprCallCompiler) compileArgumentList(ctx fql.IArgumentListContext) cor
 	}
 
 	return seq
+}
+
+func (c *exprCallCompiler) argumentSpansFromCall(ctx antlr.ParserRuleContext) []source.Span {
+	call, ok := ctx.(fql.IFunctionCallContext)
+	if !ok {
+		return nil
+	}
+
+	return c.argumentSpansFromList(call.ArgumentList())
+}
+
+func (c *exprCallCompiler) argumentSpansFromList(ctx fql.IArgumentListContext) []source.Span {
+	if ctx == nil {
+		return nil
+	}
+
+	exps := ctx.AllExpression()
+	if len(exps) == 0 {
+		return nil
+	}
+
+	spans := make([]source.Span, len(exps))
+
+	for i, exp := range exps {
+		spans[i] = source.Span{Start: -1, End: -1}
+
+		prc, ok := exp.(antlr.ParserRuleContext)
+		if !ok {
+			continue
+		}
+
+		spans[i] = diagnostics.SpanFromRuleContext(prc)
+	}
+
+	return spans
 }
 
 func (c *exprCallCompiler) compileRangeOperator(ctx fql.IRangeOperatorContext) bytecode.Operand {

--- a/pkg/compiler/internal/optimization/pass_peephole_test.go
+++ b/pkg/compiler/internal/optimization/pass_peephole_test.go
@@ -679,7 +679,13 @@ func TestPeephole_RemapsCatchDebugSpansAndLabels(t *testing.T) {
 		},
 		Metadata: bytecode.Metadata{
 			AggregateSelectorSlots: []int{-1, 7, -1, 9},
-			MatchFailTargets:       []int{3, -1, -1, -1},
+			CallArgumentSpans: [][]source.Span{
+				{{Start: 8, End: 9}},
+				{{Start: 10, End: 11}},
+				nil,
+				{{Start: 12, End: 13}, {Start: 14, End: 15}},
+			},
+			MatchFailTargets: []int{3, -1, -1, -1},
 			DebugSpans: []source.Span{
 				{Start: 0, End: 1},
 				{Start: 2, End: 3},
@@ -717,6 +723,15 @@ func TestPeephole_RemapsCatchDebugSpansAndLabels(t *testing.T) {
 	expectedAggregateSelectorSlots := []int{-1, -1, 9}
 	if !reflect.DeepEqual(program.Metadata.AggregateSelectorSlots, expectedAggregateSelectorSlots) {
 		t.Fatalf("unexpected aggregate selector slots: %#v", program.Metadata.AggregateSelectorSlots)
+	}
+
+	expectedCallArgumentSpans := [][]source.Span{
+		{{Start: 8, End: 9}},
+		nil,
+		{{Start: 12, End: 13}, {Start: 14, End: 15}},
+	}
+	if !reflect.DeepEqual(program.Metadata.CallArgumentSpans, expectedCallArgumentSpans) {
+		t.Fatalf("unexpected call argument spans: %#v", program.Metadata.CallArgumentSpans)
 	}
 
 	expectedMatchFailTargets := []int{2, -1, -1}

--- a/pkg/compiler/internal/optimization/peephole_remap.go
+++ b/pkg/compiler/internal/optimization/peephole_remap.go
@@ -11,6 +11,7 @@ func applyPeepholeCompactionAndRemap(state *peepholeRunState) {
 
 	state.prog.Bytecode = newCode
 	remapAggregateSelectorSlots(state.prog, state.keep)
+	remapCallArgumentSpans(state.prog, state.keep)
 	remapMatchFailTargets(state.prog, indexMap, state.keep)
 	remapDebugSpans(state.prog, state.keep)
 	remapLabels(state.prog, indexMap)
@@ -148,6 +149,35 @@ func remapAggregateSelectorSlots(prog *bytecode.Program, keep []bool) {
 	}
 
 	prog.Metadata.AggregateSelectorSlots = updated
+}
+
+func remapCallArgumentSpans(prog *bytecode.Program, keep []bool) {
+	if prog == nil || len(prog.Metadata.CallArgumentSpans) == 0 {
+		return
+	}
+
+	if len(prog.Metadata.CallArgumentSpans) != len(keep) {
+		return
+	}
+
+	updated := make([][]source.Span, 0, len(prog.Metadata.CallArgumentSpans))
+
+	for i, spans := range prog.Metadata.CallArgumentSpans {
+		if !keep[i] {
+			continue
+		}
+
+		if len(spans) == 0 {
+			updated = append(updated, nil)
+			continue
+		}
+
+		next := make([]source.Span, len(spans))
+		copy(next, spans)
+		updated = append(updated, next)
+	}
+
+	prog.Metadata.CallArgumentSpans = updated
 }
 
 func remapMatchFailTargets(prog *bytecode.Program, indexMap []int, keep []bool) {

--- a/pkg/runtime/function_helper.go
+++ b/pkg/runtime/function_helper.go
@@ -1,17 +1,11 @@
 package runtime
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // ArgError creates an error for an invalid argument at the specified position.
 // The position is 0-based internally but reported as 1-based to users.
 func ArgError(err error, pos int) error {
-	return fmt.Errorf(
-		"%w at position %d - %w",
-		ErrInvalidArgument,
-		pos+1, err,
-	)
+	return newInvalidArgumentError(err, pos)
 }
 
 // ValidateArgs validates that the number of arguments is within the specified range.

--- a/pkg/runtime/invalid_argument_details.go
+++ b/pkg/runtime/invalid_argument_details.go
@@ -1,0 +1,16 @@
+package runtime
+
+import "errors"
+
+// InvalidArgumentDetails returns the outermost invalid argument position and cause.
+// The returned position is zero-based so callers can use it both for metadata lookups
+// and for user-facing messages after converting to a one-based index.
+func InvalidArgumentDetails(err error) (pos int, ok bool, cause error) {
+	var invalidErr *invalidArgumentError
+
+	if !errors.As(err, &invalidErr) || invalidErr == nil {
+		return 0, false, nil
+	}
+
+	return invalidErr.position, true, invalidErr.cause
+}

--- a/pkg/runtime/invalid_argument_details_test.go
+++ b/pkg/runtime/invalid_argument_details_test.go
@@ -1,0 +1,64 @@
+package runtime_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+func TestInvalidArgumentDetails(t *testing.T) {
+	cause := runtime.TypeErrorOf(runtime.True, runtime.TypeString)
+	err := runtime.ArgError(cause, 1)
+
+	if !errors.Is(err, runtime.ErrInvalidArgument) {
+		t.Fatalf("expected errors.Is(err, ErrInvalidArgument) to be true")
+	}
+
+	if !errors.Is(err, runtime.ErrInvalidType) {
+		t.Fatalf("expected errors.Is(err, ErrInvalidType) to be true")
+	}
+
+	pos, ok, wrappedCause := runtime.InvalidArgumentDetails(err)
+	if !ok {
+		t.Fatal("expected invalid argument details")
+	}
+
+	if got, want := pos, 1; got != want {
+		t.Fatalf("unexpected invalid argument position: got %d, want %d", got, want)
+	}
+
+	if wrappedCause == nil {
+		t.Fatal("expected wrapped cause")
+	}
+
+	if !errors.Is(wrappedCause, runtime.ErrInvalidType) {
+		t.Fatalf("expected wrapped cause to preserve invalid type classification")
+	}
+
+	if got, want := err.Error(), "invalid argument at position 2 - "+cause.Error(); got != want {
+		t.Fatalf("unexpected invalid argument error string: got %q, want %q", got, want)
+	}
+}
+
+func TestInvalidArgumentDetailsReturnsOutermostArgument(t *testing.T) {
+	inner := runtime.ArgError(runtime.TypeErrorOf(runtime.True, runtime.TypeString), 1)
+	outer := runtime.ArgError(inner, 0)
+
+	pos, ok, cause := runtime.InvalidArgumentDetails(outer)
+	if !ok {
+		t.Fatal("expected invalid argument details")
+	}
+
+	if got, want := pos, 0; got != want {
+		t.Fatalf("unexpected outer invalid argument position: got %d, want %d", got, want)
+	}
+
+	if cause == nil {
+		t.Fatal("expected outer invalid argument cause")
+	}
+
+	if got, want := cause.Error(), inner.Error(); got != want {
+		t.Fatalf("unexpected outer invalid argument cause: got %q, want %q", got, want)
+	}
+}

--- a/pkg/runtime/invalid_argument_error.go
+++ b/pkg/runtime/invalid_argument_error.go
@@ -1,0 +1,39 @@
+package runtime
+
+import "fmt"
+
+type invalidArgumentError struct {
+	cause    error
+	position int
+}
+
+func newInvalidArgumentError(err error, pos int) error {
+	return &invalidArgumentError{
+		cause:    err,
+		position: pos,
+	}
+}
+
+func (e *invalidArgumentError) Error() string {
+	if e == nil {
+		return ErrInvalidArgument.Error()
+	}
+
+	if e.cause == nil {
+		return fmt.Sprintf("%s at position %d", ErrInvalidArgument, e.position+1)
+	}
+
+	return fmt.Sprintf("%s at position %d - %s", ErrInvalidArgument, e.position+1, e.cause)
+}
+
+func (e *invalidArgumentError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.cause
+}
+
+func (e *invalidArgumentError) Is(target error) bool {
+	return target == ErrInvalidArgument
+}

--- a/pkg/runtime/type.go
+++ b/pkg/runtime/type.go
@@ -64,13 +64,12 @@ func NewType(pkg, name string, assert TypeMatcher) Type {
 	return &runtimeType{name: pkg + "." + name, assert: assert}
 }
 
-// NewTypeFor creates a new Type with the given package name and type name, using a TypeMatcher that checks if a value is of type T.
-// The pkg parameter is the package name of the type, and the name parameter is the name of the type.
-// The resulting Type's Name will be in the format "pkg.name". If pkg is empty, it will panic. If name is empty, it will panic.
+// NewTypeFor creates a new Type for T, using a TypeMatcher that checks if a value is of type T.
+// The resulting Type's Name is derived from T's package path and type name.
 // Example usage:
 //
 //	type MyType struct{}
-//	myType := runtime.NewTypeFor[MyType]("myPackage", "MyType")
+//	myType := runtime.NewTypeFor[MyType]()
 //
 // This will create a Type that matches any value of type MyType.
 func NewTypeFor[T Value]() Type {

--- a/pkg/runtime/type.go
+++ b/pkg/runtime/type.go
@@ -73,8 +73,9 @@ func NewType(pkg, name string, assert TypeMatcher) Type {
 //	myType := runtime.NewTypeFor[MyType]("myPackage", "MyType")
 //
 // This will create a Type that matches any value of type MyType.
-func NewTypeFor[T Value](pkg, name string) Type {
-	return NewType(pkg, name, func(v Value) bool {
+func NewTypeFor[T Value]() Type {
+	t := reflect.TypeFor[T]()
+	return NewType(t.PkgPath(), t.Name(), func(v Value) bool {
 		_, ok := v.(T)
 
 		return ok

--- a/pkg/stdlib/arrays/append.go
+++ b/pkg/stdlib/arrays/append.go
@@ -17,7 +17,7 @@ func Append(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	list, err := runtime.CastList(args[0])
+	list, err := runtime.CastArgAt[runtime.List](args, 0)
 
 	if err != nil {
 		return runtime.None, err
@@ -27,7 +27,7 @@ func Append(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	unique := runtime.False
 
 	if len(args) > 2 {
-		arg3, err := runtime.CastBoolean(args[2])
+		arg3, err := runtime.CastArgAt[runtime.Boolean](args, 2)
 
 		if err != nil {
 			return runtime.None, err

--- a/pkg/stdlib/io/fs/write.go
+++ b/pkg/stdlib/io/fs/write.go
@@ -34,7 +34,7 @@ func Write(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	params := defaultParams
 
 	if len(args) == 3 {
-		p, err := parseParams(args[2])
+		p, err := parseParams(args[2], 2)
 
 		if err != nil {
 			return runtime.None, runtime.Error(
@@ -80,8 +80,8 @@ var defaultParams = parsedParams{
 	ModeFlag: os.O_WRONLY | os.O_CREATE | os.O_TRUNC,
 }
 
-func parseParams(value runtime.Value) (parsedParams, error) {
-	err := runtime.ValidateType(value, runtime.TypeObject, runtime.TypeMap)
+func parseParams(value runtime.Value, pos int) (parsedParams, error) {
+	err := runtime.ValidateArgType(value, pos, runtime.TypeObject, runtime.TypeMap)
 
 	if err != nil {
 		return parsedParams{}, err

--- a/pkg/stdlib/io/net/http/request.go
+++ b/pkg/stdlib/io/net/http/request.go
@@ -30,7 +30,7 @@ func REQUEST(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 }
 
 func execMethod(ctx context.Context, method runtime.String, arg runtime.Value) (runtime.Value, error) {
-	params, err := runtime.CastMap(arg)
+	params, err := runtime.CastArg[runtime.Map](arg, 0)
 
 	if err != nil {
 		return runtime.None, err
@@ -126,7 +126,7 @@ func newParamsFrom(ctx context.Context, obj runtime.Map) (Params, error) {
 			return Params{}, err
 		}
 
-		if err := runtime.ValidateType(headers, runtime.TypeObject, runtime.TypeMap); err != nil {
+		if err := runtime.ValidateArgType(headers, 0, runtime.TypeObject, runtime.TypeMap); err != nil {
 			return Params{}, runtime.Error(err, ".headers")
 		}
 

--- a/pkg/stdlib/math/percentile.go
+++ b/pkg/stdlib/math/percentile.go
@@ -34,7 +34,7 @@ func Percentile(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 		return runtime.NewFloat(math.NaN()), nil
 	}
 
-	num, err := runtime.CastInt(args[1])
+	num, err := runtime.CastArg[runtime.Int](args[1], 1)
 
 	if err != nil {
 		return runtime.None, err
@@ -45,7 +45,7 @@ func Percentile(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 	method := "rank"
 
 	if len(args) > 2 {
-		if err := runtime.ValidateType(args[2], runtime.TypeString); err != nil {
+		if err := runtime.ValidateArgType(args[2], 2, runtime.TypeString); err != nil {
 			return runtime.None, err
 		}
 

--- a/pkg/stdlib/objects/values.go
+++ b/pkg/stdlib/objects/values.go
@@ -10,7 +10,7 @@ import (
 // @param {Map} map - Target map.
 // @return {Any[]} - Values of document returned in any order.
 func Values(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeMap); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeMap); err != nil {
 		return runtime.None, err
 	}
 

--- a/pkg/stdlib/path/base.go
+++ b/pkg/stdlib/path/base.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path.
 // @return {String} - The last component of the path.
 func Base(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.EmptyString, err
 	}
 

--- a/pkg/stdlib/path/clean.go
+++ b/pkg/stdlib/path/clean.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path.
 // @return {String} - The shortest path name equivalent to path
 func Clean(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.EmptyString, err
 	}
 

--- a/pkg/stdlib/path/dir.go
+++ b/pkg/stdlib/path/dir.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path.
 // @return {String} - The directory component of path.
 func Dir(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.EmptyString, err
 	}
 

--- a/pkg/stdlib/path/ext.go
+++ b/pkg/stdlib/path/ext.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path.
 // @return {String} - The extension of the last component of path.
 func Ext(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.EmptyString, err
 	}
 

--- a/pkg/stdlib/path/is_abs.go
+++ b/pkg/stdlib/path/is_abs.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path.
 // @return {Boolean} - True if the path is absolute.
 func IsAbs(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.False, err
 	}
 

--- a/pkg/stdlib/path/join.go
+++ b/pkg/stdlib/path/join.go
@@ -31,7 +31,7 @@ func Join(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 
 	for idx := runtime.ZeroInt; idx < size; idx++ {
 		arrElem, _ := arr.At(ctx, idx)
-		err := runtime.ValidateType(arrElem, runtime.TypeString)
+		err := runtime.ValidateArgType(arrElem, 0, runtime.TypeString)
 
 		if err != nil {
 			return runtime.None, err

--- a/pkg/stdlib/path/match.go
+++ b/pkg/stdlib/path/match.go
@@ -12,11 +12,11 @@ import (
 // @param {String} name - The name.
 // @return {Boolean} - True if the name matches the pattern.
 func Match(_ context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg1, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg1, 0, runtime.TypeString); err != nil {
 		return runtime.False, err
 	}
 
-	if err := runtime.ValidateType(arg2, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg2, 1, runtime.TypeString); err != nil {
 		return runtime.False, err
 	}
 

--- a/pkg/stdlib/path/separate.go
+++ b/pkg/stdlib/path/separate.go
@@ -11,7 +11,7 @@ import (
 // @param {String} path - The path
 // @return {Any[]} - First item is a directory component, and second is a filename component.
 func Separate(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateType(arg, runtime.TypeString); err != nil {
+	if err := runtime.ValidateArgType(arg, 0, runtime.TypeString); err != nil {
 		return runtime.None, err
 	}
 

--- a/pkg/stdlib/strings/fmt.go
+++ b/pkg/stdlib/strings/fmt.go
@@ -21,7 +21,7 @@ func Fmt(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	arg0, err := runtime.CastString(args[0])
+	arg0, err := runtime.CastArg[runtime.String](args[0], 0)
 
 	if err != nil {
 		return runtime.None, err

--- a/pkg/stdlib/strings/random.go
+++ b/pkg/stdlib/strings/random.go
@@ -23,7 +23,7 @@ var randSrc = rand.NewSource(time.Now().UnixNano())
 // @param {Int} len - The desired string length for the token. It must be greater than 0 and at most 65536.
 // @return {String} - A generated token consisting of lowercase letters, uppercase letters and numbers.
 func RandomToken(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	size, err := runtime.CastInt(arg)
+	size, err := runtime.CastArg[runtime.Int](arg, 0)
 
 	if err != nil {
 		return runtime.EmptyString, err

--- a/pkg/stdlib/strings/substr.go
+++ b/pkg/stdlib/strings/substr.go
@@ -16,7 +16,7 @@ func Substring(_ context.Context, args ...runtime.Value) (runtime.Value, error) 
 		return runtime.EmptyString, err
 	}
 
-	offsetArg, err := runtime.CastInt(args[1])
+	offsetArg, err := runtime.CastArg[runtime.Int](args[1], 1)
 
 	if err != nil {
 		return runtime.EmptyString, err

--- a/pkg/stdlib/types/is_nan.go
+++ b/pkg/stdlib/types/is_nan.go
@@ -10,7 +10,7 @@ import (
 // @param {Any} value - Input value of arbitrary type.
 // @return {Boolean} - Returns true if value is NaN, otherwise false.
 func IsNaN(_ context.Context, arg runtime.Value) (runtime.Value, error) {
-	val, err := runtime.CastFloat(arg)
+	val, err := runtime.CastArg[runtime.Float](arg, 0)
 
 	if err != nil {
 		return runtime.False, nil

--- a/pkg/vm/internal/data/regexp.go
+++ b/pkg/vm/internal/data/regexp.go
@@ -13,7 +13,10 @@ import (
 
 type Regexp regexp.Regexp
 
-var TypeRegexp = runtime.NewTypeFor[*Regexp](pkg, "Regexp")
+var TypeRegexp = runtime.NewType(pkg, "Regexp", func(value runtime.Value) bool {
+	_, ok := value.(*Regexp)
+	return ok
+})
 
 func NewRegexp(pattern runtime.String) (*Regexp, error) {
 	r, err := regexp.Compile(string(pattern))

--- a/pkg/vm/internal/diagnostics/runtime_error.go
+++ b/pkg/vm/internal/diagnostics/runtime_error.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/frame"
 )
 
@@ -99,7 +100,7 @@ func RuntimeErrorFromPanic(program *bytecode.Program, pc int, callStack []frame.
 			Message: fmt.Sprintf("%s. %s", message, cause.Error()),
 			Source:  program.Source,
 			Note:    stackNote(callStack),
-			Spans:   buildSpans(program, pc, callStack, ""),
+			Spans:   buildSpans(program, callStack, SpanAt(program, pc-1), ""),
 			Cause:   cause,
 		},
 	}
@@ -124,6 +125,8 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 	var cause error
 	var memberErr *MemberAccessError
 	var invariantErr *InvariantError
+	mainSpan := runtimeErrorSpan(program, pc, err)
+	argPos, hasArg, argCause := runtime.InvalidArgumentDetails(err)
 
 	switch {
 	case errors.Is(err, ErrDivisionByZero):
@@ -146,6 +149,19 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		}
 		label = memberErr.Label()
 		hint = memberErr.Hint()
+	case hasArg && (errors.Is(argCause, runtime.ErrInvalidType) || errors.Is(argCause, runtime.ErrInvalidArgumentType)):
+		index := argPos + 1
+		kind = diagnostics.TypeError
+		message = fmt.Sprintf("Invalid argument %d type", index)
+		label = fmt.Sprintf("argument %d type mismatch", index)
+		hint = fmt.Sprintf("Ensure argument %d matches the expected type", index)
+		cause = argCause
+
+		msg, cs := diagnostics.Unwrap(argCause)
+
+		if msg != nil && cs != nil {
+			cause = cs
+		}
 	case errors.Is(err, runtime.ErrInvalidType):
 		kind = diagnostics.TypeError
 		message = "Invalid type"
@@ -181,11 +197,24 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		hint = "Check the function arguments"
 		cause = err
 
-		msg, cs := diagnostics.Unwrap(err)
+		if hasArg {
+			index := argPos + 1
+			message = fmt.Sprintf("Invalid argument %d", index)
+			label = fmt.Sprintf("invalid argument %d", index)
+			hint = fmt.Sprintf("Check argument %d", index)
+			cause = argCause
 
-		if msg != nil && cs != nil {
-			message = diagnostics.FormatMessage(msg.Error())
-			cause = cs
+			_, cs := diagnostics.Unwrap(cause)
+			if cs != nil {
+				cause = cs
+			}
+		} else {
+			msg, cs := diagnostics.Unwrap(cause)
+
+			if msg != nil && cs != nil {
+				message = diagnostics.FormatMessage(msg.Error())
+				cause = cs
+			}
 		}
 	case errors.Is(err, ErrMissedParam):
 		kind = UnresolvedSymbol
@@ -234,8 +263,24 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 			Hint:    hint,
 			Note:    appendStackNote(note, callStack),
 			Source:  program.Source,
-			Spans:   buildSpans(program, pc, callStack, label),
+			Spans:   buildSpans(program, callStack, mainSpan, label),
 			Cause:   cause,
 		},
 	}
+}
+
+func runtimeErrorSpan(program *bytecode.Program, pc int, err error) source.Span {
+	mainSpan := SpanAt(program, pc-1)
+
+	argPos, ok, _ := runtime.InvalidArgumentDetails(err)
+	if !ok {
+		return mainSpan
+	}
+
+	argSpan := CallArgumentSpanAt(program, pc-1, argPos)
+	if argSpan.Start < 0 || argSpan.End < 0 {
+		return mainSpan
+	}
+
+	return argSpan
 }

--- a/pkg/vm/internal/diagnostics/span.go
+++ b/pkg/vm/internal/diagnostics/span.go
@@ -7,12 +7,33 @@ import (
 
 func SpanAt(program *bytecode.Program, pc int) source.Span {
 	if program == nil {
-		return source.Span{Start: -1, End: -1}
+		return invalidSpan()
 	}
 
 	if pc < 0 || pc >= len(program.Metadata.DebugSpans) {
-		return source.Span{Start: -1, End: -1}
+		return invalidSpan()
 	}
 
 	return program.Metadata.DebugSpans[pc]
+}
+
+func CallArgumentSpanAt(program *bytecode.Program, pc int, pos int) source.Span {
+	if program == nil || pos < 0 {
+		return invalidSpan()
+	}
+
+	if pc < 0 || pc >= len(program.Metadata.CallArgumentSpans) {
+		return invalidSpan()
+	}
+
+	spans := program.Metadata.CallArgumentSpans[pc]
+	if pos >= len(spans) {
+		return invalidSpan()
+	}
+
+	return spans[pos]
+}
+
+func invalidSpan() source.Span {
+	return source.Span{Start: -1, End: -1}
 }

--- a/pkg/vm/internal/diagnostics/stack.go
+++ b/pkg/vm/internal/diagnostics/stack.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 	"github.com/MontFerret/ferret/v2/pkg/vm/internal/frame"
 )
 
@@ -57,9 +58,9 @@ func callStackSpans(program *bytecode.Program, callStack []frame.TraceEntry) []d
 	return spans
 }
 
-func buildSpans(program *bytecode.Program, pc int, callStack []frame.TraceEntry, label string) []diagnostics.ErrorSpan {
+func buildSpans(program *bytecode.Program, callStack []frame.TraceEntry, mainSpan source.Span, label string) []diagnostics.ErrorSpan {
 	spans := callStackSpans(program, callStack)
-	spans = append(spans, diagnostics.NewMainErrorSpan(SpanAt(program, pc-1), label))
+	spans = append(spans, diagnostics.NewMainErrorSpan(mainSpan, label))
 
 	return spans
 }

--- a/test/integration/compiler/compiler_call_argument_lowering_test.go
+++ b/test/integration/compiler/compiler_call_argument_lowering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/compile"
 	"github.com/MontFerret/ferret/v2/test/spec/compile/inspect"
@@ -74,4 +75,45 @@ RETURN TEST(x, 2)
 			return nil
 		}, "non-literal arg keeps tracked move"),
 	})
+}
+
+func TestCallArgumentSpansRecordedForCallInstructions(t *testing.T) {
+	const query = "RETURN TEST(1 + 2, [3, 4])"
+
+	for _, level := range []compiler.OptimizationLevel{compiler.O0, compiler.O1} {
+		t.Run(fmt.Sprintf("O%d", level), func(t *testing.T) {
+			prog := compileWithLevel(t, level, query)
+
+			callIndex, ok := inspect.FindFirstOpcodeIndex(prog.Bytecode, bytecode.OpHCall)
+			if !ok {
+				t.Fatal("expected OpHCall in bytecode")
+			}
+
+			if got, want := len(prog.Metadata.CallArgumentSpans), len(prog.Bytecode); got != want {
+				t.Fatalf("unexpected call argument span metadata length: got %d, want %d", got, want)
+			}
+
+			for i, spans := range prog.Metadata.CallArgumentSpans {
+				if i == callIndex {
+					continue
+				}
+
+				if len(spans) != 0 {
+					t.Fatalf("expected non-call instruction %d to have no call argument spans, got %#v", i, spans)
+				}
+			}
+
+			spans := prog.Metadata.CallArgumentSpans[callIndex]
+			if got, want := len(spans), 2; got != want {
+				t.Fatalf("unexpected call argument span count: got %d, want %d", got, want)
+			}
+
+			wantFragments := []string{"1 + 2", "[3, 4]"}
+			for i, span := range spans {
+				if got := query[span.Start:span.End]; got != wantFragments[i] {
+					t.Fatalf("unexpected call argument %d span: got %q, want %q", i, got, wantFragments[i])
+				}
+			}
+		})
+	}
 }

--- a/test/integration/vm/vm_program_artifact_roundtrip_test.go
+++ b/test/integration/vm/vm_program_artifact_roundtrip_test.go
@@ -87,6 +87,10 @@ RETURN add(2, 3)
 				if !reflect.DeepEqual(original.Functions.UserDefined, decoded.Functions.UserDefined) {
 					t.Fatalf("udf metadata mismatch: got %#v, want %#v", decoded.Functions.UserDefined, original.Functions.UserDefined)
 				}
+
+				if !reflect.DeepEqual(original.Metadata.CallArgumentSpans, decoded.Metadata.CallArgumentSpans) {
+					t.Fatalf("call argument spans mismatch: got %#v, want %#v", decoded.Metadata.CallArgumentSpans, original.Metadata.CallArgumentSpans)
+				}
 			},
 		},
 		{

--- a/test/integration/vm/vm_runtime_error_format_test.go
+++ b/test/integration/vm/vm_runtime_error_format_test.go
@@ -3,9 +3,13 @@ package vm_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	pkgdiagnostics "github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 	"github.com/MontFerret/ferret/v2/pkg/vm"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/exec"
@@ -61,4 +65,83 @@ RETURN Outer()
 			}),
 		),
 	})
+}
+
+func TestRuntimeErrorFormatsArgumentTypeFailuresWithArgumentSpan(t *testing.T) {
+	const query = `RETURN BROKEN("ok", [1, 2])`
+
+	for _, level := range []compiler.OptimizationLevel{compiler.O0, compiler.O1} {
+		t.Run(fmt.Sprintf("O%d", level), func(t *testing.T) {
+			program, err := compiler.New(compiler.WithOptimizationLevel(level)).Compile(source.New("arg_type.fql", query))
+			if err != nil {
+				t.Fatalf("compile failed: %v", err)
+			}
+
+			instance, err := vm.New(program)
+			if err != nil {
+				t.Fatalf("vm init failed: %v", err)
+			}
+			defer func() {
+				if closeErr := instance.Close(); closeErr != nil {
+					t.Fatalf("vm close failed: %v", closeErr)
+				}
+			}()
+
+			env, err := vm.NewEnvironment([]vm.EnvironmentOption{
+				vm.WithFunction("BROKEN", func(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
+					return runtime.None, runtime.ValidateArgTypeAt(args, 1, runtime.TypeString, runtime.TypeInt, runtime.TypeObject)
+				}),
+			})
+			if err != nil {
+				t.Fatalf("environment init failed: %v", err)
+			}
+
+			_, err = instance.Run(context.Background(), env)
+			if err == nil {
+				t.Fatal("expected runtime error")
+			}
+
+			var runtimeErr *vm.RuntimeError
+			if !errors.As(err, &runtimeErr) {
+				t.Fatalf("expected runtime error, got %T", err)
+			}
+
+			if got, want := runtimeErr.Message, "Invalid argument 2 type"; got != want {
+				t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+			}
+
+			if got, want := runtimeErr.Kind, pkgdiagnostics.TypeError; got != want {
+				t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+			}
+
+			mainSpanFound := false
+			for _, span := range runtimeErr.Spans {
+				if !span.Main {
+					continue
+				}
+
+				mainSpanFound = true
+
+				if got, want := query[span.Span.Start:span.Span.End], "[1, 2]"; got != want {
+					t.Fatalf("unexpected main span fragment: got %q, want %q", got, want)
+				}
+
+				if got, want := span.Label, "argument 2 type mismatch"; got != want {
+					t.Fatalf("unexpected main span label: got %q, want %q", got, want)
+				}
+			}
+
+			if !mainSpanFound {
+				t.Fatal("expected a main error span")
+			}
+
+			if runtimeErr.Cause == nil {
+				t.Fatal("expected nested runtime error cause")
+			}
+
+			if got, want := runtimeErr.Cause.Error(), "expected String or Int or Object, but got Array"; got != want {
+				t.Fatalf("unexpected runtime error cause: got %q, want %q", got, want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This pull request introduces support for tracking and persisting call argument source spans throughout the compilation and validation pipeline. The main changes add a new `CallArgumentSpans` field to bytecode metadata, propagate it through serialization/deserialization, and ensure correct emission, copying, and validation of these spans. Several tests are updated and added to verify the new behavior.

**Call Argument Span Support**

* Added a `CallArgumentSpans` field to the `Metadata` struct in `program.go`, and updated all serialization/deserialization logic in `frame.go` to handle this new field. [[1]](diffhunk://#diff-1086c928e17aecdaa2c1ba05d7beed59a0ca8180928492ff8b861d129cf5d890R24) [[2]](diffhunk://#diff-19c101240bdfb2725afd1fc0909a481e6ea2361d0748ee7e948233a59e92a23dR81) [[3]](diffhunk://#diff-19c101240bdfb2725afd1fc0909a481e6ea2361d0748ee7e948233a59e92a23dR200-R214) [[4]](diffhunk://#diff-19c101240bdfb2725afd1fc0909a481e6ea2361d0748ee7e948233a59e92a23dR260) [[5]](diffhunk://#diff-19c101240bdfb2725afd1fc0909a481e6ea2361d0748ee7e948233a59e92a23dR363-R377) [[6]](diffhunk://#diff-19c101240bdfb2725afd1fc0909a481e6ea2361d0748ee7e948233a59e92a23dR411)
* Updated the `Emitter` in `emitter.go` to emit, copy, and expose call argument spans, including a new `EmitAsWithCallArgumentSpans` method and support for call argument spans in all relevant instruction emission and mutation paths. [[1]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5R17) [[2]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5R56-R69) [[3]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5R218-R234) [[4]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5L217-R278) [[5]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5R388) [[6]](diffhunk://#diff-61b29ee70e28951046a1807ece17407857c166e2f264a6fb54c593cc423cafc5R413-R415)
* Modified the function call compilation pipeline to extract argument spans from the parse tree and pass them through to emission, including changes to UDF and host function call compilation. [[1]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2R168-R176) [[2]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2L185-R188) [[3]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2L222-R225) [[4]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2L239-R242) [[5]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2L249-R259) [[6]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2L267-R270) [[7]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2R279-R284) [[8]](diffhunk://#diff-3b381c65c8e9d37d404d844bfceb8b129b4a7b4e378ec0f9126e4761a32d73d2R381-R415)

**Validation and Testing**

* Enhanced the program validator to check that `CallArgumentSpans` (if present) matches the bytecode length and that all spans are valid. Added a test case for invalid call argument span metadata. [[1]](diffhunk://#diff-f5eb7aa341fea926e26597f8a7bae766d9d9b621f867903e3878f748c360e3f3R89-R106) [[2]](diffhunk://#diff-1910b9cab6a160b27ad1fae85633d4ace8ac15b160e2296cb5e86580c924e278R53-R61)
* Updated and extended tests to cover the new field, including round-trip and peephole optimization tests. [[1]](diffhunk://#diff-1910b9cab6a160b27ad1fae85633d4ace8ac15b160e2296cb5e86580c924e278R166) [[2]](diffhunk://#diff-7b39295c53f5bc852126255cea9037904b85fd4cc93527e7a7afa92b6525b55cR682-R687) [[3]](diffhunk://#diff-7b39295c53f5bc852126255cea9037904b85fd4cc93527e7a7afa92b6525b55cR728-R736)

**Compiler Integration**

* The compiler now collects and persists call argument spans from the emitter into the program metadata.

These changes ensure that the source code spans of function call arguments are accurately tracked and available throughout the compilation and optimization process, improving diagnostics and tooling support.