### PR TITLE
Standardize runtime error messages for clarity

### DIFF
--- a/pkg/vm/call_udf.go
+++ b/pkg/vm/call_udf.go
@@ -46,7 +46,7 @@ func collectUdfArgsInto(dst, src []runtime.Value, start, count int) int {
 
 func callUdf(s *execState, desc *callDescriptor, udf *bytecode.UDF) error {
 	if desc.ArgCount != udf.Params {
-		return runtime.Error(runtime.ErrInvalidArgument, fmt.Sprintf("UDF '%s' expects %d arguments, got %d", desc.DisplayName, udf.Params, desc.ArgCount))
+		return runtime.Error(runtime.ErrInvalidArgumentNumber, fmt.Sprintf("UDF '%s' expects %d arguments, but got %d", desc.DisplayName, udf.Params, desc.ArgCount))
 	}
 
 	if udf.Registers <= 0 {
@@ -64,7 +64,7 @@ func tailCallUdf(s *execState, desc *callDescriptor, udf *bytecode.UDF) error {
 	argCount := desc.ArgCount
 
 	if udf.Params != desc.ArgCount {
-		return runtime.Error(runtime.ErrInvalidArgument, fmt.Sprintf("UDF '%s' expects %d arguments, got %d", desc.DisplayName, udf.Params, desc.ArgCount))
+		return runtime.Error(runtime.ErrInvalidArgumentNumber, fmt.Sprintf("UDF '%s' expects %d arguments, but got %d", desc.DisplayName, udf.Params, desc.ArgCount))
 	}
 
 	if udf.Registers <= 0 {

--- a/pkg/vm/call_udf.go
+++ b/pkg/vm/call_udf.go
@@ -46,7 +46,10 @@ func collectUdfArgsInto(dst, src []runtime.Value, start, count int) int {
 
 func callUdf(s *execState, desc *callDescriptor, udf *bytecode.UDF) error {
 	if desc.ArgCount != udf.Params {
-		return runtime.Error(runtime.ErrInvalidArgumentNumber, fmt.Sprintf("UDF '%s' expects %d arguments, but got %d", desc.DisplayName, udf.Params, desc.ArgCount))
+		return runtime.Error(
+			runtime.ErrInvalidArgumentNumber,
+			fmt.Sprintf("UDF '%s' expects %d %s, but got %d", desc.DisplayName, udf.Params, argumentWordForCount(udf.Params), desc.ArgCount),
+		)
 	}
 
 	if udf.Registers <= 0 {
@@ -64,7 +67,10 @@ func tailCallUdf(s *execState, desc *callDescriptor, udf *bytecode.UDF) error {
 	argCount := desc.ArgCount
 
 	if udf.Params != desc.ArgCount {
-		return runtime.Error(runtime.ErrInvalidArgumentNumber, fmt.Sprintf("UDF '%s' expects %d arguments, but got %d", desc.DisplayName, udf.Params, desc.ArgCount))
+		return runtime.Error(
+			runtime.ErrInvalidArgumentNumber,
+			fmt.Sprintf("UDF '%s' expects %d %s, but got %d", desc.DisplayName, udf.Params, argumentWordForCount(udf.Params), desc.ArgCount),
+		)
 	}
 
 	if udf.Registers <= 0 {

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -47,6 +47,7 @@ const (
 
 const (
 	ArityError       diagnostics.Kind = rtdiagnostics.ArityError
+	InvalidArgument  diagnostics.Kind = rtdiagnostics.InvalidArgument
 	NullDereferenced diagnostics.Kind = rtdiagnostics.NullDereferenced
 	DivideByZero     diagnostics.Kind = rtdiagnostics.DivideByZero
 	ModuloByZero     diagnostics.Kind = rtdiagnostics.ModuloByZero

--- a/pkg/vm/errors.go
+++ b/pkg/vm/errors.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	rtdiagnostics "github.com/MontFerret/ferret/v2/pkg/vm/internal/diagnostics"
@@ -66,3 +67,19 @@ var (
 	ErrPoolExhausted         = errors.New("pool exhausted")
 	ErrPoolClosed            = errors.New("pool closed")
 )
+
+func argumentWordForCount(count int) string {
+	if count == 1 {
+		return "argument"
+	}
+
+	return "arguments"
+}
+
+func argumentWordForExpectation(expected string) string {
+	if strings.TrimSpace(expected) == "1" {
+		return "argument"
+	}
+
+	return "arguments"
+}

--- a/pkg/vm/internal/diagnostics/errors.go
+++ b/pkg/vm/internal/diagnostics/errors.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	ArityError       diagnostics.Kind = "ArityError"
+	InvalidArgument  diagnostics.Kind = "InvalidArgument"
 	NullDereferenced diagnostics.Kind = "NullDereference"
 	DivideByZero     diagnostics.Kind = "DivideByZero"
 	ModuloByZero     diagnostics.Kind = "ModuloByZero"
@@ -46,10 +47,11 @@ func CheckDivisionByZero(
 			program,
 			pc,
 			DivideByZero,
-			"Division by zero",
+			"division by zero",
 			"attempt to divide by zero",
 			"Ensure the denominator is non-zero before division",
-			"Add a conditional check before dividing",
+			"",
+			ErrDivisionByZero,
 		)
 	}
 
@@ -77,10 +79,11 @@ func CheckModuloByZero(
 			program,
 			pc,
 			ModuloByZero,
-			"Modulo by zero",
+			"modulo by zero",
 			"attempt to take modulo by zero",
 			"Ensure the divisor is non-zero before modulo",
-			"Add a conditional check before modulo",
+			"",
+			ErrModuloByZero,
 		)
 	}
 

--- a/pkg/vm/internal/diagnostics/member_access.go
+++ b/pkg/vm/internal/diagnostics/member_access.go
@@ -63,16 +63,30 @@ func (e *MemberAccessError) Label() string {
 		return ""
 	}
 
-	access := string(e.Access)
-	if access == "" {
-		access = "member"
-	}
+	switch e.Access {
+	case MemberAccessIndex:
+		if e.Member == "" {
+			return "index cannot be read from this value"
+		}
 
-	if runtime.TypeName(e.Target) == "" {
-		return fmt.Sprintf("%s access", access)
-	}
+		return fmt.Sprintf("index %s cannot be read from this value", e.Member)
+	case MemberAccessProperty:
+		if e.Member == "" {
+			return "property cannot be read from this value"
+		}
 
-	return fmt.Sprintf("%s access on %s", access, e.Target)
+		return fmt.Sprintf("property %q cannot be read from this value", e.Member)
+	default:
+		if e.Member == "" {
+			return "member cannot be read from this value"
+		}
+
+		return fmt.Sprintf("member %q cannot be read from this value", e.Member)
+	}
+}
+
+func (e *MemberAccessError) Note() string {
+	return e.Error()
 }
 
 func (e *MemberAccessError) Hint() string {

--- a/pkg/vm/internal/diagnostics/runtime_error.go
+++ b/pkg/vm/internal/diagnostics/runtime_error.go
@@ -3,7 +3,6 @@ package diagnostics
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
@@ -34,17 +33,17 @@ func NewRuntimeError(
 	label string,
 	hint string,
 	note string,
+	cause error,
 ) *RuntimeError {
-	return &RuntimeError{
-		Diagnostic: &diagnostics.Diagnostic{
-			Kind:    kind,
-			Message: message,
-			Hint:    hint,
-			Note:    note,
-			Source:  program.Source,
-			Spans:   []diagnostics.ErrorSpan{diagnostics.NewMainErrorSpan(SpanAt(program, pc-1), label)},
-		},
-	}
+	return newRuntimeErrorWithSpec(program, nil, runtimeDiagnosticSpec{
+		Cause:   cause,
+		Kind:    kind,
+		Span:    SpanAt(program, pc-1),
+		Hint:    hint,
+		Label:   label,
+		Message: message,
+		Note:    note,
+	})
 }
 
 func NewRuntimeErrorSet(size int) *RuntimeErrorSet {
@@ -87,23 +86,21 @@ func WrapRuntimeError(program *bytecode.Program, pc int, callStack []frame.Trace
 }
 
 func RuntimeErrorFromPanic(program *bytecode.Program, pc int, callStack []frame.TraceEntry, r any) error {
-	message := "unexpected runtime panic"
 	cause := fmt.Errorf("panic: %v", r)
 
 	if err, ok := r.(error); ok {
 		cause = err
 	}
 
-	return &RuntimeError{
-		Diagnostic: &diagnostics.Diagnostic{
-			Kind:    diagnostics.UnexpectedError,
-			Message: fmt.Sprintf("%s. %s", message, cause.Error()),
-			Source:  program.Source,
-			Note:    stackNote(callStack),
-			Spans:   buildSpans(program, callStack, SpanAt(program, pc-1), ""),
-			Cause:   cause,
-		},
-	}
+	return newRuntimeErrorWithSpec(program, callStack, runtimeDiagnosticSpec{
+		Cause:   cause,
+		Kind:    diagnostics.UnexpectedError,
+		Span:    SpanAt(program, pc-1),
+		Hint:    "This indicates an internal VM bug; please report it with the query and stack context",
+		Label:   "panic occurred during VM execution",
+		Message: "unexpected runtime panic",
+		Note:    panicValueNote(r),
+	})
 }
 
 func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEntry, err error) *RuntimeError {
@@ -117,169 +114,146 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		return runtimeError
 	}
 
-	kind := diagnostics.Unknown
-	message := ""
-	label := ""
-	hint := ""
-	note := ""
-	var cause error
+	spec := runtimeDiagnosticSpec{
+		Cause:   err,
+		Kind:    UncaughtError,
+		Span:    runtimeErrorSpan(program, pc, err),
+		Message: "runtime error",
+	}
+
 	var memberErr *MemberAccessError
 	var invariantErr *InvariantError
-	mainSpan := runtimeErrorSpan(program, pc, err)
 	argPos, hasArg, argCause := runtime.InvalidArgumentDetails(err)
+
+	if hasArg {
+		for {
+			_, ok, nestedCause := runtime.InvalidArgumentDetails(argCause)
+			if !ok {
+				break
+			}
+
+			argCause = nestedCause
+		}
+	}
 
 	switch {
 	case errors.Is(err, ErrDivisionByZero):
-		kind = DivideByZero
-		message = "Division by zero"
-		label = "denominator evaluates to zero"
-		hint = "Ensure the denominator is non-zero before division"
-		cause = ErrDivisionByZero
+		spec.Kind = DivideByZero
+		spec.Message = "division by zero"
+		spec.Label = "denominator evaluates to zero"
+		spec.Hint = "Ensure the denominator is non-zero before division"
+		spec.Cause = ErrDivisionByZero
 	case errors.Is(err, ErrModuloByZero):
-		kind = ModuloByZero
-		message = "Modulo by zero"
-		label = "divisor evaluates to zero"
-		hint = "Ensure the divisor is non-zero before modulo"
-		cause = ErrModuloByZero
+		spec.Kind = ModuloByZero
+		spec.Message = "modulo by zero"
+		spec.Label = "divisor evaluates to zero"
+		spec.Hint = "Ensure the divisor is non-zero before modulo"
+		spec.Cause = ErrModuloByZero
 	case errors.As(err, &memberErr):
-		kind = diagnostics.TypeError
-		message = memberErr.Error()
-
-		if message != "" {
-			message = strings.ToUpper(message[:1]) + message[1:]
-		}
-
-		label = memberErr.Label()
-		hint = memberErr.Hint()
+		spec.Kind = diagnostics.TypeError
+		spec.Message = "invalid type"
+		spec.Label = memberErr.Label()
+		spec.Note = memberErr.Note()
+		spec.Hint = memberErr.Hint()
+		spec.Cause = runtime.ErrInvalidType
 	case hasArg && (errors.Is(argCause, runtime.ErrInvalidType) || errors.Is(argCause, runtime.ErrInvalidArgumentType)):
 		index := argPos + 1
-		kind = diagnostics.TypeError
-		message = fmt.Sprintf("Invalid argument %d type", index)
-		label = fmt.Sprintf("argument %d type mismatch", index)
-		hint = fmt.Sprintf("Ensure argument %d matches the expected type", index)
-		cause = argCause
+		cause, detail := unwrapRuntimeDetail(argCause)
 
-		msg, cs := diagnostics.Unwrap(argCause)
-
-		if msg != nil && cs != nil {
-			cause = cs
-		}
+		spec.Kind = diagnostics.TypeError
+		spec.Message = "invalid argument type"
+		spec.Label = fmt.Sprintf("argument %d has incompatible type", index)
+		spec.Note = argumentDetailNote(index, detail)
+		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidType):
-		kind = diagnostics.TypeError
-		message = "Invalid type"
-		label = "type mismatch"
-		hint = "Ensure the value has the expected type"
-		cause = err
+		cause, detail := unwrapRuntimeDetail(err)
 
-		msg, cs := diagnostics.Unwrap(err)
-
-		if msg != nil && cs != nil {
-			message = diagnostics.FormatMessage(msg.Error())
-			cause = cs
-		}
+		spec.Kind = diagnostics.TypeError
+		spec.Message = "invalid type"
+		spec.Label = "value has incompatible type"
+		spec.Note = detailNote(detail)
+		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidArgumentType):
-		kind = diagnostics.TypeError
-		message = "Invalid argument type"
-		hint = "Ensure the argument types match the function signature"
-		cause = err
-		msg, cs := diagnostics.Unwrap(err)
+		cause, detail := unwrapRuntimeDetail(err)
 
-		if msg != nil && cs != nil {
-			message = diagnostics.FormatMessage(msg.Error())
-			cause = cs
-		}
+		spec.Kind = diagnostics.TypeError
+		spec.Message = "invalid argument type"
+		spec.Label = "argument has incompatible type"
+		spec.Note = detailNote(detail)
+		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidArgumentNumber):
-		kind = ArityError
-		message = "Invalid number of arguments"
-		label = "invalid number of arguments"
-		hint = "Check the function signature for the expected argument count"
-		cause = runtime.ErrInvalidArgumentNumber
+		cause, detail := unwrapRuntimeDetail(err)
 
-		_, detail := diagnostics.Unwrap(err)
-		if detail != nil {
-			s := detail.Error()
-			if len(s) > 0 {
-				note = strings.ToUpper(s[:1]) + s[1:]
-			}
-		}
+		spec.Kind = ArityError
+		spec.Message = "invalid number of arguments"
+		spec.Note = detailNote(detail)
+		spec.Label = arityLabel(spec.Note)
+		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidArgument):
-		kind = ArityError
-		message = "Invalid argument"
-		hint = "Check the function arguments"
-		cause = err
+		spec.Kind = InvalidArgument
+		spec.Message = "invalid argument"
 
 		if hasArg {
 			index := argPos + 1
-			message = fmt.Sprintf("Invalid argument %d", index)
-			label = fmt.Sprintf("invalid argument %d", index)
-			hint = fmt.Sprintf("Check argument %d", index)
-			cause = argCause
+			cause, detail := unwrapRuntimeDetail(argCause)
 
-			_, cs := diagnostics.Unwrap(cause)
-			if cs != nil {
-				cause = cs
-			}
+			spec.Label = fmt.Sprintf("argument %d is invalid", index)
+			spec.Note = argumentDetailNote(index, detail)
+			spec.Cause = cause
 		} else {
-			msg, cs := diagnostics.Unwrap(cause)
+			cause, detail := unwrapRuntimeDetail(err)
 
-			if msg != nil && cs != nil {
-				message = diagnostics.FormatMessage(msg.Error())
-				cause = cs
-			}
+			spec.Label = "invalid argument"
+			spec.Note = detailNote(detail)
+			spec.Cause = cause
 		}
 	case errors.Is(err, ErrMissedParam):
-		kind = UnresolvedSymbol
-		message = "Missing parameter"
-		label = "missing parameter"
-		hint = "Provide all required parameters"
-		cause = err
+		cause, detail := unwrapRuntimeDetail(err)
+		name := detailNote(detail)
+
+		spec.Kind = UnresolvedSymbol
+		spec.Message = "missing parameter"
+		spec.Cause = cause
+
+		if name == "" {
+			spec.Label = "parameter was not provided"
+			spec.Hint = "Provide all required parameters before executing this query"
+			break
+		}
+
+		spec.Label = fmt.Sprintf("parameter '%s' was not provided", name)
+		spec.Note = fmt.Sprintf("this query requires parameter '%s'", name)
+		spec.Hint = fmt.Sprintf("Provide a value for %s before executing this query", name)
 	case errors.Is(err, ErrUnresolvedFunction):
-		kind = UnresolvedSymbol
-		message = "Unresolved function"
-		label = "unresolved function"
-		hint = "Ensure the function is registered and accessible in the current context"
-		note = "Add the function to the registry if it's missing"
-		cause = ErrUnresolvedFunction
+		spec.Kind = UnresolvedSymbol
+		spec.Message = "unresolved function"
+		spec.Label = "function is not registered"
+		spec.Note = "function could not be resolved in the current registry"
+		spec.Hint = "Register the function before executing this query"
+		spec.Cause = ErrUnresolvedFunction
 	case errors.Is(err, ErrInvalidFunctionName):
-		kind = UnresolvedSymbol
-		message = "Invalid function name"
-		label = "invalid function name"
-		hint = "Ensure the function name is valid and does not contain illegal characters"
-		cause = ErrInvalidFunctionName
+		spec.Kind = UnresolvedSymbol
+		spec.Message = "invalid function name"
+		spec.Label = "function name is invalid"
+		spec.Note = "host call target must resolve to a string function name"
+		spec.Hint = "Pass a string function name to the host call"
+		spec.Cause = ErrInvalidFunctionName
 	case errors.As(err, &invariantErr):
-		kind = diagnostics.UnexpectedError
-		message = "VM invariant violation"
-		if invariantErr.Message != "" {
-			message = invariantErr.Message
-		}
-
-		label = "internal invariant violated"
-		hint = "This indicates an internal VM bug; please report it with the query and stack context"
-		cause = invariantErr.Cause
+		spec.Kind = diagnostics.UnexpectedError
+		spec.Message = "vm invariant violation"
+		spec.Label = "internal invariant violated"
+		spec.Note = detailNote(invariantErr.Message)
+		spec.Hint = "This indicates an internal VM bug; please report it with the query and stack context"
+		spec.Cause = invariantErr.Cause
 	default:
-		kind = UncaughtError
-		msg, cs := diagnostics.Unwrap(err)
+		cause, detail := unwrapRuntimeDetail(err)
 
-		if msg != nil && cs != nil {
-			message = diagnostics.FormatMessage(msg.Error())
-			cause = cs
-		} else {
-			message = "Runtime Error"
-			cause = err
-		}
+		spec.Message = fallbackRuntimeMessage(err)
+		spec.Note = detailNote(detail)
+		spec.Cause = cause
 	}
 
-	return &RuntimeError{
-		Diagnostic: &diagnostics.Diagnostic{
-			Kind:    kind,
-			Message: message,
-			Hint:    hint,
-			Note:    appendStackNote(note, callStack),
-			Source:  program.Source,
-			Spans:   buildSpans(program, callStack, mainSpan, label),
-			Cause:   cause,
-		},
-	}
+	return newRuntimeErrorWithSpec(program, callStack, spec)
 }
 
 func runtimeErrorSpan(program *bytecode.Program, pc int, err error) source.Span {

--- a/pkg/vm/internal/diagnostics/runtime_error.go
+++ b/pkg/vm/internal/diagnostics/runtime_error.go
@@ -158,7 +158,7 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Cause = runtime.ErrInvalidType
 	case hasArg && (errors.Is(argCause, runtime.ErrInvalidType) || errors.Is(argCause, runtime.ErrInvalidArgumentType)):
 		index := argPos + 1
-		cause, detail := unwrapRuntimeDetail(argCause)
+		detail, cause := unwrapRuntimeDetail(argCause)
 
 		spec.Kind = diagnostics.TypeError
 		spec.Message = "invalid argument type"
@@ -166,7 +166,7 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Note = argumentDetailNote(index, detail)
 		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidType):
-		cause, detail := unwrapRuntimeDetail(err)
+		detail, cause := unwrapRuntimeDetail(err)
 
 		spec.Kind = diagnostics.TypeError
 		spec.Message = "invalid type"
@@ -174,7 +174,7 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Note = detailNote(detail)
 		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidArgumentType):
-		cause, detail := unwrapRuntimeDetail(err)
+		detail, cause := unwrapRuntimeDetail(err)
 
 		spec.Kind = diagnostics.TypeError
 		spec.Message = "invalid argument type"
@@ -182,7 +182,7 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Note = detailNote(detail)
 		spec.Cause = cause
 	case errors.Is(err, runtime.ErrInvalidArgumentNumber):
-		cause, detail := unwrapRuntimeDetail(err)
+		detail, cause := unwrapRuntimeDetail(err)
 
 		spec.Kind = ArityError
 		spec.Message = "invalid number of arguments"
@@ -195,20 +195,20 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 
 		if hasArg {
 			index := argPos + 1
-			cause, detail := unwrapRuntimeDetail(argCause)
+			detail, cause := unwrapRuntimeDetail(argCause)
 
 			spec.Label = fmt.Sprintf("argument %d is invalid", index)
 			spec.Note = argumentDetailNote(index, detail)
 			spec.Cause = cause
 		} else {
-			cause, detail := unwrapRuntimeDetail(err)
+			detail, cause := unwrapRuntimeDetail(err)
 
 			spec.Label = "invalid argument"
 			spec.Note = detailNote(detail)
 			spec.Cause = cause
 		}
 	case errors.Is(err, ErrMissedParam):
-		cause, detail := unwrapRuntimeDetail(err)
+		detail, cause := unwrapRuntimeDetail(err)
 		name := detailNote(detail)
 
 		spec.Kind = UnresolvedSymbol
@@ -246,7 +246,7 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Hint = "This indicates an internal VM bug; please report it with the query and stack context"
 		spec.Cause = invariantErr.Cause
 	default:
-		cause, detail := unwrapRuntimeDetail(err)
+		detail, cause := unwrapRuntimeDetail(err)
 
 		spec.Message = fallbackRuntimeMessage(err)
 		spec.Note = detailNote(detail)

--- a/pkg/vm/internal/diagnostics/runtime_error_builder.go
+++ b/pkg/vm/internal/diagnostics/runtime_error_builder.go
@@ -1,0 +1,103 @@
+package diagnostics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/frame"
+)
+
+type runtimeDiagnosticSpec struct {
+	Cause   error
+	Kind    diagnostics.Kind
+	Hint    string
+	Label   string
+	Message string
+	Note    string
+	Span    source.Span
+}
+
+func newRuntimeErrorWithSpec(
+	program *bytecode.Program,
+	callStack []frame.TraceEntry,
+	spec runtimeDiagnosticSpec,
+) *RuntimeError {
+	if spec.Hint == "" {
+		spec.Hint = synthesizeRuntimeHint(spec)
+	}
+
+	return &RuntimeError{
+		Diagnostic: &diagnostics.Diagnostic{
+			Kind:    spec.Kind,
+			Message: spec.Message,
+			Hint:    spec.Hint,
+			Note:    appendStackNote(spec.Note, callStack),
+			Source:  runtimeErrorSource(program),
+			Spans:   buildSpans(program, callStack, spec.Span, spec.Label),
+			Cause:   spec.Cause,
+		},
+	}
+}
+
+func runtimeErrorSource(program *bytecode.Program) *source.Source {
+	if program == nil {
+		return nil
+	}
+
+	return program.Source
+}
+
+func unwrapRuntimeDetail(err error) (error, string) {
+	if err == nil {
+		return nil, ""
+	}
+
+	wrapped, detail := diagnostics.Unwrap(err)
+	if wrapped == nil || detail == nil {
+		return err, ""
+	}
+
+	text := strings.TrimSpace(detail.Error())
+	if text == "" {
+		return wrapped, ""
+	}
+
+	return wrapped, text
+}
+
+func detailNote(detail string) string {
+	return strings.TrimSpace(detail)
+}
+
+func argumentDetailNote(index int, detail string) string {
+	detail = detailNote(detail)
+	if detail == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(detail, "expected ") {
+		return fmt.Sprintf("argument %d expects %s", index, strings.TrimPrefix(detail, "expected "))
+	}
+
+	if strings.HasPrefix(detail, "expects ") || strings.HasPrefix(detail, "must ") {
+		return fmt.Sprintf("argument %d %s", index, detail)
+	}
+
+	return fmt.Sprintf("argument %d: %s", index, detail)
+}
+
+func fallbackRuntimeMessage(err error) string {
+	cause, _ := unwrapRuntimeDetail(err)
+	if cause == nil {
+		return "runtime error"
+	}
+
+	return strings.TrimSpace(cause.Error())
+}
+
+func panicValueNote(r any) string {
+	return fmt.Sprintf("panic value: %v", r)
+}

--- a/pkg/vm/internal/diagnostics/runtime_error_builder.go
+++ b/pkg/vm/internal/diagnostics/runtime_error_builder.go
@@ -50,22 +50,22 @@ func runtimeErrorSource(program *bytecode.Program) *source.Source {
 	return program.Source
 }
 
-func unwrapRuntimeDetail(err error) (error, string) {
+func unwrapRuntimeDetail(err error) (string, error) {
 	if err == nil {
-		return nil, ""
+		return "", nil
 	}
 
 	wrapped, detail := diagnostics.Unwrap(err)
 	if wrapped == nil || detail == nil {
-		return err, ""
+		return "", err
 	}
 
 	text := strings.TrimSpace(detail.Error())
 	if text == "" {
-		return wrapped, ""
+		return "", wrapped
 	}
 
-	return wrapped, text
+	return text, wrapped
 }
 
 func detailNote(detail string) string {
@@ -90,7 +90,7 @@ func argumentDetailNote(index int, detail string) string {
 }
 
 func fallbackRuntimeMessage(err error) string {
-	cause, _ := unwrapRuntimeDetail(err)
+	_, cause := unwrapRuntimeDetail(err)
 	if cause == nil {
 		return "runtime error"
 	}

--- a/pkg/vm/internal/diagnostics/runtime_error_hint.go
+++ b/pkg/vm/internal/diagnostics/runtime_error_hint.go
@@ -1,0 +1,154 @@
+package diagnostics
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	pkgdiagnostics "github.com/MontFerret/ferret/v2/pkg/diagnostics"
+)
+
+type arityExpectation struct {
+	CallTarget string
+	Expected   string
+	AtLeast    bool
+}
+
+var (
+	runtimeArityCallablePattern  = regexp.MustCompile(`^(.+?) expects (.+) argument[s]?, (?:but )?got \d+$`)
+	runtimeArityExpectedPattern  = regexp.MustCompile(`^expected number of arguments (.+), but got \d+$`)
+	runtimeArityAtLeastPattern   = regexp.MustCompile(`^expected at least (\d+) argument[s]?, but got \d+$`)
+	runtimeArgumentTypePattern   = regexp.MustCompile(`^argument (\d+) expects (.+), but got .+$`)
+	runtimeExpectedTypePattern   = regexp.MustCompile(`^expected (.+), but got .+$`)
+	runtimeArgumentMustBePattern = regexp.MustCompile(`^argument (\d+) must be (.+)$`)
+	runtimeMustBePattern         = regexp.MustCompile(`^must be (.+)$`)
+)
+
+func synthesizeRuntimeHint(spec runtimeDiagnosticSpec) string {
+	switch spec.Kind {
+	case ArityError:
+		return synthesizeArityHint(spec.Note)
+	case InvalidArgument:
+		return synthesizeInvalidArgumentHint(spec.Note)
+	case pkgdiagnostics.TypeError:
+		return synthesizeTypeHint(spec.Message, spec.Note)
+	default:
+		return ""
+	}
+}
+
+func arityLabel(note string) string {
+	expectation, ok := parseArityExpectation(note)
+	if !ok || expectation.CallTarget == "" {
+		return "wrong number of arguments"
+	}
+
+	return fmt.Sprintf("wrong number of arguments in call to %s", expectation.CallTarget)
+}
+
+func synthesizeArityHint(note string) string {
+	expectation, ok := parseArityExpectation(note)
+	if !ok {
+		return ""
+	}
+
+	target := "this call"
+	if expectation.CallTarget != "" {
+		target = expectation.CallTarget
+	}
+
+	if expectation.AtLeast {
+		return fmt.Sprintf(
+			"Pass at least %s %s to %s",
+			expectation.Expected,
+			argumentWord(expectation.Expected),
+			target,
+		)
+	}
+
+	return fmt.Sprintf(
+		"Pass %s %s to %s",
+		expectation.Expected,
+		argumentWord(expectation.Expected),
+		target,
+	)
+}
+
+func synthesizeTypeHint(message string, note string) string {
+	if match := runtimeArgumentTypePattern.FindStringSubmatch(strings.TrimSpace(note)); len(match) == 3 {
+		return fmt.Sprintf("Convert argument %s to %s before this call", match[1], match[2])
+	}
+
+	if match := runtimeExpectedTypePattern.FindStringSubmatch(strings.TrimSpace(note)); len(match) == 2 {
+		if message == "invalid argument type" {
+			return fmt.Sprintf("Pass a value of type %s to this call", match[1])
+		}
+
+		return fmt.Sprintf("Convert the value to %s before this operation", match[1])
+	}
+
+	return ""
+}
+
+func synthesizeInvalidArgumentHint(note string) string {
+	trimmed := strings.TrimSpace(note)
+
+	if match := runtimeArgumentMustBePattern.FindStringSubmatch(trimmed); len(match) == 3 {
+		return fmt.Sprintf("Pass argument %s with a value that is %s", match[1], match[2])
+	}
+
+	if match := runtimeMustBePattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return fmt.Sprintf("Pass a value that is %s", match[1])
+	}
+
+	return ""
+}
+
+func parseArityExpectation(note string) (arityExpectation, bool) {
+	trimmed := strings.TrimSpace(note)
+
+	if match := runtimeArityAtLeastPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return arityExpectation{
+			Expected: match[1],
+			AtLeast:  true,
+		}, true
+	}
+
+	if match := runtimeArityExpectedPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return arityExpectation{
+			Expected: strings.TrimSpace(match[1]),
+		}, true
+	}
+
+	if match := runtimeArityCallablePattern.FindStringSubmatch(trimmed); len(match) == 3 {
+		return arityExpectation{
+			CallTarget: normalizeCallTarget(match[1]),
+			Expected:   strings.TrimSpace(match[2]),
+		}, true
+	}
+
+	return arityExpectation{}, false
+}
+
+func normalizeCallTarget(subject string) string {
+	subject = strings.TrimSpace(subject)
+
+	switch {
+	case strings.HasPrefix(subject, "UDF '") && strings.HasSuffix(subject, "'"):
+		return strings.TrimSuffix(strings.TrimPrefix(subject, "UDF '"), "'")
+	case strings.HasPrefix(subject, "function '") && strings.HasSuffix(subject, "'"):
+		return strings.TrimSuffix(strings.TrimPrefix(subject, "function '"), "'")
+	case strings.HasPrefix(subject, "'") && strings.HasSuffix(subject, "'"):
+		return strings.TrimSuffix(strings.TrimPrefix(subject, "'"), "'")
+	default:
+		return subject
+	}
+}
+
+func argumentWord(expected string) string {
+	if strings.TrimSpace(expected) == "1" {
+		return "argument"
+	}
+
+	return "arguments"
+}

--- a/pkg/vm/vm_host_plan_test.go
+++ b/pkg/vm/vm_host_plan_test.go
@@ -216,7 +216,7 @@ func TestRunReturnsUnresolvedFunctionWhenHostCacheEntryIsMissing(t *testing.T) {
 
 	_, err := instance.Run(context.Background(), env)
 	rtErr := assertUnresolvedFunctionError(t, err)
-	if rtErr.Message != "Unresolved function" {
+	if rtErr.Message != "unresolved function" {
 		t.Fatalf("expected unresolved function message, got %q", rtErr.Message)
 	}
 }

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -3143,7 +3143,7 @@ func TestUdfRuntimeMessageUsesSourceSpellingName(t *testing.T) {
 		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 	}
 
-	if got, want := rtErr.Note, "UDF 'boo' expects 1 arguments, but got 0"; got != want {
+	if got, want := rtErr.Note, "UDF 'boo' expects 1 argument, but got 0"; got != want {
 		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
 	}
 

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -98,7 +98,7 @@ func assertUnresolvedFunctionError(t *testing.T, err error) *RuntimeError {
 		t.Fatalf("expected runtime error, got %T", err)
 	}
 
-	if got, want := rtErr.Message, "Unresolved function"; got != want {
+	if got, want := rtErr.Message, "unresolved function"; got != want {
 		t.Fatalf("unexpected message: got %q, want %q", got, want)
 	}
 
@@ -759,17 +759,17 @@ func TestOpLoadParam_MissingParamsPreserveRuntimeError(t *testing.T) {
 		t.Fatal("expected missing parameter error")
 	}
 
-	if !strings.Contains(err.Error(), "Missing parameter") {
+	if !strings.Contains(err.Error(), "missing parameter") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	cause := errors.Unwrap(err)
-	if cause == nil {
-		cause = err
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) {
+		t.Fatalf("expected runtime error, got %T", err)
 	}
 
-	if !strings.Contains(cause.Error(), "@bar") {
-		t.Fatalf("expected missing parameter name in error, got %v (cause: %v)", err, cause)
+	if !strings.Contains(rtErr.Note, "@bar") {
+		t.Fatalf("expected missing parameter note to mention @bar, got %q", rtErr.Note)
 	}
 }
 
@@ -806,17 +806,12 @@ func TestWarmupMissingParamsSingleSiteReturnsRuntimeError(t *testing.T) {
 		t.Fatalf("expected single runtime error, got set")
 	}
 
-	if got, want := rtErr.Message, "Missing parameter"; got != want {
+	if got, want := rtErr.Message, "missing parameter"; got != want {
 		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 	}
 
-	cause := errors.Unwrap(rtErr)
-	if cause == nil {
-		t.Fatal("expected missing parameter cause")
-	}
-
-	if !strings.Contains(cause.Error(), "@foo") {
-		t.Fatalf("expected missing parameter name in cause, got %v", cause)
+	if !strings.Contains(rtErr.Note, "@foo") {
+		t.Fatalf("expected missing parameter note to mention @foo, got %q", rtErr.Note)
 	}
 }
 
@@ -852,12 +847,12 @@ func TestWarmupMissingParamsAggregateDifferentSlotsByCallsite(t *testing.T) {
 		t.Fatal("expected aggregated runtime errors")
 	}
 
-	if !strings.Contains(first.Cause.Error(), "@foo") {
-		t.Fatalf("expected first missing param cause to mention @foo, got %v", first.Cause)
+	if !strings.Contains(first.Note, "@foo") {
+		t.Fatalf("expected first missing param note to mention @foo, got %q", first.Note)
 	}
 
-	if !strings.Contains(last.Cause.Error(), "@bar") {
-		t.Fatalf("expected second missing param cause to mention @bar, got %v", last.Cause)
+	if !strings.Contains(last.Note, "@bar") {
+		t.Fatalf("expected second missing param note to mention @bar, got %q", last.Note)
 	}
 }
 
@@ -892,12 +887,12 @@ func TestWarmupMissingParamsAggregateRepeatedCallsites(t *testing.T) {
 			t.Fatalf("expected runtime error at index %d", i)
 		}
 
-		if got, want := rtErr.Message, "Missing parameter"; got != want {
+		if got, want := rtErr.Message, "missing parameter"; got != want {
 			t.Fatalf("unexpected runtime error message at index %d: got %q, want %q", i, got, want)
 		}
 
-		if !strings.Contains(rtErr.Cause.Error(), "@foo") {
-			t.Fatalf("expected missing parameter cause at index %d to mention @foo, got %v", i, rtErr.Cause)
+		if !strings.Contains(rtErr.Note, "@foo") {
+			t.Fatalf("expected missing parameter note at index %d to mention @foo, got %q", i, rtErr.Note)
 		}
 	}
 }
@@ -935,7 +930,7 @@ func TestWarmupHostResolutionPrecedesMissingParamAggregation(t *testing.T) {
 		t.Fatalf("expected runtime error, got %T", err)
 	}
 
-	if got, want := rtErr.Message, "Unresolved function"; got != want {
+	if got, want := rtErr.Message, "unresolved function"; got != want {
 		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 	}
 }
@@ -2408,6 +2403,295 @@ func TestOpFail_InvalidMessageTypeReturnsTypeError(t *testing.T) {
 	if !strings.Contains(strings.ToLower(rtErr.Format()), "invalid type") {
 		t.Fatalf("expected invalid type error, got:\n%s", rtErr.Format())
 	}
+
+	if got, want := rtErr.Message, "invalid type"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "expected String, but got Int"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Hint, "Convert the value to String before this operation"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != runtime.ErrInvalidType.Error() {
+		t.Fatalf("expected invalid type cause, got %v", rtErr.Cause)
+	}
+}
+
+func TestToRuntimeError_InvalidArgumentTypeUsesArgumentSpanAndSeparatesNoteFromCause(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "F(1,true)"),
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpCall, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{
+				{Start: 0, End: 9},
+			},
+			CallArgumentSpans: [][]source.Span{
+				{
+					{Start: 2, End: 3},
+					{Start: 4, End: 8},
+				},
+			},
+		},
+	}
+
+	rtErr := rtdiagnostics.ToRuntimeError(
+		program,
+		1,
+		nil,
+		runtime.ArgError(runtime.TypeErrorOf(runtime.True, runtime.TypeString), 1),
+	)
+
+	if rtErr == nil {
+		t.Fatal("expected runtime error")
+	}
+
+	if got, want := rtErr.Kind, diagnostics.TypeError; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "invalid argument type"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "argument 2 expects String, but got Boolean"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Hint, "Convert argument 2 to String before this call"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != runtime.ErrInvalidType.Error() {
+		t.Fatalf("expected invalid type cause, got %v", rtErr.Cause)
+	}
+
+	formatted := rtErr.Format()
+	if !strings.Contains(formatted, "--> test.fql:1:5") {
+		t.Fatalf("expected argument span highlight, got:\n%s", formatted)
+	}
+
+	if !strings.Contains(formatted, "argument 2 has incompatible type") {
+		t.Fatalf("expected concrete argument label, got:\n%s", formatted)
+	}
+
+	if !strings.Contains(formatted, "Hint: Convert argument 2 to String before this call") {
+		t.Fatalf("expected synthesized argument type hint in formatted output, got:\n%s", formatted)
+	}
+
+	if !strings.Contains(formatted, "Caused by: invalid type") {
+		t.Fatalf("expected technical cause in formatted output, got:\n%s", formatted)
+	}
+}
+
+func TestToRuntimeError_InvalidArgumentUsesDedicatedKind(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "F(-1)"),
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpCall, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{
+				{Start: 0, End: 5},
+			},
+			CallArgumentSpans: [][]source.Span{
+				{
+					{Start: 2, End: 4},
+				},
+			},
+		},
+	}
+
+	rtErr := rtdiagnostics.ToRuntimeError(
+		program,
+		1,
+		nil,
+		runtime.ArgError(runtime.Error(runtime.ErrInvalidArgument, "must be positive"), 0),
+	)
+
+	if rtErr == nil {
+		t.Fatal("expected runtime error")
+	}
+
+	if got, want := rtErr.Kind, InvalidArgument; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "invalid argument"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "argument 1 must be positive"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Hint, "Pass argument 1 with a value that is positive"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != runtime.ErrInvalidArgument.Error() {
+		t.Fatalf("expected invalid argument cause, got %v", rtErr.Cause)
+	}
+
+	if formatted := rtErr.Format(); !strings.Contains(formatted, "argument 1 is invalid") {
+		t.Fatalf("expected concrete invalid argument label, got:\n%s", formatted)
+	}
+}
+
+func TestToRuntimeError_GenericInvalidArgumentWithoutStructuredDetailOmitsHint(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "F(1)"),
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpCall, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{
+				{Start: 0, End: 4},
+			},
+		},
+	}
+
+	rtErr := rtdiagnostics.ToRuntimeError(
+		program,
+		1,
+		nil,
+		runtime.Error(runtime.ErrInvalidArgument, "constraint violated"),
+	)
+
+	if rtErr == nil {
+		t.Fatal("expected runtime error")
+	}
+
+	if rtErr.Hint != "" {
+		t.Fatalf("expected opaque invalid argument hint to be omitted, got %q", rtErr.Hint)
+	}
+}
+
+func TestToRuntimeError_GenericArityErrorSynthesizesHint(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "F(1)"),
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpCall, bytecode.NewRegister(0)),
+		},
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{
+				{Start: 0, End: 4},
+			},
+		},
+	}
+
+	rtErr := rtdiagnostics.ToRuntimeError(program, 1, nil, runtime.ArityError(1, 2, 3))
+	if rtErr == nil {
+		t.Fatal("expected runtime error")
+	}
+
+	mainSpan := rtErr.Spans[0]
+	if got, want := mainSpan.Label, "wrong number of arguments"; got != want {
+		t.Fatalf("unexpected runtime error label: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "expected number of arguments 2-3, but got 1"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Hint, "Pass 2-3 arguments to this call"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+}
+
+func TestToRuntimeError_MissingParameterPromotesDetailIntoNote(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "@foo"),
+		Bytecode: []bytecode.Instruction{
+			bytecode.NewInstruction(bytecode.OpLoadParam, bytecode.NewRegister(0), bytecode.Operand(1)),
+		},
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{
+				{Start: 0, End: 4},
+			},
+		},
+	}
+
+	rtErr := rtdiagnostics.ToRuntimeError(program, 1, nil, runtime.Error(ErrMissedParam, "@foo"))
+	if rtErr == nil {
+		t.Fatal("expected runtime error")
+	}
+
+	if got, want := rtErr.Kind, UnresolvedSymbol; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "missing parameter"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "this query requires parameter '@foo'"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Hint, "Provide a value for @foo before executing this query"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != ErrMissedParam.Error() {
+		t.Fatalf("expected missing parameter cause, got %v", rtErr.Cause)
+	}
+
+	formatted := rtErr.Format()
+	if !strings.Contains(formatted, "parameter '@foo' was not provided") {
+		t.Fatalf("expected parameter-specific label, got:\n%s", formatted)
+	}
+
+	if !strings.Contains(formatted, "Note: this query requires parameter '@foo'") {
+		t.Fatalf("expected factual note in formatted output, got:\n%s", formatted)
+	}
+}
+
+func TestRuntimeErrorFromPanicUsesStableMessageAndBugHint(t *testing.T) {
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Source:     source.New("test.fql", "RETURN 1"),
+		Metadata: bytecode.Metadata{
+			DebugSpans: []source.Span{{Start: 0, End: 6}},
+		},
+	}
+
+	err := rtdiagnostics.RuntimeErrorFromPanic(program, 1, nil, errors.New("boom"))
+
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) {
+		t.Fatalf("expected runtime error, got %T", err)
+	}
+
+	if got, want := rtErr.Kind, diagnostics.UnexpectedError; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "unexpected runtime panic"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "panic value: boom"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if !strings.Contains(rtErr.Hint, "internal VM bug") {
+		t.Fatalf("expected bug-report hint, got %q", rtErr.Hint)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != "boom" {
+		t.Fatalf("expected panic cause to be preserved, got %v", rtErr.Cause)
+	}
 }
 
 func TestStrictWarmupInvalidTargetReturnsInvalidFunctionName(t *testing.T) {
@@ -2619,6 +2903,22 @@ func TestWrapRuntimeErrorSingleWarmupFailureReturnsRuntimeError(t *testing.T) {
 	if errors.As(err, &rtErrSet) {
 		t.Fatalf("expected single runtime error, got set")
 	}
+
+	if got, want := rtErr.Kind, UnresolvedSymbol; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "invalid function name"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "host call target must resolve to a string function name"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
+	if rtErr.Cause == nil || rtErr.Cause.Error() != ErrInvalidFunctionName.Error() {
+		t.Fatalf("expected invalid function name cause, got %v", rtErr.Cause)
+	}
 }
 
 func TestNearestBoundaryPrefersCatchOverProtectedUnwind(t *testing.T) {
@@ -2719,10 +3019,11 @@ func TestWrapRuntimeErrorPreservesExistingNoteAndDoesNotDuplicateStackDetails(t 
 		program,
 		1,
 		UncaughtError,
-		"Runtime error",
+		"runtime error",
 		"",
 		"",
 		"existing note",
+		nil,
 	)
 
 	stack := []frame.TraceEntry{
@@ -2834,7 +3135,27 @@ func TestUdfRuntimeMessageUsesSourceSpellingName(t *testing.T) {
 		t.Fatalf("expected runtime error, got %T", err)
 	}
 
+	if got, want := rtErr.Kind, ArityError; got != want {
+		t.Fatalf("unexpected runtime error kind: got %s, want %s", got, want)
+	}
+
+	if got, want := rtErr.Message, "invalid number of arguments"; got != want {
+		t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
+	}
+
+	if got, want := rtErr.Note, "UDF 'boo' expects 1 arguments, but got 0"; got != want {
+		t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+	}
+
 	formatted := rtErr.Format()
+	if got, want := rtErr.Hint, "Pass 1 argument to boo"; got != want {
+		t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+	}
+
+	if !strings.Contains(formatted, "Hint: Pass 1 argument to boo") {
+		t.Fatalf("expected callable-aware arity hint, got:\n%s", formatted)
+	}
+
 	if !strings.Contains(formatted, "'boo'") {
 		t.Fatalf("expected source-spelling name in runtime diagnostic, got:\n%s", formatted)
 	}
@@ -2873,8 +3194,12 @@ func TestInvariantInRecoverModeBecomesUnexpectedRuntimeError(t *testing.T) {
 		t.Fatalf("unexpected kind: got %s, want %s", rtErr.Kind, diagnostics.UnexpectedError)
 	}
 
-	if !strings.Contains(strings.ToLower(rtErr.Message), "invalid aggregate plan index") {
+	if got, want := rtErr.Message, "vm invariant violation"; got != want {
 		t.Fatalf("unexpected message: %q", rtErr.Message)
+	}
+
+	if got, want := rtErr.Note, "invalid aggregate plan index"; got != want {
+		t.Fatalf("unexpected note: %q", rtErr.Note)
 	}
 }
 
@@ -2907,8 +3232,12 @@ func TestInvalidCollectorTypeInvariantInRecoverModeBecomesUnexpectedRuntimeError
 		t.Fatalf("unexpected kind: got %s, want %s", rtErr.Kind, diagnostics.UnexpectedError)
 	}
 
-	if !strings.Contains(strings.ToLower(rtErr.Message), "invalid collector configuration") {
+	if got, want := rtErr.Message, "vm invariant violation"; got != want {
 		t.Fatalf("unexpected message: %q", rtErr.Message)
+	}
+
+	if got, want := rtErr.Note, "invalid collector configuration"; got != want {
+		t.Fatalf("unexpected note: %q", rtErr.Note)
 	}
 }
 

--- a/pkg/vm/warmup.go
+++ b/pkg/vm/warmup.go
@@ -225,12 +225,14 @@ func warmupBindHostCall(descriptor callDescriptor, functions *runtime.Functions)
 
 	if err != nil && errors.Is(err, ErrUnresolvedFunction) && functions.Has(descriptor.DisplayName) {
 		available := resolveAvailableArities(descriptor.DisplayName, functions)
+		expected := strings.Join(available, " or ")
 
 		return mem.CachedHostFunction{}, fmt.Errorf(
-			"%w: %s expects %s arguments, but got %d",
+			"%w: %s expects %s %s, but got %d",
 			runtime.ErrInvalidArgumentNumber,
 			descriptor.DisplayName,
-			strings.Join(available, " or "),
+			expected,
+			argumentWordForExpectation(expected),
 			argCount,
 		)
 	}

--- a/pkg/vm/warmup.go
+++ b/pkg/vm/warmup.go
@@ -227,8 +227,11 @@ func warmupBindHostCall(descriptor callDescriptor, functions *runtime.Functions)
 		available := resolveAvailableArities(descriptor.DisplayName, functions)
 
 		return mem.CachedHostFunction{}, fmt.Errorf(
-			"%w: expected number of arguments %s, but got %d",
-			runtime.ErrInvalidArgumentNumber, strings.Join(available, " or "), argCount,
+			"%w: %s expects %s arguments, but got %d",
+			runtime.ErrInvalidArgumentNumber,
+			descriptor.DisplayName,
+			strings.Join(available, " or "),
+			argCount,
 		)
 	}
 

--- a/pkg/vm/warmup_param_test.go
+++ b/pkg/vm/warmup_param_test.go
@@ -113,7 +113,7 @@ RETURN outer()
 			formatted := rtErr.Format()
 			for _, needle := range []string{
 				"FUNC inner() => @foo",
-				"^^^^ missing parameter",
+				"^^^^ parameter '@foo' was not provided",
 			} {
 				if !strings.Contains(formatted, needle) {
 					t.Fatalf("expected formatted error to contain %q, got:\n%s", needle, formatted)
@@ -161,7 +161,7 @@ RETURN left + right
 			}
 
 			formatted := rtErr.Format()
-			if got, want := strings.Count(formatted, "Missing parameter"), 1; got != want {
+			if got, want := strings.Count(formatted, "missing parameter"), 1; got != want {
 				t.Fatalf("unexpected missing parameter count: got %d, want %d\n%s", got, want, formatted)
 			}
 
@@ -197,7 +197,7 @@ RETURN risky()?
 				t.Fatalf("expected runtime error, got %T", err)
 			}
 
-			if got, want := rtErr.Message, "Missing parameter"; got != want {
+			if got, want := rtErr.Message, "missing parameter"; got != want {
 				t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 			}
 

--- a/test/integration/vm/vm_bytecode_validation_test.go
+++ b/test/integration/vm/vm_bytecode_validation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	"github.com/MontFerret/ferret/v2/test/spec/assert"
 	. "github.com/MontFerret/ferret/v2/test/spec/exec"
@@ -57,8 +58,12 @@ func TestFailsOnUnknownOpcode(t *testing.T) {
 				return errors.New("expected unknown opcode error")
 			}
 
-			unwrapped := errors.Unwrap(err)
-			if unwrapped == nil || !strings.Contains(unwrapped.Error(), "unknown opcode 255 at pc 0") {
+			var rtErr *vm.RuntimeError
+			if !errors.As(err, &rtErr) {
+				return fmt.Errorf("expected runtime error, got %T", err)
+			}
+
+			if rtErr.Note != "unknown opcode 255 at pc 0" {
 				return fmt.Errorf("unexpected error: %v", err)
 			}
 

--- a/test/integration/vm/vm_dispatch_test.go
+++ b/test/integration/vm/vm_dispatch_test.go
@@ -181,17 +181,17 @@ func TestDispatchRuntimeErrors(t *testing.T) {
 	RunSpecs(t, []spec.Spec{
 		S(`RETURN DISPATCH "click" IN @value`, "Should fail when target is not a dispatcher").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Message: "Invalid type"},
+			&ExpectedRuntimeError{Message: "invalid type"},
 		),
 		S("DISPATCH \"click\" IN @value ON ERROR RETURN NONE\nRETURN 1", 1, "Statement suppression should continue after dispatch failure"),
 		S(`RETURN DISPATCH @event IN @d`, "Should fail when event name is not a string").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Message: "Invalid type"},
+			&ExpectedRuntimeError{Message: "invalid type"},
 		),
 		Nil(`RETURN DISPATCH @event IN @d ON ERROR RETURN NONE`, "Expression suppression should return none on dispatch failure"),
 		S(`RETURN "click" -> @value`, "Shorthand should fail when target is not a dispatcher").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Message: "Invalid type"},
+			&ExpectedRuntimeError{Message: "invalid type"},
 		),
 	}, vm.WithParams(map[string]runtime.Value{
 		"d":     dispatcher,

--- a/test/integration/vm/vm_host_call_test.go
+++ b/test/integration/vm/vm_host_call_test.go
@@ -164,6 +164,6 @@ func TestHostFunctionLookupIsCaseSensitive(t *testing.T) {
 
 	RunSpecs(t, []spec.Spec{
 		Array("RETURN [Foo(), foo()]", []any{"upper", "lower"}),
-		ErrorStr("RETURN FOO()", "Unresolved function"),
+		ErrorStr("RETURN FOO()", "unresolved function"),
 	}, vm.WithFunctionsBuilder(builder))
 }

--- a/test/integration/vm/vm_host_warmup_integration_test.go
+++ b/test/integration/vm/vm_host_warmup_integration_test.go
@@ -33,7 +33,7 @@ func TestWarmupClearsStaleHostCacheAcrossEnvironments(t *testing.T) {
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 				},
 			},
@@ -181,14 +181,14 @@ func TestWarmupRepeatedMissingRunsAfterSuccessRecoverCleanly(t *testing.T) {
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "missing second",
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "recovered",
@@ -223,8 +223,12 @@ func TestWarmupArityMismatchProducesDescriptiveError(t *testing.T) {
 							}),
 						},
 						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{
-							Message:  "Invalid number of arguments",
-							Contains: []string{"Expected number of arguments 1, but got 2"},
+							Message: "invalid number of arguments",
+							Contains: []string{
+								"wrong number of arguments in call to F",
+								"Note: F expects 1 arguments, but got 2",
+								"Hint: Pass 1 argument to F",
+							},
 						}),
 					},
 				},
@@ -259,7 +263,7 @@ func TestWarmupArityMismatchRecovery(t *testing.T) {
 								})
 							}),
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Invalid number of arguments"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "invalid number of arguments"}),
 					},
 					{
 						Name: "recovered",
@@ -289,7 +293,7 @@ func TestWarmupTrulyMissingFunctionStillReportsUnresolved(t *testing.T) {
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 				},
 			},
@@ -332,7 +336,7 @@ RETURN [a, b, c]
 								})
 							}),
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "recovered",

--- a/test/integration/vm/vm_host_warmup_integration_test.go
+++ b/test/integration/vm/vm_host_warmup_integration_test.go
@@ -226,7 +226,7 @@ func TestWarmupArityMismatchProducesDescriptiveError(t *testing.T) {
 							Message: "invalid number of arguments",
 							Contains: []string{
 								"wrong number of arguments in call to F",
-								"Note: F expects 1 arguments, but got 2",
+								"Note: F expects 1 argument, but got 2",
 								"Hint: Pass 1 argument to F",
 							},
 						}),

--- a/test/integration/vm/vm_param_test.go
+++ b/test/integration/vm/vm_param_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestParam(t *testing.T) {
 	RunSpecs(t, []spec.Spec{
-		ErrorStr(`RETURN @foo`, "Missing parameter"),
+		ErrorStr(`RETURN @foo`, "missing parameter"),
 		ErrorStr(`
 FUNC read() => @foo
 RETURN read()
-`, "Missing parameter"),
+`, "missing parameter"),
 		S(`RETURN @str`, "bar", "Should return a value of a parameter"),
 		S(`RETURN @int + @int`, 2, "Should return a sum of two parameters"),
 		S(`RETURN @obj.str1 + @obj.str2`, "foobar", "Should return a concatenated string of two parameter properties"),
@@ -46,7 +46,7 @@ RETURN outer()
 `
 
 	RunSpecs(t, []spec.Spec{
-		ErrorStr(expr, "Missing parameter", "Should report missing parameter used only in nested UDF path"),
+		ErrorStr(expr, "missing parameter", "Should report missing parameter used only in nested UDF path"),
 		S(expr, "bar", "Should resolve parameter in nested UDF path when provided").Env(spec.WithParam("foo", "bar")),
 	},
 	)

--- a/test/integration/vm/vm_queryable_test.go
+++ b/test/integration/vm/vm_queryable_test.go
@@ -25,7 +25,7 @@ func TestQueryable(t *testing.T) {
 		Array("RETURN QUERY `SELECT * FROM products` IN @doc USING sql WITH { c: \"phones\" }", []any{"ok"}, "Should apply query expression with options"),
 		Array("RETURN @doc[~ text]", []any{"ok"}, "Should apply query literal with no string payload"),
 		spec.NewSpec("RETURN @val[~ css`x`]").Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-			Message: "Invalid type",
+			Message: "invalid type",
 		}),
 	}, vm.WithParams(map[string]runtime.Value{
 		"doc": queryable,
@@ -200,7 +200,7 @@ func TestQueryableListInput(t *testing.T) {
 		),
 		spec.NewSpec("RETURN [@qA, 1][~ text]", "Should fail when list element is not queryable").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Message: "Invalid type"},
+			&ExpectedRuntimeError{Message: "invalid type"},
 		),
 	}, vm.WithParams(map[string]runtime.Value{
 		"doc":  queryableDoc,
@@ -244,11 +244,11 @@ func TestQueryableModifiers(t *testing.T) {
 		Nil("LET maybe = QUERY ONE `.items` IN @many USING css ON ERROR RETURN NONE\nRETURN maybe", "Explicit suppress should catch ONE multi-result failure"),
 		spec.NewSpec("LET maybe = (QUERY ONE `.items` IN @empty USING css)?\nRETURN maybe.foo", "Catch should not swallow the first instruction after a guarded QUERY ONE").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Contains: []string{"Cannot read property", "\"foo\""}},
+			&ExpectedRuntimeError{Contains: []string{"cannot read property", "\"foo\""}},
 		),
 		spec.NewSpec("LET maybe = QUERY ONE `.items` IN @empty USING css ON ERROR RETURN NONE\nRETURN maybe.foo", "Explicit suppress should not swallow the first instruction after a guarded QUERY ONE").Expect().ExecError(
 			ShouldBeRuntimeError,
-			&ExpectedRuntimeError{Contains: []string{"Cannot read property", "\"foo\""}},
+			&ExpectedRuntimeError{Contains: []string{"cannot read property", "\"foo\""}},
 		),
 	}, vm.WithParams(map[string]runtime.Value{
 		"many":  queryableMany,

--- a/test/integration/vm/vm_runtime_error_format_test.go
+++ b/test/integration/vm/vm_runtime_error_format_test.go
@@ -22,13 +22,12 @@ func TestRuntimeErrorFormatting(t *testing.T) {
 			"LET numerator = 10\nRETURN numerator / 0",
 			"script.fql",
 		).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-			Message: "Division by zero",
+			Message: "division by zero",
 			Contains: []string{
-				"DivideByZero: Division by zero",
+				"DivideByZero: division by zero",
 				":2:8",
 				"attempt to divide by zero",
 				"Hint: Ensure the denominator is non-zero before division",
-				"Note: Add a conditional check before dividing",
 			},
 			NotContains: []string{"~"},
 		}),
@@ -36,13 +35,14 @@ func TestRuntimeErrorFormatting(t *testing.T) {
 			"LET obj = {}\nRETURN obj.foo.bar",
 			"obj.fql",
 		).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-			Message: "Cannot read property \"bar\" of None",
+			Message: "invalid type",
 			Contains: []string{
-				"TypeError: Cannot read property \"bar\" of None",
-				"property access on None",
+				"TypeError: invalid type",
+				"property \"bar\" cannot be read from this value",
+				"Note: cannot read property \"bar\" of None",
 				"Hint: Use optional chaining (?.) or check for None before accessing a member",
+				"Caused by: invalid type",
 			},
-			NotContains: []string{"Caused by:"},
 		}),
 		spec.NewSpec(
 			`
@@ -98,7 +98,7 @@ func TestRuntimeErrorFormatsMissingParamWithParamSpan(t *testing.T) {
 				t.Fatalf("expected runtime error, got %T", err)
 			}
 
-			if got, want := runtimeErr.Message, "Missing parameter"; got != want {
+			if got, want := runtimeErr.Message, "missing parameter"; got != want {
 				t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 			}
 
@@ -114,7 +114,7 @@ func TestRuntimeErrorFormatsMissingParamWithParamSpan(t *testing.T) {
 					t.Fatalf("unexpected main span fragment: got %q, want %q", got, want)
 				}
 
-				if got, want := span.Label, "missing parameter"; got != want {
+				if got, want := span.Label, "parameter '@foo' was not provided"; got != want {
 					t.Fatalf("unexpected main span label: got %q, want %q", got, want)
 				}
 			}
@@ -125,12 +125,13 @@ func TestRuntimeErrorFormatsMissingParamWithParamSpan(t *testing.T) {
 
 			formatted := runtimeErr.Format()
 			for _, needle := range []string{
-				"UnresolvedSymbol: Missing parameter",
+				"UnresolvedSymbol: missing parameter",
 				" --> missing_param.fql:1:8",
 				"RETURN @foo",
-				"^^^^ missing parameter",
-				"Hint: Provide all required parameters",
-				"Caused by: missed parameter: @foo",
+				"^^^^ parameter '@foo' was not provided",
+				"Note: this query requires parameter '@foo'",
+				"Hint: Provide a value for @foo before executing this query",
+				"Caused by: missed parameter",
 			} {
 				if !strings.Contains(formatted, needle) {
 					t.Fatalf("expected formatted runtime error to contain %q, got:\n%s", needle, formatted)
@@ -201,8 +202,9 @@ RETURN outer()
 			for _, needle := range []string{
 				" --> missing_param_udf.fql:1:17",
 				"FUNC inner() => @foo",
-				"^^^^ missing parameter",
-				"Caused by: missed parameter: @foo",
+				"^^^^ parameter '@foo' was not provided",
+				"Note: this query requires parameter '@foo'",
+				"Caused by: missed parameter",
 			} {
 				if !strings.Contains(formatted, needle) {
 					t.Fatalf("expected formatted runtime error to contain %q, got:\n%s", needle, formatted)
@@ -257,15 +259,15 @@ func TestRuntimeErrorFormatsAggregatedMissingParams(t *testing.T) {
 			for _, needle := range []string{
 				" --> missing_params.fql:1:8",
 				" --> missing_params.fql:1:15",
-				"Caused by: missed parameter: @foo",
-				"Caused by: missed parameter: @bar",
+				"parameter '@foo' was not provided",
+				"parameter '@bar' was not provided",
 			} {
 				if !strings.Contains(formatted, needle) {
 					t.Fatalf("expected formatted runtime error set to contain %q, got:\n%s", needle, formatted)
 				}
 			}
 
-			if got, want := strings.Count(formatted, "UnresolvedSymbol: Missing parameter"), 2; got != want {
+			if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 2; got != want {
 				t.Fatalf("unexpected missing parameter diagnostic count: got %d, want %d\n%s", got, want, formatted)
 			}
 		})
@@ -307,12 +309,12 @@ func TestRuntimeErrorFormatsAggregatedRepeatedMissingParamCallsites(t *testing.T
 				}
 			}
 
-			if got, want := strings.Count(formatted, "UnresolvedSymbol: Missing parameter"), 2; got != want {
+			if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 2; got != want {
 				t.Fatalf("unexpected missing parameter diagnostic count: got %d, want %d\n%s", got, want, formatted)
 			}
 
-			if got, want := strings.Count(formatted, "Caused by: missed parameter: @foo"), 2; got != want {
-				t.Fatalf("unexpected repeated missing parameter cause count: got %d, want %d\n%s", got, want, formatted)
+			if got, want := strings.Count(formatted, "parameter '@foo' was not provided"), 2; got != want {
+				t.Fatalf("unexpected repeated missing parameter label count: got %d, want %d\n%s", got, want, formatted)
 			}
 		})
 	}
@@ -356,12 +358,12 @@ RETURN left + right
 				}
 			}
 
-			if got, want := strings.Count(formatted, "UnresolvedSymbol: Missing parameter"), 1; got != want {
+			if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 1; got != want {
 				t.Fatalf("unexpected missing parameter diagnostic count: got %d, want %d\n%s", got, want, formatted)
 			}
 
-			if got, want := strings.Count(formatted, "Caused by: missed parameter: @foo"), 1; got != want {
-				t.Fatalf("unexpected missing parameter cause count: got %d, want %d\n%s", got, want, formatted)
+			if got, want := strings.Count(formatted, "parameter '@foo' was not provided"), 1; got != want {
+				t.Fatalf("unexpected missing parameter label count: got %d, want %d\n%s", got, want, formatted)
 			}
 
 			for _, needle := range []string{
@@ -414,16 +416,16 @@ RETURN [val, val2, TEST()]
 				"LET val = @foo",
 				"LET val2 = @bar",
 				"RETURN @baz",
-				"Caused by: missed parameter: @foo",
-				"Caused by: missed parameter: @bar",
-				"Caused by: missed parameter: @baz",
+				"parameter '@foo' was not provided",
+				"parameter '@bar' was not provided",
+				"parameter '@baz' was not provided",
 			} {
 				if !strings.Contains(formatted, needle) {
 					t.Fatalf("expected formatted runtime error set to contain %q, got:\n%s", needle, formatted)
 				}
 			}
 
-			if got, want := strings.Count(formatted, "UnresolvedSymbol: Missing parameter"), 3; got != want {
+			if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 3; got != want {
 				t.Fatalf("unexpected missing parameter diagnostic count: got %d, want %d\n%s", got, want, formatted)
 			}
 
@@ -478,7 +480,7 @@ func TestRuntimeErrorFormatsArgumentTypeFailuresWithArgumentSpan(t *testing.T) {
 				t.Fatalf("expected runtime error, got %T", err)
 			}
 
-			if got, want := runtimeErr.Message, "Invalid argument 2 type"; got != want {
+			if got, want := runtimeErr.Message, "invalid argument type"; got != want {
 				t.Fatalf("unexpected runtime error message: got %q, want %q", got, want)
 			}
 
@@ -498,7 +500,7 @@ func TestRuntimeErrorFormatsArgumentTypeFailuresWithArgumentSpan(t *testing.T) {
 					t.Fatalf("unexpected main span fragment: got %q, want %q", got, want)
 				}
 
-				if got, want := span.Label, "argument 2 type mismatch"; got != want {
+				if got, want := span.Label, "argument 2 has incompatible type"; got != want {
 					t.Fatalf("unexpected main span label: got %q, want %q", got, want)
 				}
 			}
@@ -511,7 +513,19 @@ func TestRuntimeErrorFormatsArgumentTypeFailuresWithArgumentSpan(t *testing.T) {
 				t.Fatal("expected nested runtime error cause")
 			}
 
-			if got, want := runtimeErr.Cause.Error(), "expected String or Int or Object, but got Array"; got != want {
+			if got, want := runtimeErr.Note, "argument 2 expects String or Int or Object, but got Array"; got != want {
+				t.Fatalf("unexpected runtime error note: got %q, want %q", got, want)
+			}
+
+			if got, want := runtimeErr.Hint, "Convert argument 2 to String or Int or Object before this call"; got != want {
+				t.Fatalf("unexpected runtime error hint: got %q, want %q", got, want)
+			}
+
+			if !strings.Contains(runtimeErr.Format(), "Hint: Convert argument 2 to String or Int or Object before this call") {
+				t.Fatalf("expected formatted runtime error to include synthesized hint, got:\n%s", runtimeErr.Format())
+			}
+
+			if got, want := runtimeErr.Cause.Error(), "invalid type"; got != want {
 				t.Fatalf("unexpected runtime error cause: got %q, want %q", got, want)
 			}
 		})

--- a/test/integration/vm/vm_runtime_regressions_integration_test.go
+++ b/test/integration/vm/vm_runtime_regressions_integration_test.go
@@ -19,7 +19,7 @@ func TestWarmupHostResolutionPrecedesMissingParamExecution(t *testing.T) {
 	RunSpecFactory(t, func() []spec.Spec {
 		return []spec.Spec{
 			spec.NewSpec("RETURN MISSING_FN(@foo)").
-				Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+				Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 		}
 	})
 }
@@ -38,7 +38,7 @@ RETURN left + right
 				}
 
 				formatted := diagnostics.Format(err)
-				if got, want := strings.Count(formatted, "Missing parameter"), 2; got != want {
+				if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 2; got != want {
 					return fmt.Errorf("unexpected missing parameter count: got %d, want %d\n%s", got, want, formatted)
 				}
 
@@ -62,12 +62,12 @@ RETURN left + right
 				}
 
 				formatted := diagnostics.Format(err)
-				if got, want := strings.Count(formatted, "Missing parameter"), 2; got != want {
+				if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 2; got != want {
 					return fmt.Errorf("unexpected missing parameter count: got %d, want %d\n%s", got, want, formatted)
 				}
 
-				if got, want := strings.Count(formatted, "missed parameter: @foo"), 2; got != want {
-					return fmt.Errorf("unexpected repeated missing parameter cause count: got %d, want %d\n%s", got, want, formatted)
+				if got, want := strings.Count(formatted, "parameter '@foo' was not provided"), 2; got != want {
+					return fmt.Errorf("unexpected repeated missing parameter label count: got %d, want %d\n%s", got, want, formatted)
 				}
 
 				return nil
@@ -91,7 +91,7 @@ RETURN left + right
 				}
 
 				formatted := diagnostics.Format(err)
-				if got, want := strings.Count(formatted, "Missing parameter"), 1; got != want {
+				if got, want := strings.Count(formatted, "UnresolvedSymbol: missing parameter"), 1; got != want {
 					return fmt.Errorf("unexpected missing parameter count: got %d, want %d\n%s", got, want, formatted)
 				}
 
@@ -114,7 +114,7 @@ func TestStrictWarmupFailsProtectedMissingParamUdfCall(t *testing.T) {
 FUNC risky() => @foo
 RETURN risky()?
 `).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-				Message:     "Missing parameter",
+				Message:     "missing parameter",
 				NotContains: []string{"called from", "VM stack:"},
 			}),
 		}
@@ -132,14 +132,14 @@ func TestStrictWarmupFailsProtectedMissingHostCallForDefaultAndBuiltEnvironment(
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "built",
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewEnvironment(nil)
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 				},
 			},
@@ -158,7 +158,7 @@ func TestStrictWarmupFailsOnDeadCodeUnresolvedHostCall(t *testing.T) {
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "dummy",
@@ -167,7 +167,7 @@ func TestStrictWarmupFailsOnDeadCodeUnresolvedHostCall(t *testing.T) {
 								return runtime.None, nil
 							}),
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 				},
 			},
@@ -189,7 +189,7 @@ RETURN a + b
 				}
 
 				formatted := diagnostics.Format(err)
-				if got, want := strings.Count(formatted, "Unresolved function"), 2; got != want {
+				if got, want := strings.Count(formatted, "UnresolvedSymbol: unresolved function"), 2; got != want {
 					return fmt.Errorf("unexpected unresolved function count: got %d, want %d\n%s", got, want, formatted)
 				}
 
@@ -213,7 +213,7 @@ RETURN a + b
 				}
 
 				formatted := diagnostics.Format(err)
-				if got, want := strings.Count(formatted, "Unresolved function"), 2; got != want {
+				if got, want := strings.Count(formatted, "UnresolvedSymbol: unresolved function"), 2; got != want {
 					return fmt.Errorf("unexpected unresolved function count: got %d, want %d\n%s", got, want, formatted)
 				}
 
@@ -234,14 +234,14 @@ func TestStrictWarmupFailureIsRepeatableUntilEnvironmentFixed(t *testing.T) {
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "missing second",
 						EnvFactory: func() (*vm.Environment, error) {
 							return vm.NewDefaultEnvironment(), nil
 						},
-						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "Unresolved function"}),
+						Error: spec.NewExpectation(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "unresolved function"}),
 					},
 					{
 						Name: "fixed env",
@@ -289,8 +289,8 @@ RETURN outer()
 								return fmt.Errorf("expected runtime error, got %T", err)
 							}
 
-							if rtErr.Message != "Division by zero" {
-								return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "Division by zero")
+							if rtErr.Message != "division by zero" {
+								return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "division by zero")
 							}
 
 							counts = append(counts, strings.Count(rtErr.Format(), "called from"))
@@ -310,8 +310,8 @@ RETURN outer()
 								return fmt.Errorf("expected runtime error, got %T", err)
 							}
 
-							if rtErr.Message != "Division by zero" {
-								return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "Division by zero")
+							if rtErr.Message != "division by zero" {
+								return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "division by zero")
 							}
 
 							counts = append(counts, strings.Count(rtErr.Format(), "called from"))
@@ -359,8 +359,8 @@ func TestModuloTypeErrorNotMisclassifiedAsModuloByZero(t *testing.T) {
 					return fmt.Errorf("expected runtime error, got %T", err)
 				}
 
-				if rtErr.Message != "Invalid type" {
-					return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "Invalid type")
+				if rtErr.Message != "invalid type" {
+					return fmt.Errorf("unexpected runtime error message: got %q, want %q", rtErr.Message, "invalid type")
 				}
 
 				if rtErr.Kind != diagnostics.TypeError {
@@ -396,8 +396,8 @@ RETURN outer()
 `).
 				Env(vm.WithParam("x", runtime.None)).
 				Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-				Message:  `Cannot read property "foo" of None`,
-				Contains: []string{"called from inner (#1)", "VM stack: outer -> middle -> inner"},
+				Message:  "invalid type",
+				Contains: []string{`cannot read property "foo" of None`, "called from inner (#1)", "VM stack: outer -> middle -> inner"},
 			}),
 		}
 	})
@@ -415,7 +415,7 @@ FUNC boo() (
 RETURN boo()
 `).
 				Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-				Message:  "Division by zero",
+				Message:  "division by zero",
 				Contains: []string{"called from boo (#1)", "VM stack: boo"},
 			}),
 		}

--- a/test/integration/vm/vm_use_test.go
+++ b/test/integration/vm/vm_use_test.go
@@ -36,14 +36,14 @@ RETURN Fn()`, true, "Should compile and resolve alias to the namespaced function
 		ErrorStr(`
 USE Foo AS F
 
-RETURN f::Test_FN()`, "Unresolved function", "Namespace alias resolution is case-sensitive"),
+RETURN f::Test_FN()`, "unresolved function", "Namespace alias resolution is case-sensitive"),
 		ErrorStr(`
 USE Foo::Test_FN AS Fn
 
-RETURN FN()`, "Unresolved function", "Function alias resolution is case-sensitive"),
+RETURN FN()`, "unresolved function", "Function alias resolution is case-sensitive"),
 		ErrorStr(`
 USE Foo AS F
 
-RETURN F::test_fn()`, "Unresolved function", "Host lookup remains case-sensitive after alias expansion"),
+RETURN F::test_fn()`, "unresolved function", "Host lookup remains case-sensitive after alias expansion"),
 	}, vm.WithNamespace(ns))
 }


### PR DESCRIPTION
This pull request refactors and improves the runtime error reporting system in the virtual machine (VM), making error messages more precise, structured, and actionable. It introduces a new builder for runtime errors, standardizes error messages, and enhances the diagnostic information provided for various error types, especially for argument and type errors. The changes also include improvements to test assertions and error kind definitions.

**Error reporting and diagnostics improvements:**

* Introduced a new runtime error builder (`runtime_error_builder.go`) that centralizes the construction of runtime errors, allowing for more consistent and detailed error messages, including cause, kind, hint, label, message, note, and source span.
* Added logic to synthesize more helpful hints and labels for arity, argument, and type errors, parsing error notes to generate actionable advice for users (`runtime_error_hint.go`).
* Refactored `ToRuntimeError` and related code to use the new builder and to provide improved messages, labels, and hints for errors such as division/modulo by zero, invalid argument/type, and unresolved symbols. [[1]](diffhunk://#diff-72a738d1adfd82f6c712716dd7e71c24c5433c0eab590f063dfb3e877c779458L120-R256) [[2]](diffhunk://#diff-72a738d1adfd82f6c712716dd7e71c24c5433c0eab590f063dfb3e877c779458R36-R46) [[3]](diffhunk://#diff-72a738d1adfd82f6c712716dd7e71c24c5433c0eab590f063dfb3e877c779458L90-R103)

**Error kind and message standardization:**

* Added a new error kind `InvalidArgument` to the diagnostics system and updated UDF call sites to use `ErrInvalidArgumentNumber` for arity errors, aligning error kinds and messages for better clarity. [[1]](diffhunk://#diff-e5d687241576487092b1ef2f304ce6d342abb2457169055500b145b7b0076aadR50) [[2]](diffhunk://#diff-4d362e86e60e2d582434ffecbbdef471ea5a6f801962155ac6949b3db29b96edR14) [[3]](diffhunk://#diff-6f35a2edaf5db2fe4c3c12445dab3c4235527c908fc5f753b7c34e4411233ac4L49-R49) [[4]](diffhunk://#diff-6f35a2edaf5db2fe4c3c12445dab3c4235527c908fc5f753b7c34e4411233ac4L67-R67)
* Standardized error messages to use lowercase and more descriptive text (e.g., "division by zero", "unresolved function"), and updated tests to match these new messages. [[1]](diffhunk://#diff-4d362e86e60e2d582434ffecbbdef471ea5a6f801962155ac6949b3db29b96edL49-R54) [[2]](diffhunk://#diff-4d362e86e60e2d582434ffecbbdef471ea5a6f801962155ac6949b3db29b96edL80-R86) [[3]](diffhunk://#diff-04010ee34f6226475b734eed53b6ed164765c97165128a0cc11f197bef619c33L219-R219) [[4]](diffhunk://#diff-8279a6ba0acb61196305d20af3a1df2adbee174750cbd5405a592c55ac452479L101-R101)

**Member access error improvements:**

* Improved the `MemberAccessError` label and note generation to provide more specific and user-friendly descriptions of member/index/property access errors.

**Codebase cleanup:**

* Removed unused imports and simplified code paths in error handling.

These changes collectively make runtime errors more actionable and user-friendly, aiding both end users and developers in diagnosing and resolving issues more efficiently.