### PR TITLE
Implement standard library group management and registration

### DIFF
--- a/engine_options.go
+++ b/engine_options.go
@@ -23,15 +23,15 @@ type (
 		encoding          *encoding.Registry
 		programLoader     *artifact.Loader
 		hooks             *hookRegistry
-		logger            []logging.Option
 		fsRoot            string
+		stdlib            stdlib.Set
+		logger            []logging.Option
 		compiler          []compiler.Option
 		modules           []module.Module
 		maxActiveSessions int
 		maxIdleVMsPerPlan int
 		maxVMsPerPlan     int
 		fsReadOnly        bool
-		noStdlib          bool
 	}
 
 	// Option configures an Engine during construction.
@@ -63,6 +63,7 @@ func newOptions(setters []Option) (*options, error) {
 		maxActiveSessions: defaultMaxActiveSessions,
 		maxIdleVMsPerPlan: defaultVMPoolSize,
 		maxVMsPerPlan:     defaultMaxVMsPerPlan,
+		stdlib:            stdlib.Full(),
 	}
 
 	for _, setter := range setters {
@@ -75,8 +76,8 @@ func newOptions(setters []Option) (*options, error) {
 		}
 	}
 
-	if !opts.noStdlib {
-		stdlib.RegisterLib(opts.library)
+	if err := opts.stdlib.Register(opts.library); err != nil {
+		return nil, fmt.Errorf("stdlib: %w", err)
 	}
 
 	return opts, nil
@@ -285,7 +286,16 @@ func WithProgramLoader(loader *artifact.Loader) Option {
 // WithoutStdlib disables the standard library, so no built-in functions are registered by default.
 func WithoutStdlib() Option {
 	return func(opts *options) error {
-		opts.noStdlib = true
+		opts.stdlib = stdlib.Empty()
+
+		return nil
+	}
+}
+
+// WithStdlib configures which standard library groups are registered by default.
+func WithStdlib(set stdlib.Set) Option {
+	return func(opts *options) error {
+		opts.stdlib = set
 
 		return nil
 	}

--- a/engine_options_test.go
+++ b/engine_options_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 )
 
 func mustNewOptionsForTest(t *testing.T, setters ...Option) *options {
@@ -168,5 +169,64 @@ func TestNewOptionsRejectsBlankFSRoot(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "fs root cannot be empty") {
 		t.Fatalf("expected blank fs root validation error, got: %v", err)
+	}
+}
+
+func TestWithStdlibSafeRegistersSelectedGroups(t *testing.T) {
+	t.Parallel()
+
+	eng := mustNewEngine(t, WithStdlib(stdlib.Safe()))
+	defer func() { _ = eng.Close() }()
+
+	if !eng.host.functions.Has("CONCAT") {
+		t.Fatal("expected safe stdlib to register non-IO functions")
+	}
+
+	for _, name := range []string{"IO::FS::READ", "IO::NET::HTTP::GET"} {
+		if eng.host.functions.Has(name) {
+			t.Fatalf("expected safe stdlib to exclude %s", name)
+		}
+	}
+}
+
+func TestWithStdlibEmptyMatchesWithoutStdlib(t *testing.T) {
+	t.Parallel()
+
+	eng := mustNewEngine(t, WithStdlib(stdlib.Empty()))
+	defer func() { _ = eng.Close() }()
+
+	if eng.host.functions.Size() != 0 {
+		t.Fatalf("expected empty stdlib to register no functions, got %d", eng.host.functions.Size())
+	}
+}
+
+func TestStdlibOptionsUseLastSelection(t *testing.T) {
+	t.Parallel()
+
+	withoutThenFull := mustNewEngine(t, WithoutStdlib(), WithStdlib(stdlib.Full()))
+	defer func() { _ = withoutThenFull.Close() }()
+
+	if !withoutThenFull.host.functions.Has("CONCAT") {
+		t.Fatal("expected WithStdlib after WithoutStdlib to restore full stdlib")
+	}
+
+	fullThenWithout := mustNewEngine(t, WithStdlib(stdlib.Full()), WithoutStdlib())
+	defer func() { _ = fullThenWithout.Close() }()
+
+	if fullThenWithout.host.functions.Size() != 0 {
+		t.Fatalf("expected WithoutStdlib after WithStdlib to disable stdlib, got %d functions", fullThenWithout.host.functions.Size())
+	}
+}
+
+func TestWithStdlibRejectsInvalidGroup(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(WithStdlib(stdlib.Only(stdlib.Group("unknown"))))
+	if err == nil {
+		t.Fatal("expected invalid stdlib group to fail engine creation")
+	}
+
+	if !strings.Contains(err.Error(), "stdlib: invalid stdlib group(s): unknown") {
+		t.Fatalf("expected invalid stdlib group error, got: %v", err)
 	}
 }

--- a/pkg/stdlib/group.go
+++ b/pkg/stdlib/group.go
@@ -1,0 +1,91 @@
+package stdlib
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/fs"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/io/net"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
+	stdlibstrings "github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/types"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/utils"
+)
+
+// Group identifies a standard library capability group.
+type Group string
+
+const (
+	Types       Group = "types"
+	Strings     Group = "strings"
+	Math        Group = "math"
+	Collections Group = "collections"
+	DateTime    Group = "datetime"
+	Arrays      Group = "arrays"
+	Objects     Group = "objects"
+	IO          Group = "io"
+	FS          Group = "fs"
+	NET         Group = "net"
+	Path        Group = "path"
+	Utils       Group = "utils"
+	Testing     Group = "testing"
+)
+
+type groupRegistration struct {
+	register func(runtime.Namespace)
+	group    Group
+}
+
+var groupRegistrations = []groupRegistration{
+	{Types, types.RegisterLib},
+	{Strings, stdlibstrings.RegisterLib},
+	{Math, math.RegisterLib},
+	{Collections, collections.RegisterLib},
+	{DateTime, datetime.RegisterLib},
+	{Arrays, arrays.RegisterLib},
+	{Objects, objects.RegisterLib},
+	{FS, registerFS},
+	{NET, registerNET},
+	{Path, path.RegisterLib},
+	{Utils, utils.RegisterLib},
+	{Testing, testing.RegisterLib},
+}
+
+func expandGroup(group Group) ([]Group, bool) {
+	switch group {
+	case IO:
+		return []Group{FS, NET}, true
+	case Types, Strings, Math, Collections, DateTime, Arrays, Objects, FS, NET, Path, Utils, Testing:
+		return []Group{group}, true
+	default:
+		return nil, false
+	}
+}
+
+func invalidGroupsError(groups []Group) error {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(groups))
+	for _, group := range groups {
+		names = append(names, string(group))
+	}
+
+	return fmt.Errorf("invalid stdlib group(s): %s", strings.Join(names, ", "))
+}
+
+func registerFS(ns runtime.Namespace) {
+	fs.RegisterLib(ns.Namespace("IO"))
+}
+
+func registerNET(ns runtime.Namespace) {
+	net.RegisterLib(ns.Namespace("IO"))
+}

--- a/pkg/stdlib/group.go
+++ b/pkg/stdlib/group.go
@@ -44,18 +44,18 @@ type groupRegistration struct {
 }
 
 var groupRegistrations = []groupRegistration{
-	{Types, types.RegisterLib},
-	{Strings, stdlibstrings.RegisterLib},
-	{Math, math.RegisterLib},
-	{Collections, collections.RegisterLib},
-	{DateTime, datetime.RegisterLib},
-	{Arrays, arrays.RegisterLib},
-	{Objects, objects.RegisterLib},
-	{FS, registerFS},
-	{NET, registerNET},
-	{Path, path.RegisterLib},
-	{Utils, utils.RegisterLib},
-	{Testing, testing.RegisterLib},
+	{group: Types, register: types.RegisterLib},
+	{group: Strings, register: stdlibstrings.RegisterLib},
+	{group: Math, register: math.RegisterLib},
+	{group: Collections, register: collections.RegisterLib},
+	{group: DateTime, register: datetime.RegisterLib},
+	{group: Arrays, register: arrays.RegisterLib},
+	{group: Objects, register: objects.RegisterLib},
+	{group: FS, register: registerFS},
+	{group: NET, register: registerNET},
+	{group: Path, register: path.RegisterLib},
+	{group: Utils, register: utils.RegisterLib},
+	{group: Testing, register: testing.RegisterLib},
 }
 
 func expandGroup(group Group) ([]Group, bool) {

--- a/pkg/stdlib/lib.go
+++ b/pkg/stdlib/lib.go
@@ -2,17 +2,6 @@ package stdlib
 
 import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/datetime"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/io"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/math"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/path"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/types"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/utils"
 )
 
 // New creates a new standard library.
@@ -26,21 +15,7 @@ func New() runtime.Namespace {
 }
 
 func RegisterLib(ns runtime.Namespace) {
-	libs := []func(runtime.Namespace){
-		types.RegisterLib,
-		strings.RegisterLib,
-		math.RegisterLib,
-		collections.RegisterLib,
-		datetime.RegisterLib,
-		arrays.RegisterLib,
-		objects.RegisterLib,
-		io.RegisterLib,
-		path.RegisterLib,
-		utils.RegisterLib,
-		testing.RegisterLib,
-	}
-
-	for _, lib := range libs {
-		lib(ns)
+	if err := Full().Register(ns); err != nil {
+		panic(err)
 	}
 }

--- a/pkg/stdlib/set.go
+++ b/pkg/stdlib/set.go
@@ -25,7 +25,7 @@ func Full() Set {
 
 // Safe returns the full standard library without filesystem or network groups.
 func Safe() Set {
-	return Full().Without(FS, NET)
+	return Full().Without(IO)
 }
 
 // Empty returns a set containing no standard library groups.

--- a/pkg/stdlib/set.go
+++ b/pkg/stdlib/set.go
@@ -1,0 +1,121 @@
+package stdlib
+
+import (
+	"fmt"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+// Set is an immutable selection of standard library capability groups.
+type Set struct {
+	groups  map[Group]struct{}
+	invalid []Group
+}
+
+// Full returns a set containing every standard library group.
+func Full() Set {
+	set := Empty()
+
+	for _, registration := range groupRegistrations {
+		set.groups[registration.group] = struct{}{}
+	}
+
+	return set
+}
+
+// Safe returns the full standard library without filesystem or network groups.
+func Safe() Set {
+	return Full().Without(FS, NET)
+}
+
+// Empty returns a set containing no standard library groups.
+func Empty() Set {
+	return Set{
+		groups: make(map[Group]struct{}),
+	}
+}
+
+// Only returns a set containing only the provided standard library groups.
+func Only(groups ...Group) Set {
+	return Empty().With(groups...)
+}
+
+// With returns a new set that also contains the provided groups.
+func (s Set) With(groups ...Group) Set {
+	next := s.clone()
+
+	for _, group := range groups {
+		expanded, ok := expandGroup(group)
+		if !ok {
+			next.addInvalid(group)
+			continue
+		}
+
+		for _, item := range expanded {
+			next.groups[item] = struct{}{}
+		}
+	}
+
+	return next
+}
+
+// Without returns a new set without the provided groups.
+func (s Set) Without(groups ...Group) Set {
+	next := s.clone()
+
+	for _, group := range groups {
+		expanded, ok := expandGroup(group)
+		if !ok {
+			next.addInvalid(group)
+			continue
+		}
+
+		for _, item := range expanded {
+			delete(next.groups, item)
+		}
+	}
+
+	return next
+}
+
+// Register registers the selected standard library groups into the namespace.
+func (s Set) Register(ns runtime.Namespace) error {
+	if ns == nil {
+		return fmt.Errorf("stdlib namespace cannot be nil")
+	}
+
+	if err := invalidGroupsError(s.invalid); err != nil {
+		return err
+	}
+
+	for _, registration := range groupRegistrations {
+		if _, ok := s.groups[registration.group]; ok {
+			registration.register(ns)
+		}
+	}
+
+	return nil
+}
+
+func (s Set) clone() Set {
+	next := Set{
+		groups:  make(map[Group]struct{}, len(s.groups)),
+		invalid: append([]Group(nil), s.invalid...),
+	}
+
+	for group := range s.groups {
+		next.groups[group] = struct{}{}
+	}
+
+	return next
+}
+
+func (s *Set) addInvalid(group Group) {
+	for _, existing := range s.invalid {
+		if existing == group {
+			return
+		}
+	}
+
+	s.invalid = append(s.invalid, group)
+}

--- a/pkg/stdlib/set_test.go
+++ b/pkg/stdlib/set_test.go
@@ -1,6 +1,8 @@
 package stdlib_test
 
 import (
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -22,6 +24,13 @@ func buildFunctions(t *testing.T, set stdlib.Set) *runtime.Functions {
 	}
 
 	return funcs
+}
+
+func functionNames(funcs *runtime.Functions) []string {
+	names := funcs.List()
+	sort.Strings(names)
+
+	return names
 }
 
 func TestFullRegistersRepresentativeFunctions(t *testing.T) {
@@ -58,6 +67,17 @@ func TestSafeExcludesExternalIO(t *testing.T) {
 		if funcs.Has(name) {
 			t.Fatalf("expected safe stdlib to exclude %s", name)
 		}
+	}
+}
+
+func TestSafeMatchesFullWithoutIO(t *testing.T) {
+	t.Parallel()
+
+	safeNames := functionNames(buildFunctions(t, stdlib.Safe()))
+	withoutIONames := functionNames(buildFunctions(t, stdlib.Full().Without(stdlib.IO)))
+
+	if !reflect.DeepEqual(safeNames, withoutIONames) {
+		t.Fatalf("expected Safe to match Full().Without(IO), got %v vs %v", safeNames, withoutIONames)
 	}
 }
 

--- a/pkg/stdlib/set_test.go
+++ b/pkg/stdlib/set_test.go
@@ -182,6 +182,19 @@ func TestSetRegisterRejectsInvalidGroup(t *testing.T) {
 	}
 }
 
+func TestSetRegisterRejectsNilNamespace(t *testing.T) {
+	t.Parallel()
+
+	err := stdlib.Full().Register(nil)
+	if err == nil {
+		t.Fatal("expected nil namespace to fail registration")
+	}
+
+	if !strings.Contains(err.Error(), "stdlib namespace cannot be nil") {
+		t.Fatalf("expected nil namespace error, got: %v", err)
+	}
+}
+
 func TestZeroValueSetRegistersNoFunctions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/stdlib/set_test.go
+++ b/pkg/stdlib/set_test.go
@@ -1,0 +1,173 @@
+package stdlib_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
+)
+
+func buildFunctions(t *testing.T, set stdlib.Set) *runtime.Functions {
+	t.Helper()
+
+	ns := runtime.NewLibrary()
+	if err := set.Register(ns); err != nil {
+		t.Fatalf("failed to register stdlib set: %v", err)
+	}
+
+	funcs, err := ns.Build()
+	if err != nil {
+		t.Fatalf("failed to build functions: %v", err)
+	}
+
+	return funcs
+}
+
+func TestFullRegistersRepresentativeFunctions(t *testing.T) {
+	t.Parallel()
+
+	funcs := buildFunctions(t, stdlib.Full())
+
+	for _, name := range []string{
+		"CONCAT",
+		"IO::FS::READ",
+		"IO::NET::HTTP::GET",
+	} {
+		if !funcs.Has(name) {
+			t.Fatalf("expected full stdlib to register %s", name)
+		}
+	}
+}
+
+func TestSafeExcludesExternalIO(t *testing.T) {
+	t.Parallel()
+
+	funcs := buildFunctions(t, stdlib.Safe())
+
+	if !funcs.Has("CONCAT") {
+		t.Fatal("expected safe stdlib to keep non-IO functions")
+	}
+
+	for _, name := range []string{
+		"IO::FS::READ",
+		"IO::FS::WRITE",
+		"IO::NET::HTTP::GET",
+		"IO::NET::HTTP::POST",
+	} {
+		if funcs.Has(name) {
+			t.Fatalf("expected safe stdlib to exclude %s", name)
+		}
+	}
+}
+
+func TestEmptyRegistersNoFunctions(t *testing.T) {
+	t.Parallel()
+
+	funcs := buildFunctions(t, stdlib.Empty())
+
+	if funcs.Size() != 0 {
+		t.Fatalf("expected empty stdlib to register no functions, got %d", funcs.Size())
+	}
+}
+
+func TestOnlyRegistersNestedIOGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		set      stdlib.Set
+		included []string
+		excluded []string
+	}{
+		{
+			name:     "fs",
+			set:      stdlib.Only(stdlib.FS),
+			included: []string{"IO::FS::READ", "IO::FS::WRITE"},
+			excluded: []string{"IO::NET::HTTP::GET", "CONCAT"},
+		},
+		{
+			name:     "net",
+			set:      stdlib.Only(stdlib.NET),
+			included: []string{"IO::NET::HTTP::GET", "IO::NET::HTTP::POST"},
+			excluded: []string{"IO::FS::READ", "CONCAT"},
+		},
+		{
+			name:     "io",
+			set:      stdlib.Only(stdlib.IO),
+			included: []string{"IO::FS::READ", "IO::NET::HTTP::GET"},
+			excluded: []string{"CONCAT"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			funcs := buildFunctions(t, tt.set)
+
+			for _, name := range tt.included {
+				if !funcs.Has(name) {
+					t.Fatalf("expected %s to be registered", name)
+				}
+			}
+
+			for _, name := range tt.excluded {
+				if funcs.Has(name) {
+					t.Fatalf("expected %s not to be registered", name)
+				}
+			}
+		})
+	}
+}
+
+func TestSetModifiersAreImmutable(t *testing.T) {
+	t.Parallel()
+
+	base := stdlib.Only(stdlib.Strings)
+	withFS := base.With(stdlib.FS)
+	withoutStrings := base.Without(stdlib.Strings)
+
+	baseFuncs := buildFunctions(t, base)
+	if !baseFuncs.Has("CONCAT") {
+		t.Fatal("expected base set to retain strings")
+	}
+	if baseFuncs.Has("IO::FS::READ") {
+		t.Fatal("expected base set not to gain FS from derived set")
+	}
+
+	withFSFuncs := buildFunctions(t, withFS)
+	if !withFSFuncs.Has("CONCAT") || !withFSFuncs.Has("IO::FS::READ") {
+		t.Fatal("expected With-derived set to contain strings and FS")
+	}
+
+	withoutStringsFuncs := buildFunctions(t, withoutStrings)
+	if withoutStringsFuncs.Has("CONCAT") {
+		t.Fatal("expected Without-derived set to remove strings")
+	}
+}
+
+func TestSetRegisterRejectsInvalidGroup(t *testing.T) {
+	t.Parallel()
+
+	ns := runtime.NewLibrary()
+	err := stdlib.Only(stdlib.Group("unknown")).Register(ns)
+	if err == nil {
+		t.Fatal("expected invalid group to fail registration")
+	}
+
+	if !strings.Contains(err.Error(), "invalid stdlib group(s): unknown") {
+		t.Fatalf("expected invalid group error, got: %v", err)
+	}
+}
+
+func TestZeroValueSetRegistersNoFunctions(t *testing.T) {
+	t.Parallel()
+
+	funcs := buildFunctions(t, stdlib.Set{})
+
+	if funcs.Size() != 0 {
+		t.Fatalf("expected zero-value set to register no functions, got %d", funcs.Size())
+	}
+}


### PR DESCRIPTION
This pull request introduces a new, flexible mechanism for selecting which standard library groups are registered in the Ferret engine. Instead of a simple enable/disable flag, you can now specify exactly which groups to include or exclude, improving both security and configurability. It also adds comprehensive tests and new APIs for working with these standard library sets.

**Standard Library Selection and Registration**

* Introduced the `stdlib.Set` type, which represents an immutable selection of standard library groups, along with helper constructors like `Full()`, `Safe()`, `Empty()`, and `Only(...)` for common configurations. [[1]](diffhunk://#diff-574c86a35ad4e342b84da1a605d9405103b8b50a1a3c6f982502d99519c7e85aR1-R121) [[2]](diffhunk://#diff-f058d5de83bcbadbdae47f33fcdb64c7d3680b16f0340538ad47bbcefc133da2R1-R91)
* Added the `WithStdlib(set stdlib.Set)` and `WithoutStdlib()` engine options to allow fine-grained control over which standard library groups are registered during engine initialization, replacing the previous `noStdlib` boolean. [[1]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7L288-R298) [[2]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7L26-L34) [[3]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7R66) [[4]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7L78-R80)
* Updated the internal registration logic to use the selected `stdlib.Set`, and to error out if invalid group names are provided. [[1]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7L78-R80) [[2]](diffhunk://#diff-574c86a35ad4e342b84da1a605d9405103b8b50a1a3c6f982502d99519c7e85aR1-R121) [[3]](diffhunk://#diff-f058d5de83bcbadbdae47f33fcdb64c7d3680b16f0340538ad47bbcefc133da2R1-R91)

**Testing and Validation**

* Added extensive tests for the new standard library selection logic, including tests for immutability, group expansion, error handling, and representative function registration. [[1]](diffhunk://#diff-786520c362a59a78831b2233045c75344c31b40e88cf26426acab7eb57bad737R1-R173) [[2]](diffhunk://#diff-9ed63033b49f7f7f81d1dc61a2d4c019c1921640586fb1b700c841fd9d10aac5R174-R232)

**Codebase Cleanup**

* Removed direct references to individual standard library groups from `lib.go`, centralizing group registration and validation logic. [[1]](diffhunk://#diff-78628a8d3f35acaf6b0ad2941ea2b478a997669451ed8b39b2cfda8f8050f62eL5-L15) [[2]](diffhunk://#diff-78628a8d3f35acaf6b0ad2941ea2b478a997669451ed8b39b2cfda8f8050f62eL29-R19)

These changes make the Ferret engine's standard library much more modular and safer to use in restricted environments.