### PR TITLE
feat: add support for implicit current source in query expressions

### DIFF
--- a/pkg/formatter/internal/expression_test.go
+++ b/pkg/formatter/internal/expression_test.go
@@ -127,6 +127,20 @@ func TestExpressionFormatter_QueryExpressionParamPayload(t *testing.T) {
 	}
 }
 
+func TestExpressionFormatter_QueryExpressionImplicitCurrentSource(t *testing.T) {
+	input := `RETURN [1][* RETURN (QUERY "a" IN . USING css)]`
+	program := parseProgram(t, input)
+	query := mustFirst[*fql.QueryExpressionContext](t, program)
+
+	var buf bytes.Buffer
+	e := newEngine(source.NewAnonymous(input), &buf, DefaultOptions())
+
+	e.expression.formatQueryExpression(query)
+	if got := buf.String(); got != `QUERY "a" IN . USING css` {
+		t.Fatalf("unexpected query expression formatting: %q", got)
+	}
+}
+
 func TestExpressionFormatter_QueryExpressionCountModifier(t *testing.T) {
 	input := "RETURN QUERY COUNT `.items` IN doc USING css"
 	program := parseProgram(t, input)

--- a/pkg/parser/antlr/FqlParser.g4
+++ b/pkg/parser/antlr/FqlParser.g4
@@ -124,6 +124,10 @@ options { tokenVocab=FqlLexer; }
 
 	func (p *FqlParser) isImplicitCurrentValue() bool {
 		la1 := p.GetTokenStream().LA(2)
+		if la1 == FqlParserUsing {
+			return true
+		}
+
 		switch la1 {
 		case FqlParserIdentifier, FqlParserStringLiteral, FqlParserParam, FqlParserOpenBracket, FqlParserBacktickOpen:
 			return false

--- a/pkg/parser/fql/fql_parser.go
+++ b/pkg/parser/fql/fql_parser.go
@@ -999,6 +999,10 @@ func (p *FqlParser) isUnsafeReservedWordToken(token int) bool {
 
 func (p *FqlParser) isImplicitCurrentValue() bool {
 	la1 := p.GetTokenStream().LA(2)
+	if la1 == FqlParserUsing {
+		return true
+	}
+
 	switch la1 {
 	case FqlParserIdentifier, FqlParserStringLiteral, FqlParserParam, FqlParserOpenBracket, FqlParserBacktickOpen:
 		return false

--- a/test/integration/compiler/compiler_query_modifier_lowering_test.go
+++ b/test/integration/compiler/compiler_query_modifier_lowering_test.go
@@ -65,6 +65,17 @@ func failPrelude(prog *bytecode.Program, expectedMessage runtime.String) error {
 	return nil
 }
 
+func TestQueryExpressionSourceImplicitCurrentCompiles(t *testing.T) {
+	RunSpecs(t, []spec.Spec{
+		ProgramCheck(`
+LET sections = @sections
+LET linksBySection = sections[* RETURN (QUERY "a" IN . USING css)]
+RETURN linksBySection[**]`, func(prog *bytecode.Program) error {
+			return threeSlotQueryDescriptor(prog.Bytecode)
+		}, "Should compile query expression with implicit current source"),
+	})
+}
+
 func TestQueryModifierLowering_ValueUsesLoadNoneAndFail(t *testing.T) {
 	RunSpecs(t, []spec.Spec{
 		ProgramCheck(`RETURN QUERY VALUE ".items" IN @doc USING css`, func(prog *bytecode.Program) error {

--- a/test/integration/vm/vm_queryable_test.go
+++ b/test/integration/vm/vm_queryable_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestQueryable(t *testing.T) {
 	queryable := mock.NewQueryable(runtime.NewArrayWith(runtime.NewString("ok")))
+	sectionA := mock.NewQueryable(runtime.NewArrayWith(runtime.NewString("one")))
+	sectionB := mock.NewQueryable(runtime.NewArrayWith(runtime.NewString("two")))
 
 	RunSpecs(t, []spec.Spec{
 		Array("RETURN @doc[~ css`.items`]", []any{"ok"}, "Should apply query literal"),
@@ -24,13 +26,15 @@ func TestQueryable(t *testing.T) {
 		Array("RETURN @doc[~ sql`SELECT * FROM products`({ c: \"laptops\" })]", []any{"ok"}, "Should apply query literal with params"),
 		Array("RETURN QUERY `SELECT * FROM products` IN @doc USING sql WITH { c: \"phones\" }", []any{"ok"}, "Should apply query expression with options"),
 		Array("RETURN @doc[~ text]", []any{"ok"}, "Should apply query literal with no string payload"),
+		Array(`RETURN @sections[* RETURN (QUERY "a" IN . USING css)][**]`, []any{"one", "two"}, "Should apply query expression to implicit current source"),
 		spec.NewSpec("RETURN @val[~ css`x`]").Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
 			Message: "invalid type",
 		}),
 	}, vm.WithParams(map[string]runtime.Value{
-		"doc": queryable,
-		"q":   runtime.NewString(".dynamic-param"),
-		"val": runtime.NewInt(1),
+		"doc":      queryable,
+		"q":        runtime.NewString(".dynamic-param"),
+		"sections": runtime.NewArrayWith(sectionA, sectionB),
+		"val":      runtime.NewInt(1),
 	}))
 
 	t.Run("Should receive correct queries", func(t *testing.T) {


### PR DESCRIPTION
This pull request improves support for query expressions that use the implicit current source (`.`) in FQL, ensuring they are parsed, compiled, formatted, and executed correctly. The main changes include updates to the parser logic, new tests across the parser, compiler, and VM layers, and enhancements to test coverage for implicit current source handling.

**Parser improvements:**

* Updated the `isImplicitCurrentValue` method in both `pkg/parser/antlr/FqlParser.g4` and the generated `pkg/parser/fql/fql_parser.go` to correctly detect the use of the implicit current source when the `USING` keyword follows a query expression. [[1]](diffhunk://#diff-d5c5bfc325fbdd1ece79592214e946222d8feb3df6f8ad0f0bba89f6855981bfR127-R130) [[2]](diffhunk://#diff-c6d5d8dbd8f0e447f04a486adcb6ce843e010abdb2d11d2895c1583ecbcb3233R1002-R1005)

**Test coverage:**

* Added a test in `pkg/formatter/internal/expression_test.go` to ensure that formatting a query expression with an implicit current source produces the expected output.
* Added a compiler integration test in `test/integration/compiler/compiler_query_modifier_lowering_test.go` to verify that query expressions with implicit current sources compile as expected.
* Enhanced the VM integration test in `test/integration/vm/vm_queryable_test.go` to check that query expressions using the implicit current source execute correctly, including setup for test data and parameters. [[1]](diffhunk://#diff-9a1d39a664778f426bfed7251a891b684cf15cc95e61c714d8d838808ad92521R17-R18) [[2]](diffhunk://#diff-9a1d39a664778f426bfed7251a891b684cf15cc95e61c714d8d838808ad92521R29-R36)