### PR TITLE
fix: allow function calls before RETURN in UDF blocks

### DIFF
--- a/pkg/parser/diagnostics/error_listener.go
+++ b/pkg/parser/diagnostics/error_listener.go
@@ -38,7 +38,7 @@ func (d *ErrorListener) ReportAmbiguity(recognizer antlr.Parser, dfa *antlr.DFA,
 
 	if ctx := recognizer.GetParserRuleContext(); ctx != nil {
 		for _, rule := range recognizer.GetRuleInvocationStack(ctx) {
-			if rule == "expressionAtom" {
+			if rule == "expressionAtom" || rule == "functionStatement" {
 				return
 			}
 		}

--- a/test/integration/vm/vm_udf_test.go
+++ b/test/integration/vm/vm_udf_test.go
@@ -94,6 +94,27 @@ FUNC normalizePrice(value) (
 LET price = normalizePrice("$19.99")
 RETURN price
 `, 19.99, "Safe reserved words are valid UDF parameter names"),
+		Object(`
+FUNC foo() (
+  RETURN NONE
+)
+FUNC normalizePrice(input) (
+  LET cleaned = TRIM(input)
+  LET numeric = SUBSTITUTE(cleaned, "$", "")
+  RETURN TO_FLOAT(numeric)
+)
+FUNC f1(product) (
+  foo()
+  RETURN {
+    title: product.name,
+    price: normalizePrice(product.price)
+  }
+)
+RETURN f1({
+  name: "Widget",
+  price: "$19.99"
+})
+`, map[string]any{"title": "Widget", "price": 19.99}, "UDF block allows a bare function call statement before RETURN"),
 		Nil(`
 FUNC risky() (
   RETURN T::FAIL()


### PR DESCRIPTION
This pull request introduces a minor parser improvement and adds a new integration test for user-defined functions (UDFs). The changes focus on improving error handling in the parser and expanding test coverage for UDF syntax.

**Parser improvements:**

* Updated `ErrorListener.ReportAmbiguity` in `error_listener.go` to ignore ambiguities in both `expressionAtom` and `functionStatement` rules, reducing unnecessary error reporting for these cases.

**Test coverage:**

* Added a new integration test in `vm_udf_test.go` to verify that UDF blocks allow bare function call statements before a `RETURN`, ensuring the parser and runtime handle this syntax correctly.