### PR TITLE
feat: updated numeric operand validation for arithmetic operations

### DIFF
--- a/pkg/compiler/internal/binding_assignment_path.go
+++ b/pkg/compiler/internal/binding_assignment_path.go
@@ -63,7 +63,7 @@ func (c *BindingCompiler) compilePathAssignmentStatement(stmt *fql.AssignmentSta
 			return bytecode.NoopOperand
 		}
 
-		value = emitBinaryOperation(c.ctx, c.facts, stmt, op, current, right)
+		value = emitBinaryOperation(c.ctx, c.facts, assignmentOperationSpans(stmt), op, current, right)
 	}
 
 	if value == bytecode.NoopOperand {

--- a/pkg/compiler/internal/binding_compiler.go
+++ b/pkg/compiler/internal/binding_compiler.go
@@ -188,7 +188,15 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 
 		left := c.snapshotBindingValue(binding)
 		right := c.exprs.Compile(stmt.Expression())
+		if right == bytecode.NoopOperand {
+			return bytecode.NoopOperand
+		}
+
 		src = emitBinaryOperation(c.ctx, c.facts, assignmentOperationSpans(stmt), op, left, right)
+	}
+
+	if src == bytecode.NoopOperand {
+		return bytecode.NoopOperand
 	}
 
 	srcType := c.facts.OperandType(src)

--- a/pkg/compiler/internal/binding_compiler.go
+++ b/pkg/compiler/internal/binding_compiler.go
@@ -188,7 +188,7 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 
 		left := c.snapshotBindingValue(binding)
 		right := c.exprs.Compile(stmt.Expression())
-		src = emitBinaryOperation(c.ctx, c.facts, stmt, op, left, right)
+		src = emitBinaryOperation(c.ctx, c.facts, assignmentOperationSpans(stmt), op, left, right)
 	}
 
 	srcType := c.facts.OperandType(src)

--- a/pkg/compiler/internal/binding_compiler_test.go
+++ b/pkg/compiler/internal/binding_compiler_test.go
@@ -327,6 +327,89 @@ RETURN total
 	}
 }
 
+func TestBindingCompilerFailedAssignmentsDoNotReachStorage(t *testing.T) {
+	tests := []struct {
+		name             string
+		query            string
+		diagnostic       string
+		forbiddenOpcodes []bytecode.Opcode
+	}{
+		{
+			name: "plain assignment invalid rhs",
+			query: `
+VAR total = 2
+total = -"x"
+RETURN total
+`,
+			diagnostic: "Operator '-' requires numeric operands",
+		},
+		{
+			name: "augmented assignment invalid numeric operand",
+			query: `
+VAR total = 2
+total *= "x"
+RETURN total
+`,
+			diagnostic:       "Operator '*=' requires numeric operands",
+			forbiddenOpcodes: []bytecode.Opcode{bytecode.OpMul},
+		},
+		{
+			name: "augmented assignment invalid rhs",
+			query: `
+VAR total = 2
+total *= -"x"
+RETURN total
+`,
+			diagnostic:       "Operator '-' requires numeric operands",
+			forbiddenOpcodes: []bytecode.Opcode{bytecode.OpMul},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := newBindingCompilerTestState(t, test.query)
+			compileBindingCompilerTestState(t, state)
+
+			assertBindingCompilerTestFailedAssignment(t, state, "total", core.TypeInt, test.diagnostic)
+
+			instructions := state.session.Program.Emitter.Bytecode()
+			assertBindingCompilerTestNoWriteFromNoop(t, instructions)
+
+			for _, opcode := range test.forbiddenOpcodes {
+				if got := countBindingCompilerTestOpcode(instructions, opcode); got != 0 {
+					t.Fatalf("unexpected %s count: got %d want 0", opcode, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBindingCompilerFailedCellAssignmentDoesNotStore(t *testing.T) {
+	state := newBindingCompilerTestState(t, `
+VAR total = 2
+FUNC update() (
+  total *= "x"
+  RETURN total
+)
+RETURN total
+`)
+
+	compileBindingCompilerTestState(t, state)
+
+	assertBindingCompilerTestFailedAssignment(t, state, "total", core.TypeInt, "Operator '*=' requires numeric operands")
+
+	instructions := state.session.Program.Emitter.Bytecode()
+	assertBindingCompilerTestNoWriteFromNoop(t, instructions)
+
+	if got := countBindingCompilerTestOpcode(instructions, bytecode.OpStoreCell); got != 0 {
+		t.Fatalf("unexpected %s count: got %d want 0", bytecode.OpStoreCell, got)
+	}
+
+	if got := countBindingCompilerTestOpcode(instructions, bytecode.OpMul); got != 0 {
+		t.Fatalf("unexpected %s count: got %d want 0", bytecode.OpMul, got)
+	}
+}
+
 func TestBindingCompilerFailedInitializerDoesNotDeclareBinding(t *testing.T) {
 	state := newBindingCompilerTestState(t, `
 LET x = missing
@@ -517,6 +600,45 @@ func assertBindingCompilerTestNoErrors(t *testing.T, state *bindingCompilerTestS
 
 	if state.errors.HasErrors() {
 		t.Fatalf("unexpected diagnostics:\n%s", state.errors.Errors().Format())
+	}
+}
+
+func assertBindingCompilerTestFailedAssignment(t *testing.T, state *bindingCompilerTestState, name string, expectedType core.ValueType, message string) {
+	t.Helper()
+
+	if got := state.errors.Errors().Size(); got != 1 {
+		t.Fatalf("unexpected diagnostic count: got %d want 1\n%s", got, state.errors.Errors().Format())
+	}
+
+	diag := state.errors.Errors().First()
+	if diag.Kind != parserd.SemanticError {
+		t.Fatalf("unexpected diagnostic kind: got %v want %v", diag.Kind, parserd.SemanticError)
+	}
+
+	if diag.Message != message {
+		t.Fatalf("unexpected diagnostic message: got %q want %q", diag.Message, message)
+	}
+
+	binding, ok := state.session.Function.Symbols.ResolveBinding(name)
+	if !ok {
+		t.Fatalf("expected binding %q to exist", name)
+	}
+
+	if binding.Type != expectedType {
+		t.Fatalf("unexpected binding type: got %v want %v", binding.Type, expectedType)
+	}
+}
+
+func assertBindingCompilerTestNoWriteFromNoop(t *testing.T, instructions []bytecode.Instruction) {
+	t.Helper()
+
+	for i, inst := range instructions {
+		switch inst.Opcode {
+		case bytecode.OpMove, bytecode.OpMoveTracked, bytecode.OpStoreCell:
+			if inst.Operands[1] == bytecode.NoopOperand {
+				t.Fatalf("instruction %d writes from %s: %s", i, bytecode.NoopOperand, inst)
+			}
+		}
 	}
 }
 

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
 type (
@@ -32,6 +34,7 @@ type (
 
 	// atomBinaryOperator represents binary operators used in FQL expressions.
 	atomBinaryOperator struct {
+		text    string
 		opcode  bytecode.Opcode
 		negated bool
 		regexp  bool
@@ -147,6 +150,9 @@ func (c *ExprCompiler) CompileIncDec(token antlr.Token, target bytecode.Operand)
 	}
 
 	operator := token.GetText()
+	if !validateKnownNumericOperands(c.ctx, c.facts, parserd.SpanFromToken(token), operator, target) {
+		return bytecode.NoopOperand
+	}
 
 	switch operator {
 	case "++":
@@ -164,7 +170,6 @@ func (c *ExprCompiler) CompileIncDec(token antlr.Token, target bytecode.Operand)
 
 func (c *ExprCompiler) compileUnary(ctx fql.IUnaryOperatorContext, parent fql.IExpressionContext) bytecode.Operand {
 	src := c.Compile(parent.GetRight())
-	dst := c.ctx.Function.Registers.Allocate()
 
 	var op bytecode.Opcode
 
@@ -178,7 +183,24 @@ func (c *ExprCompiler) compileUnary(ctx fql.IUnaryOperatorContext, parent fql.IE
 		return bytecode.NoopOperand
 	}
 
-	c.ctx.Program.Emitter.EmitAB(op, dst, src)
+	prc, _ := parent.(antlr.ParserRuleContext)
+	span := source.Span{Start: -1, End: -1}
+	if prc != nil {
+		span = parserd.SpanFromRuleContext(prc)
+	}
+
+	if op != bytecode.OpNot && !validateKnownNumericOperands(c.ctx, c.facts, span, ctx.GetText(), src) {
+		return bytecode.NoopOperand
+	}
+
+	dst := c.ctx.Function.Registers.Allocate()
+	c.ctx.Program.Emitter.WithSpan(span, func() {
+		c.ctx.Program.Emitter.EmitAB(op, dst, src)
+	})
+
+	if op != bytecode.OpNot {
+		c.ctx.Function.Types.Set(dst, c.facts.OperandType(src))
+	}
 
 	return dst
 }

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -40,6 +40,13 @@ type (
 		regexp  bool
 	}
 
+	binaryOperationSpans struct {
+		expression   source.Span
+		operator     source.Span
+		leftOperand  source.Span
+		rightOperand source.Span
+	}
+
 	matchResultGroup struct {
 		result fql.IExpressionContext
 		arms   []int
@@ -150,7 +157,13 @@ func (c *ExprCompiler) CompileIncDec(token antlr.Token, target bytecode.Operand)
 	}
 
 	operator := token.GetText()
-	if !validateKnownNumericOperands(c.ctx, c.facts, parserd.SpanFromToken(token), operator, target) {
+	if !validateKnownNumericOperands(
+		c.ctx,
+		c.facts,
+		parserd.SpanFromToken(token),
+		operator,
+		numericOperandDiagnostic{operand: target},
+	) {
 		return bytecode.NoopOperand
 	}
 
@@ -189,7 +202,17 @@ func (c *ExprCompiler) compileUnary(ctx fql.IUnaryOperatorContext, parent fql.IE
 		span = parserd.SpanFromRuleContext(prc)
 	}
 
-	if op != bytecode.OpNot && !validateKnownNumericOperands(c.ctx, c.facts, span, ctx.GetText(), src) {
+	if op != bytecode.OpNot && !validateKnownNumericOperands(
+		c.ctx,
+		c.facts,
+		parserd.SpanFromRuleContext(ctx),
+		ctx.GetText(),
+		numericOperandDiagnostic{
+			operand: src,
+			span:    parserd.SpanFromRuleContext(parent.GetRight()),
+			label:   "operand",
+		},
+	) {
 		return bytecode.NoopOperand
 	}
 

--- a/pkg/compiler/internal/expr_predicate.go
+++ b/pkg/compiler/internal/expr_predicate.go
@@ -263,9 +263,7 @@ func (c *ExprCompiler) compileBinaryAtom(ctx fql.IExpressionAtomContext, op atom
 }
 
 func (c *ExprCompiler) emitBinaryAtomOperation(ctx fql.IExpressionAtomContext, op atomBinaryOperator, left, right bytecode.Operand) bytecode.Operand {
-	prc, _ := ctx.(antlr.ParserRuleContext)
-
-	return emitBinaryOperation(c.ctx, c.facts, prc, op, left, right)
+	return emitBinaryOperation(c.ctx, c.facts, binaryAtomOperationSpans(ctx), op, left, right)
 }
 
 func (c *ExprCompiler) validateRegexpOperand(ctx fql.IExpressionAtomContext) {

--- a/pkg/compiler/internal/expr_predicate_helpers.go
+++ b/pkg/compiler/internal/expr_predicate_helpers.go
@@ -150,23 +150,30 @@ func resolveArithmeticBinaryOperator(operator string) (atomBinaryOperator, bool)
 	}
 }
 
-func emitBinaryOperation(ctx *CompilationSession, facts *TypeFacts, prc antlr.ParserRuleContext, op atomBinaryOperator, left, right bytecode.Operand) bytecode.Operand {
+type numericOperandDiagnostic struct {
+	operand bytecode.Operand
+	span    source.Span
+	label   string
+}
+
+func emitBinaryOperation(ctx *CompilationSession, facts *TypeFacts, spans binaryOperationSpans, op atomBinaryOperator, left, right bytecode.Operand) bytecode.Operand {
 	if ctx == nil {
 		return bytecode.NoopOperand
 	}
 
-	span := source.Span{Start: -1, End: -1}
-
-	if prc != nil {
-		span = parserd.SpanFromRuleContext(prc)
-	}
-
-	if isStrictNumericBinaryOpcode(op.opcode) && !validateKnownNumericOperands(ctx, facts, span, op.text, left, right) {
+	if isStrictNumericBinaryOpcode(op.opcode) && !validateKnownNumericOperands(
+		ctx,
+		facts,
+		spans.operator,
+		op.text,
+		numericOperandDiagnostic{operand: left, span: spans.leftOperand, label: "left operand"},
+		numericOperandDiagnostic{operand: right, span: spans.rightOperand, label: "right operand"},
+	) {
 		return bytecode.NoopOperand
 	}
 
 	dst := ctx.Function.Registers.Allocate()
-	ctx.Program.Emitter.WithSpan(span, func() {
+	ctx.Program.Emitter.WithSpan(spans.expression, func() {
 		ctx.Program.Emitter.EmitABC(op.opcode, dst, left, right)
 
 		if op.negated {
@@ -197,26 +204,42 @@ func isStrictNumericBinaryOpcode(op bytecode.Opcode) bool {
 func validateKnownNumericOperands(
 	ctx *CompilationSession,
 	facts *TypeFacts,
-	span source.Span,
+	operatorSpan source.Span,
 	operator string,
-	operands ...bytecode.Operand,
+	operands ...numericOperandDiagnostic,
 ) bool {
+	spans := []pkgdiagnostics.ErrorSpan{
+		pkgdiagnostics.NewMainErrorSpan(operatorSpan, ""),
+	}
+	invalid := false
+
 	for _, operand := range operands {
-		if knownNumericOperandTypeAllowed(facts.OperandType(operand)) {
+		typ := facts.OperandType(operand.operand)
+		if knownNumericOperandTypeAllowed(typ) {
 			continue
 		}
 
-		ctx.Program.Errors.Add(&pkgdiagnostics.Diagnostic{
-			Kind:    parserd.SemanticError,
-			Message: fmt.Sprintf("Operator '%s' requires numeric operands", operator),
-			Hint:    "Use Int or Float values with this operator.",
-			Spans:   []pkgdiagnostics.ErrorSpan{pkgdiagnostics.NewMainErrorSpan(span, "")},
-		})
-
-		return false
+		invalid = true
+		if operand.label != "" && validDiagnosticSpan(operand.span) {
+			spans = append(spans, pkgdiagnostics.NewSecondaryErrorSpan(
+				operand.span,
+				fmt.Sprintf("%s is %s", operand.label, numericDiagnosticTypeName(typ)),
+			))
+		}
 	}
 
-	return true
+	if !invalid {
+		return true
+	}
+
+	ctx.Program.Errors.Add(&pkgdiagnostics.Diagnostic{
+		Kind:    parserd.SemanticError,
+		Message: fmt.Sprintf("Operator '%s' requires numeric operands", operator),
+		Hint:    "Use Int or Float values with this operator.",
+		Spans:   spans,
+	})
+
+	return false
 }
 
 func knownNumericOperandTypeAllowed(typ core.ValueType) bool {
@@ -225,5 +248,73 @@ func knownNumericOperandTypeAllowed(typ core.ValueType) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func binaryAtomOperationSpans(ctx fql.IExpressionAtomContext) binaryOperationSpans {
+	spans := binaryOperationSpans{
+		expression:   spanFromParserRuleContext(ctx),
+		leftOperand:  spanFromParserRuleContext(ctx.GetLeft()),
+		rightOperand: spanFromParserRuleContext(ctx.GetRight()),
+	}
+
+	if op := ctx.MultiplicativeOperator(); op != nil {
+		spans.operator = parserd.SpanFromRuleContext(op)
+	} else if op := ctx.AdditiveOperator(); op != nil {
+		spans.operator = parserd.SpanFromRuleContext(op)
+	}
+
+	return spans
+}
+
+func assignmentOperationSpans(ctx *fql.AssignmentStatementContext) binaryOperationSpans {
+	if ctx == nil {
+		return binaryOperationSpans{}
+	}
+
+	return binaryOperationSpans{
+		expression:   parserd.SpanFromRuleContext(ctx),
+		operator:     spanFromParserRuleContext(ctx.AssignmentOperator()),
+		leftOperand:  spanFromParserRuleContext(ctx.AssignmentTarget()),
+		rightOperand: spanFromParserRuleContext(ctx.Expression()),
+	}
+}
+
+func spanFromParserRuleContext(ctx antlr.ParserRuleContext) source.Span {
+	if ctx == nil {
+		return source.Span{Start: -1, End: -1}
+	}
+
+	return parserd.SpanFromRuleContext(ctx)
+}
+
+func validDiagnosticSpan(span source.Span) bool {
+	return span.Start >= 0 && span.End > span.Start
+}
+
+func numericDiagnosticTypeName(typ core.ValueType) string {
+	switch typ {
+	case core.TypeNone:
+		return "None"
+	case core.TypeInt:
+		return "Int"
+	case core.TypeFloat:
+		return "Float"
+	case core.TypeString:
+		return "String"
+	case core.TypeBool:
+		return "Bool"
+	case core.TypeArray:
+		return "Array"
+	case core.TypeObject:
+		return "Object"
+	case core.TypeList:
+		return "List"
+	case core.TypeMap:
+		return "Map"
+	case core.TypeAny:
+		return "Any"
+	default:
+		return "Unknown"
 	}
 }

--- a/pkg/compiler/internal/expr_predicate_helpers.go
+++ b/pkg/compiler/internal/expr_predicate_helpers.go
@@ -1,11 +1,14 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/antlr4-go/antlr/v4"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
-	"github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	pkgdiagnostics "github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
@@ -121,6 +124,7 @@ func resolveAtomBinaryOperator(ctx fql.IExpressionAtomContext) (atomBinaryOperat
 	if op := ctx.RegexpOperator(); op != nil {
 		return atomBinaryOperator{
 			opcode:  bytecode.OpRegexp,
+			text:    op.GetText(),
 			negated: op.GetText() == "!~",
 			regexp:  true,
 		}, true
@@ -132,15 +136,15 @@ func resolveAtomBinaryOperator(ctx fql.IExpressionAtomContext) (atomBinaryOperat
 func resolveArithmeticBinaryOperator(operator string) (atomBinaryOperator, bool) {
 	switch operator {
 	case "+", "+=":
-		return atomBinaryOperator{opcode: bytecode.OpAdd}, true
+		return atomBinaryOperator{opcode: bytecode.OpAdd, text: operator}, true
 	case "-", "-=":
-		return atomBinaryOperator{opcode: bytecode.OpSub}, true
+		return atomBinaryOperator{opcode: bytecode.OpSub, text: operator}, true
 	case "*", "*=":
-		return atomBinaryOperator{opcode: bytecode.OpMul}, true
+		return atomBinaryOperator{opcode: bytecode.OpMul, text: operator}, true
 	case "/", "/=":
-		return atomBinaryOperator{opcode: bytecode.OpDiv}, true
+		return atomBinaryOperator{opcode: bytecode.OpDiv, text: operator}, true
 	case "%":
-		return atomBinaryOperator{opcode: bytecode.OpMod}, true
+		return atomBinaryOperator{opcode: bytecode.OpMod, text: operator}, true
 	default:
 		return atomBinaryOperator{}, false
 	}
@@ -151,13 +155,17 @@ func emitBinaryOperation(ctx *CompilationSession, facts *TypeFacts, prc antlr.Pa
 		return bytecode.NoopOperand
 	}
 
-	dst := ctx.Function.Registers.Allocate()
 	span := source.Span{Start: -1, End: -1}
 
 	if prc != nil {
-		span = diagnostics.SpanFromRuleContext(prc)
+		span = parserd.SpanFromRuleContext(prc)
 	}
 
+	if isStrictNumericBinaryOpcode(op.opcode) && !validateKnownNumericOperands(ctx, facts, span, op.text, left, right) {
+		return bytecode.NoopOperand
+	}
+
+	dst := ctx.Function.Registers.Allocate()
 	ctx.Program.Emitter.WithSpan(span, func() {
 		ctx.Program.Emitter.EmitABC(op.opcode, dst, left, right)
 
@@ -175,4 +183,47 @@ func emitBinaryOperation(ctx *CompilationSession, facts *TypeFacts, prc antlr.Pa
 	}
 
 	return dst
+}
+
+func isStrictNumericBinaryOpcode(op bytecode.Opcode) bool {
+	switch op {
+	case bytecode.OpSub, bytecode.OpMul, bytecode.OpDiv, bytecode.OpMod:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateKnownNumericOperands(
+	ctx *CompilationSession,
+	facts *TypeFacts,
+	span source.Span,
+	operator string,
+	operands ...bytecode.Operand,
+) bool {
+	for _, operand := range operands {
+		if knownNumericOperandTypeAllowed(facts.OperandType(operand)) {
+			continue
+		}
+
+		ctx.Program.Errors.Add(&pkgdiagnostics.Diagnostic{
+			Kind:    parserd.SemanticError,
+			Message: fmt.Sprintf("Operator '%s' requires numeric operands", operator),
+			Hint:    "Use Int or Float values with this operator.",
+			Spans:   []pkgdiagnostics.ErrorSpan{pkgdiagnostics.NewMainErrorSpan(span, "")},
+		})
+
+		return false
+	}
+
+	return true
+}
+
+func knownNumericOperandTypeAllowed(typ core.ValueType) bool {
+	switch typ {
+	case core.TypeUnknown, core.TypeAny, core.TypeInt, core.TypeFloat:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/compiler/internal/optimization/const_eval.go
+++ b/pkg/compiler/internal/optimization/const_eval.go
@@ -95,8 +95,10 @@ func foldBinary(op bytecode.Opcode, left, right runtime.Value, bg context.Contex
 			return nil, false
 		}
 
-		if ri, ok := right.(runtime.Int); ok && ri == 0 {
-			return nil, false
+		if _, ok := left.(runtime.Int); ok {
+			if ri, ok := right.(runtime.Int); ok && ri == 0 {
+				return nil, false
+			}
 		}
 
 		return runtime.Divide(bg, left, right), true

--- a/pkg/compiler/internal/optimization/const_eval.go
+++ b/pkg/compiler/internal/optimization/const_eval.go
@@ -58,8 +58,16 @@ func foldUnary(op bytecode.Opcode, val runtime.Value, bg context.Context) (runti
 	case bytecode.OpNegate:
 		return negate(val), true
 	case bytecode.OpFlipPositive:
+		if !isNumericValue(val) {
+			return nil, false
+		}
+
 		return positive(val), true
 	case bytecode.OpFlipNegative:
+		if !isNumericValue(val) {
+			return nil, false
+		}
+
 		return negative(val), true
 	default:
 		return nil, false
@@ -71,21 +79,32 @@ func foldBinary(op bytecode.Opcode, left, right runtime.Value, bg context.Contex
 	case bytecode.OpAdd:
 		return runtime.Add(bg, left, right), true
 	case bytecode.OpSub:
+		if !areNumericValues(left, right) {
+			return nil, false
+		}
+
 		return runtime.Subtract(bg, left, right), true
 	case bytecode.OpMul:
+		if !areNumericValues(left, right) {
+			return nil, false
+		}
+
 		return runtime.Multiply(bg, left, right), true
 	case bytecode.OpDiv:
-		lv := runtime.ToNumberOnly(bg, left)
+		if !areNumericValues(left, right) {
+			return nil, false
+		}
 
-		if _, ok := lv.(runtime.Int); ok {
-			rv := runtime.ToNumberOnly(bg, right)
-			if ri, ok := rv.(runtime.Int); ok && ri == 0 {
-				return nil, false
-			}
+		if ri, ok := right.(runtime.Int); ok && ri == 0 {
+			return nil, false
 		}
 
 		return runtime.Divide(bg, left, right), true
 	case bytecode.OpMod:
+		if !areNumericValues(left, right) {
+			return nil, false
+		}
+
 		if r, _ := runtime.ToInt(bg, right); r == 0 {
 			return nil, false
 		}
@@ -269,6 +288,19 @@ func increment(ctx context.Context, input runtime.Value) runtime.Value {
 	default:
 		return runtime.None
 	}
+}
+
+func isNumericValue(value runtime.Value) bool {
+	switch value.(type) {
+	case runtime.Int, runtime.Float:
+		return true
+	default:
+		return false
+	}
+}
+
+func areNumericValues(left, right runtime.Value) bool {
+	return isNumericValue(left) && isNumericValue(right)
 }
 
 func decrement(ctx context.Context, input runtime.Value) runtime.Value {

--- a/pkg/compiler/internal/optimization/const_eval_math_test.go
+++ b/pkg/compiler/internal/optimization/const_eval_math_test.go
@@ -1,0 +1,39 @@
+package optimization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+func TestFoldBinaryRejectsNonNumericMathOperands(t *testing.T) {
+	for _, op := range []bytecode.Opcode{bytecode.OpSub, bytecode.OpMul, bytecode.OpDiv, bytecode.OpMod} {
+		t.Run(op.String(), func(t *testing.T) {
+			if out, ok := foldBinary(op, runtime.NewString("3"), runtime.NewInt(2), context.Background()); ok || out != nil {
+				t.Fatalf("expected %s with non-numeric operand not to fold, got value=%v ok=%v", op, out, ok)
+			}
+		})
+	}
+}
+
+func TestFoldUnaryRejectsNonNumericMathOperands(t *testing.T) {
+	for _, op := range []bytecode.Opcode{bytecode.OpFlipPositive, bytecode.OpFlipNegative} {
+		t.Run(op.String(), func(t *testing.T) {
+			if out, ok := foldUnary(op, runtime.NewString("3"), context.Background()); ok || out != nil {
+				t.Fatalf("expected %s with non-numeric operand not to fold, got value=%v ok=%v", op, out, ok)
+			}
+		})
+	}
+}
+
+func TestFoldIncDecRejectsNonNumericOperands(t *testing.T) {
+	for _, op := range []bytecode.Opcode{bytecode.OpIncr, bytecode.OpDecr} {
+		t.Run(op.String(), func(t *testing.T) {
+			if out, ok := foldIncDecValue(op, runtime.NewString("3"), context.Background()); ok || out != nil {
+				t.Fatalf("expected %s with non-numeric operand not to fold, got value=%v ok=%v", op, out, ok)
+			}
+		})
+	}
+}

--- a/pkg/compiler/internal/optimization/const_eval_math_test.go
+++ b/pkg/compiler/internal/optimization/const_eval_math_test.go
@@ -2,6 +2,7 @@ package optimization
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
@@ -13,6 +14,42 @@ func TestFoldBinaryRejectsNonNumericMathOperands(t *testing.T) {
 		t.Run(op.String(), func(t *testing.T) {
 			if out, ok := foldBinary(op, runtime.NewString("3"), runtime.NewInt(2), context.Background()); ok || out != nil {
 				t.Fatalf("expected %s with non-numeric operand not to fold, got value=%v ok=%v", op, out, ok)
+			}
+		})
+	}
+}
+
+func TestFoldBinaryDivisionByZeroMatchesRuntimeSemantics(t *testing.T) {
+	tests := []struct {
+		left       runtime.Value
+		right      runtime.Value
+		name       string
+		shouldFold bool
+	}{
+		{name: "int by int zero", left: runtime.NewInt(1), right: runtime.ZeroInt, shouldFold: false},
+		{name: "float by int zero", left: runtime.NewFloat(1), right: runtime.ZeroInt, shouldFold: true},
+		{name: "int by float zero", left: runtime.NewInt(1), right: runtime.ZeroFloat, shouldFold: true},
+		{name: "float by float zero", left: runtime.NewFloat(1), right: runtime.ZeroFloat, shouldFold: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, ok := foldBinary(bytecode.OpDiv, test.left, test.right, context.Background())
+			if ok != test.shouldFold {
+				t.Fatalf("expected fold=%v, got value=%v fold=%v", test.shouldFold, out, ok)
+			}
+
+			if !test.shouldFold {
+				if out != nil {
+					t.Fatalf("expected no folded value, got %v", out)
+				}
+
+				return
+			}
+
+			value, ok := out.(runtime.Float)
+			if !ok || !math.IsInf(float64(value), 1) {
+				t.Fatalf("expected positive infinity, got %T(%v)", out, out)
 			}
 		})
 	}

--- a/pkg/compiler/internal/optimization/const_fold.go
+++ b/pkg/compiler/internal/optimization/const_fold.go
@@ -96,6 +96,10 @@ func foldIncDecInstruction(inst *bytecode.Instruction, env constFoldEnv, result 
 }
 
 func foldIncDecValue(op bytecode.Opcode, val runtime.Value, bg context.Context) (runtime.Value, bool) {
+	if !isNumericValue(val) {
+		return nil, false
+	}
+
 	if op == bytecode.OpIncr {
 		return increment(bg, val), true
 	}

--- a/pkg/vm/arithmetic.go
+++ b/pkg/vm/arithmetic.go
@@ -1,0 +1,15 @@
+package vm
+
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
+
+func assertNumericOperand(value runtime.Value) error {
+	return runtime.AssertNumber(value)
+}
+
+func assertNumericOperands(left, right runtime.Value) error {
+	if err := runtime.AssertNumber(left); err != nil {
+		return err
+	}
+
+	return runtime.AssertNumber(right)
+}

--- a/pkg/vm/arithmetic_test.go
+++ b/pkg/vm/arithmetic_test.go
@@ -1,0 +1,37 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+func TestIncDecRejectNonNumericOperands(t *testing.T) {
+	for _, op := range []bytecode.Opcode{bytecode.OpIncr, bytecode.OpDecr} {
+		t.Run(op.String(), func(t *testing.T) {
+			program := newTestProgram(
+				1,
+				[]runtime.Value{runtime.NewString("3")},
+				bytecode.NewInstruction(bytecode.OpLoadConst, bytecode.NewRegister(0), bytecode.NewConstant(0)),
+				bytecode.NewInstruction(op, bytecode.NewRegister(0)),
+				bytecode.NewInstruction(bytecode.OpReturn, bytecode.NewRegister(0)),
+			)
+
+			_, err := mustNewVM(t, program).Run(context.Background(), NewDefaultEnvironment())
+			if err == nil {
+				t.Fatal("expected runtime error")
+			}
+
+			var runtimeErr *RuntimeError
+			if !errors.As(err, &runtimeErr) {
+				t.Fatalf("expected runtime error, got %T", err)
+			}
+			if runtimeErr.Message != "invalid type" {
+				t.Fatalf("unexpected runtime error message: got %q, want %q", runtimeErr.Message, "invalid type")
+			}
+		})
+	}
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -883,10 +883,25 @@ loop:
 		case bytecode.OpConcat:
 			reg[dst] = concatStrings(reg, src1, src2)
 		case bytecode.OpSub:
+			if err := assertNumericOperands(reg[src1], reg[src2]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = runtime.Subtract(ctx, reg[src1], reg[src2])
 		case bytecode.OpMul:
+			if err := assertNumericOperands(reg[src1], reg[src2]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = runtime.Multiply(ctx, reg[src1], reg[src2])
 		case bytecode.OpDiv:
+			if err := assertNumericOperands(reg[src1], reg[src2]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			if err := state.checkDivisionByZeroAt(ctx, pc, reg[src1], reg[src2]); err != nil {
 				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
 				break
@@ -894,6 +909,11 @@ loop:
 
 			reg[dst] = runtime.Divide(ctx, reg[src1], reg[src2])
 		case bytecode.OpMod:
+			if err := assertNumericOperands(reg[src1], reg[src2]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			if err := state.checkModuloByZeroAt(ctx, pc, reg[src2]); err != nil {
 				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
 				break
@@ -901,14 +921,34 @@ loop:
 
 			reg[dst] = runtime.Modulus(ctx, reg[src1], reg[src2])
 		case bytecode.OpIncr:
+			if err := assertNumericOperand(reg[dst]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = runtime.Increment(ctx, reg[dst])
 		case bytecode.OpDecr:
+			if err := assertNumericOperand(reg[dst]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = runtime.Decrement(ctx, reg[dst])
 		case bytecode.OpNegate:
 			reg[dst] = negate(reg[src1])
 		case bytecode.OpFlipPositive:
+			if err := assertNumericOperand(reg[src1]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = positive(reg[src1])
 		case bytecode.OpFlipNegative:
+			if err := assertNumericOperand(reg[src1]); err != nil {
+				state.raiseRuntimeAt(pc, err, recoverDefault, bytecode.NoopOperand, nil, false)
+				break
+			}
+
 			reg[dst] = negative(reg[src1])
 		case bytecode.OpCastBool:
 			reg[dst] = coerceBool(reg[src1])

--- a/test/benchmarks/bench_constprop_test.go
+++ b/test/benchmarks/bench_constprop_test.go
@@ -10,10 +10,23 @@ FOR i IN [1,2,3,4,5,6,7,8,9,10]
   RETURN v
 `
 
+const constPropFloatDivisionByIntZeroExpr = `
+FOR i IN 1..1000
+  RETURN 1.0 / 0
+`
+
 func BenchmarkConstPropagation_O0(b *testing.B) {
 	RunBenchmarkO0(b, constPropExpr)
 }
 
 func BenchmarkConstPropagation_O1(b *testing.B) {
 	RunBenchmarkO1(b, constPropExpr)
+}
+
+func BenchmarkConstPropagationFloatDivisionByIntZero_O0(b *testing.B) {
+	RunBenchmarkO0(b, constPropFloatDivisionByIntZeroExpr)
+}
+
+func BenchmarkConstPropagationFloatDivisionByIntZero_O1(b *testing.B) {
+	RunBenchmarkO1(b, constPropFloatDivisionByIntZeroExpr)
 }

--- a/test/benchmarks/bench_math_operators_test.go
+++ b/test/benchmarks/bench_math_operators_test.go
@@ -1,0 +1,35 @@
+package benchmarks_test
+
+import "testing"
+
+const mathOperatorsQuery = `
+FOR i IN 1..1000
+  LET sub = @left - @right
+  LET mul = sub * @factor
+  LET div = mul / @divisor
+  RETURN div % @modulus
+`
+
+func BenchmarkMathOperators_O0(b *testing.B) {
+	RunBenchmarkO0(
+		b,
+		mathOperatorsQuery,
+		WithParam("left", 42),
+		WithParam("right", 2),
+		WithParam("factor", 3),
+		WithParam("divisor", 4),
+		WithParam("modulus", 7),
+	)
+}
+
+func BenchmarkMathOperators_O1(b *testing.B) {
+	RunBenchmarkO1(
+		b,
+		mathOperatorsQuery,
+		WithParam("left", 42),
+		WithParam("right", 2),
+		WithParam("factor", 3),
+		WithParam("divisor", 4),
+		WithParam("modulus", 7),
+	)
+}

--- a/test/integration/compiler/compiler_math_operators_test.go
+++ b/test/integration/compiler/compiler_math_operators_test.go
@@ -1,0 +1,28 @@
+package compiler_test
+
+import (
+	"testing"
+
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/test/spec"
+	. "github.com/MontFerret/ferret/v2/test/spec/compile"
+)
+
+func TestMathOperatorsRejectKnownNonNumericOperands(t *testing.T) {
+	expected := func(operator string) E {
+		return E{
+			Kind:    parserd.SemanticError,
+			Message: "Operator '" + operator + "' requires numeric operands",
+			Hint:    "Use Int or Float values with this operator.",
+		}
+	}
+
+	RunSpecs(t, []spec.Spec{
+		Failure(`RETURN [120, 45, 300] * 2`, expected("*"), "array multiplication"),
+		Failure(`RETURN "3" * 2`, expected("*"), "string multiplication"),
+		Failure(`RETURN TRUE - 1`, expected("-"), "boolean subtraction"),
+		Failure(`RETURN {} / 2`, expected("/"), "object division"),
+		Failure(`RETURN -"x"`, expected("-"), "string unary negative"),
+		Failure(`RETURN +"3"`, expected("+"), "string unary positive"),
+	})
+}

--- a/test/integration/compiler/compiler_math_operators_test.go
+++ b/test/integration/compiler/compiler_math_operators_test.go
@@ -1,9 +1,13 @@
 package compiler_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/compile"
 )
@@ -25,4 +29,120 @@ func TestMathOperatorsRejectKnownNonNumericOperands(t *testing.T) {
 		Failure(`RETURN -"x"`, expected("-"), "string unary negative"),
 		Failure(`RETURN +"3"`, expected("+"), "string unary positive"),
 	})
+}
+
+func TestMathOperatorDiagnosticSpansMultiline(t *testing.T) {
+	src := `RETURN [
+    120,
+    45,
+    300
+] * 2`
+	diag := compileMathOperatorDiagnostic(t, "arithmetic.fql", src)
+
+	assertMathOperatorDiagnostic(t, diag, "*", 2)
+	assertMathOperatorSpan(t, diag.Spans[0], strings.Index(src, "*"), strings.Index(src, "*")+1, "", true)
+	assertMathOperatorSpan(t, diag.Spans[1], strings.Index(src, "["), strings.Index(src, "]")+1, "left operand is Array", false)
+
+	expected := `SemanticError: Operator '*' requires numeric operands
+ --> arithmetic.fql:1:8
+  |
+1 | RETURN [
+  |        ^ left operand is Array
+2 |     120,
+ --> arithmetic.fql:5:3
+  |
+4 |     300
+5 | ] * 2
+  |   ^
+Hint: Use Int or Float values with this operator.
+`
+	if actual := diag.Format(); actual != expected {
+		t.Fatalf("unexpected formatted diagnostic:\n%s\nDiff expected:\n%s", actual, expected)
+	}
+}
+
+func TestMathOperatorDiagnosticIdentifiesInvalidOperands(t *testing.T) {
+	t.Run("right operand", func(t *testing.T) {
+		src := `RETURN 2 * "x"`
+		diag := compileMathOperatorDiagnostic(t, "right_operand.fql", src)
+
+		assertMathOperatorDiagnostic(t, diag, "*", 2)
+		assertMathOperatorSpan(t, diag.Spans[0], strings.Index(src, "*"), strings.Index(src, "*")+1, "", true)
+		assertMathOperatorSpan(t, diag.Spans[1], strings.Index(src, `"x"`), strings.Index(src, `"x"`)+3, "right operand is String", false)
+	})
+
+	t.Run("both operands", func(t *testing.T) {
+		src := `RETURN TRUE * {}`
+		diag := compileMathOperatorDiagnostic(t, "both_operands.fql", src)
+
+		assertMathOperatorDiagnostic(t, diag, "*", 3)
+		assertMathOperatorSpan(t, diag.Spans[0], strings.Index(src, "*"), strings.Index(src, "*")+1, "", true)
+		assertMathOperatorSpan(t, diag.Spans[1], strings.Index(src, "TRUE"), strings.Index(src, "TRUE")+4, "left operand is Bool", false)
+		assertMathOperatorSpan(t, diag.Spans[2], strings.Index(src, "{}"), strings.Index(src, "{}")+2, "right operand is Object", false)
+	})
+
+	t.Run("unary operand", func(t *testing.T) {
+		src := `RETURN -"x"`
+		diag := compileMathOperatorDiagnostic(t, "unary_operand.fql", src)
+
+		assertMathOperatorDiagnostic(t, diag, "-", 2)
+		assertMathOperatorSpan(t, diag.Spans[0], strings.Index(src, "-"), strings.Index(src, "-")+1, "", true)
+		assertMathOperatorSpan(t, diag.Spans[1], strings.Index(src, `"x"`), strings.Index(src, `"x"`)+3, "operand is String", false)
+	})
+
+	t.Run("augmented assignment right operand", func(t *testing.T) {
+		src := "VAR total = 2\ntotal *= \"x\"\nRETURN total"
+		diag := compileMathOperatorDiagnostic(t, "assignment_operand.fql", src)
+
+		assertMathOperatorDiagnostic(t, diag, "*=", 2)
+		assertMathOperatorSpan(t, diag.Spans[0], strings.Index(src, "*="), strings.Index(src, "*=")+2, "", true)
+		assertMathOperatorSpan(t, diag.Spans[1], strings.Index(src, `"x"`), strings.Index(src, `"x"`)+3, "right operand is String", false)
+	})
+}
+
+func compileMathOperatorDiagnostic(t *testing.T, name, src string) *diagnostics.Diagnostic {
+	t.Helper()
+
+	_, err := compiler.New().Compile(source.New(name, src))
+	if err == nil {
+		t.Fatal("expected compilation error")
+	}
+
+	diag := firstCompilationError(err)
+	if diag == nil {
+		t.Fatalf("expected diagnostic, got %T", err)
+	}
+
+	return diag
+}
+
+func assertMathOperatorDiagnostic(t *testing.T, diag *diagnostics.Diagnostic, operator string, spanCount int) {
+	t.Helper()
+
+	if diag.Kind != parserd.SemanticError {
+		t.Fatalf("unexpected diagnostic kind: got %s want %s", diag.Kind, parserd.SemanticError)
+	}
+	if diag.Message != "Operator '"+operator+"' requires numeric operands" {
+		t.Fatalf("unexpected diagnostic message: %q", diag.Message)
+	}
+	if diag.Hint != "Use Int or Float values with this operator." {
+		t.Fatalf("unexpected diagnostic hint: %q", diag.Hint)
+	}
+	if len(diag.Spans) != spanCount {
+		t.Fatalf("unexpected span count: got %d want %d", len(diag.Spans), spanCount)
+	}
+}
+
+func assertMathOperatorSpan(t *testing.T, actual diagnostics.ErrorSpan, start, end int, label string, main bool) {
+	t.Helper()
+
+	if actual.Span.Start != start || actual.Span.End != end {
+		t.Fatalf("unexpected span: got [%d,%d) want [%d,%d)", actual.Span.Start, actual.Span.End, start, end)
+	}
+	if actual.Label != label {
+		t.Fatalf("unexpected span label: got %q want %q", actual.Label, label)
+	}
+	if actual.Main != main {
+		t.Fatalf("unexpected main flag: got %t want %t", actual.Main, main)
+	}
 }

--- a/test/integration/optimization/constant_propagation_test.go
+++ b/test/integration/optimization/constant_propagation_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	"github.com/MontFerret/ferret/v2/test/spec/compile"
 	. "github.com/MontFerret/ferret/v2/test/spec/optimize"
@@ -23,8 +24,8 @@ func TestConstantPropagation(t *testing.T) {
 			Exists: []bytecode.Opcode{bytecode.OpDiv},
 		}, runtime.ErrInvalidOperation, "should not fold division by zero"),
 
-		OpcodeErr(`RETURN 1 / "0"`, compile.OpcodeExistence{
+		OpcodeErr(`RETURN 1 / @zero`, compile.OpcodeExistence{
 			Exists: []bytecode.Opcode{bytecode.OpDiv},
-		}, runtime.ErrInvalidOperation, "should not fold division by zero with string"),
+		}, runtime.ErrInvalidOperation, "should not fold division by zero with dynamic value").Env(vm.WithParam("zero", runtime.ZeroInt)),
 	})
 }

--- a/test/integration/optimization/constant_propagation_test.go
+++ b/test/integration/optimization/constant_propagation_test.go
@@ -20,6 +20,13 @@ func TestConstantPropagation(t *testing.T) {
 
 		OpcodeNotExists(`LET a = 10 RETURN (a - 3) * 2`, []bytecode.Opcode{bytecode.OpSub, bytecode.OpMul}, 14, "should fold chain of arithmetic operations"),
 
+		OpcodeNotExists(`RETURN 1.0 / 0`, []bytecode.Opcode{bytecode.OpDiv}, "+Inf", "should fold float division by integer zero").
+			Raw(),
+
+		OpcodeExists(`RETURN 1.0 / @zero`, []bytecode.Opcode{bytecode.OpDiv}, "+Inf", "should preserve dynamic float division by integer zero").
+			Raw().
+			Env(vm.WithParam("zero", runtime.ZeroInt)),
+
 		OpcodeErr(`RETURN 1 / 0`, compile.OpcodeExistence{
 			Exists: []bytecode.Opcode{bytecode.OpDiv},
 		}, runtime.ErrInvalidOperation, "should not fold division by zero"),

--- a/test/integration/vm/vm_op_math_test.go
+++ b/test/integration/vm/vm_op_math_test.go
@@ -3,6 +3,8 @@ package vm_test
 import (
 	"testing"
 
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/exec"
 )
@@ -25,10 +27,40 @@ func TestMathOperators(t *testing.T) {
 		S(`RETURN 1 / 2.0`, 0.5),
 		S(`RETURN 1.0 / 2.0`, 0.5),
 		S(`RETURN 5 % 2`, 1),
+		S(`RETURN "a" + 1`, "a1"),
 		S(`
 LET a = 1
 LET b = 2
 RETURN (a - b) / 2
 `, -0.5),
 	})
+}
+
+func TestMathOperatorsRejectDynamicNonNumericOperands(t *testing.T) {
+	tests := []struct {
+		value runtime.Value
+		name  string
+		query string
+	}{
+		{name: "subtract string", query: `RETURN @value - 1`, value: runtime.NewString("3")},
+		{name: "multiply array", query: `RETURN @value * 2`, value: runtime.NewArrayWith(runtime.NewInt(120), runtime.NewInt(45), runtime.NewInt(300))},
+		{name: "multiply string", query: `RETURN @value * 2`, value: runtime.NewString("3")},
+		{name: "multiply boolean", query: `RETURN @value * 2`, value: runtime.True},
+		{name: "divide object", query: `RETURN @value / 2`, value: runtime.NewObject()},
+		{name: "modulo boolean", query: `RETURN @value % 2`, value: runtime.True},
+		{name: "unary negative string", query: `RETURN -@value`, value: runtime.NewString("3")},
+		{name: "unary positive boolean", query: `RETURN +@value`, value: runtime.True},
+	}
+
+	specs := make([]spec.Spec, 0, len(tests))
+	for _, test := range tests {
+		specs = append(specs,
+			spec.NewSpec(test.query, test.name).
+				Env(vm.WithParam("value", test.value)).
+				Expect().
+				ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "invalid type"}),
+		)
+	}
+
+	RunSpecs(t, specs)
 }

--- a/test/integration/vm/vm_runtime_regressions_integration_test.go
+++ b/test/integration/vm/vm_runtime_regressions_integration_test.go
@@ -347,7 +347,8 @@ func TestHostNilResultIsNormalizedToNone(t *testing.T) {
 func TestModuloTypeErrorNotMisclassifiedAsModuloByZero(t *testing.T) {
 	RunSpecFactory(t, func() []spec.Spec {
 		return []spec.Spec{
-			spec.NewSpec(`RETURN 5 % "x"`).
+			spec.NewSpec(`RETURN 5 % @value`).
+				Env(vm.WithParam("value", runtime.NewString("x"))).
 				Expect().ExecError(assert.NewUnaryAssertion(func(actual any) error {
 				err, ok := actual.(error)
 				if !ok || err == nil {


### PR DESCRIPTION
This pull request enforces strict numeric operand requirements for all arithmetic operators (subtraction, multiplication, division, modulo, unary plus/minus, increment, decrement) throughout the Ferret compiler, optimizer, and VM. Now, only operands of type `Int` or `Float` are accepted for these operations. Non-numeric operands are rejected at compile-time when possible, with clear semantic errors, and at runtime otherwise, resulting in consistent error handling. Comprehensive tests and benchmarks have been added to verify this behavior.

**Compiler and Semantic Analysis:**
- Added compile-time validation (`validateKnownNumericOperands`) to reject non-numeric operands for all strict math operators, emitting semantic errors with clear messages and hints. This covers both binary and unary math operators. [[1]](diffhunk://#diff-8933509822f2c1ec39a80f83a73147f9723915a2f9d1b86ffde9f0f65212cfa4R153-R155) [[2]](diffhunk://#diff-9f76e02d8a9e7d236de98d745b29992d2847ca83d9806df0e173f39450c70a51L154-R168) [[3]](diffhunk://#diff-9f76e02d8a9e7d236de98d745b29992d2847ca83d9806df0e173f39450c70a51R187-R229) [[4]](diffhunk://#diff-a1a9f65641cba02d02027b216236ac9a7ece908ccb55a4661a0eea722c0fbf7eR1-R28)
- Updated operator resolution and operator structs to track operator text for better error reporting. [[1]](diffhunk://#diff-8933509822f2c1ec39a80f83a73147f9723915a2f9d1b86ffde9f0f65212cfa4R37) [[2]](diffhunk://#diff-9f76e02d8a9e7d236de98d745b29992d2847ca83d9806df0e173f39450c70a51R127) [[3]](diffhunk://#diff-9f76e02d8a9e7d236de98d745b29992d2847ca83d9806df0e173f39450c70a51L135-R147)

**Optimizer:**
- The constant folding optimizer now refuses to fold math expressions with non-numeric operands, ensuring that only valid numeric types are folded. Helper functions `isNumericValue` and `areNumericValues` were added for this purpose. [[1]](diffhunk://#diff-c1aa62fcaf99b157ebb374b36938ed3300fdfed7929f6efa471a0abe94b3d8c0R61-R70) [[2]](diffhunk://#diff-c1aa62fcaf99b157ebb374b36938ed3300fdfed7929f6efa471a0abe94b3d8c0R82-R107) [[3]](diffhunk://#diff-4dc0363fbf5ae5fde5b3efde9dcc81a873ff9d430224fb6bebe3772d70405c69R99-R102) [[4]](diffhunk://#diff-c1aa62fcaf99b157ebb374b36938ed3300fdfed7929f6efa471a0abe94b3d8c0R293-R305)
- Added tests to ensure that constant folding does not incorrectly fold invalid math expressions.

**Virtual Machine (VM):**
- Introduced runtime assertions (`assertNumericOperand`, `assertNumericOperands`) in the VM to check operand types before executing math instructions, raising runtime errors for invalid types. [[1]](diffhunk://#diff-0a390aaf501ae36928a63dd4a3fe7dd716acd6fa853adb28dfafbb0c9db58a58R1-R15) [[2]](diffhunk://#diff-5184da1da3707411ccc455aba81effcc985af06f4ab0c3e0bd8d827fb2c363dcR886-R951)
- Added integration tests to verify that the VM raises runtime errors when math operators are used with non-numeric operands. [[1]](diffhunk://#diff-491c7bf6c4142d637ad32cdb4673cf17efcfa199a79f6e17d5e39d1edf215f96R1-R37) [[2]](diffhunk://#diff-f0162bac6026f4f62c925d9819dbac9e0556ea90dddb6b58a3a03dfecf6fa70cR30-R66)

**Testing and Benchmarks:**
- Added integration and compiler tests to verify both compile-time and runtime error handling for invalid math operands. [[1]](diffhunk://#diff-a1a9f65641cba02d02027b216236ac9a7ece908ccb55a4661a0eea722c0fbf7eR1-R28) [[2]](diffhunk://#diff-f0162bac6026f4f62c925d9819dbac9e0556ea90dddb6b58a3a03dfecf6fa70cR30-R66) [[3]](diffhunk://#diff-10112f179d7af585ec597655833f8dab687a247178ddecbf37549aa0a22eb0e9R1-R39)
- Added math operator benchmarks to ensure performance is maintained.

These changes ensure strict type safety and consistent error handling for all math operations across the Ferret language.