### PR TITLE
feat: enhance WAITFOR predicate handling

### DIFF
--- a/pkg/compiler/internal/wait_helpers.go
+++ b/pkg/compiler/internal/wait_helpers.go
@@ -137,6 +137,15 @@ func literalFromExpression(ctx fql.IExpressionContext) fql.ILiteralContext {
 	return atom.Literal()
 }
 
+func literalPresentFromExpression(ctx fql.IExpressionContext) (bool, bool) {
+	lit := literalFromExpression(ctx)
+	if lit == nil {
+		return false, false
+	}
+
+	return lit.NoneLiteral() == nil, true
+}
+
 func literalExistsFromExpression(ctx fql.IExpressionContext) (bool, bool) {
 	lit := literalFromExpression(ctx)
 	if lit == nil {

--- a/pkg/compiler/internal/wait_polling.go
+++ b/pkg/compiler/internal/wait_polling.go
@@ -39,6 +39,22 @@ func (c *WaitCompiler) tryCompileWaitPredicateFastPath(config waitPredicateCompi
 		}
 
 		return bytecode.NoopOperand, false
+	case waitForPredicateModeValue:
+		present, ok := literalPresentFromExpression(config.predExpr)
+		if !ok {
+			return bytecode.NoopOperand, false
+		}
+
+		if present {
+			return c.exprs.Compile(config.predExpr), true
+		}
+
+		if config.timeoutReg != bytecode.NoopOperand {
+			c.ctx.Program.Emitter.EmitA(bytecode.OpSleep, config.timeoutReg)
+			return c.emitImmediateWaitNone(), true
+		}
+
+		return bytecode.NoopOperand, false
 	default:
 		exists, ok := literalExistsFromExpression(config.predExpr)
 		if !ok {
@@ -51,19 +67,11 @@ func (c *WaitCompiler) tryCompileWaitPredicateFastPath(config waitPredicateCompi
 		}
 
 		if cond {
-			if config.mode == waitForPredicateModeValue {
-				return c.exprs.Compile(config.predExpr), true
-			}
-
 			return c.emitImmediateWaitBool(true), true
 		}
 
 		if config.timeoutReg != bytecode.NoopOperand {
 			c.ctx.Program.Emitter.EmitA(bytecode.OpSleep, config.timeoutReg)
-			if config.mode == waitForPredicateModeValue {
-				return c.emitImmediateWaitNone(), true
-			}
-
 			return c.emitImmediateWaitBool(false), true
 		}
 
@@ -160,16 +168,24 @@ func (c *WaitCompiler) emitWaitPredicatePollIteration(
 	startLabel, successLabel, timeoutLabel core.Label,
 ) bytecode.Operand {
 	valueReg := c.exprs.Compile(config.predExpr)
-	condReg := c.emitWaitPredicateCondition(config.mode, valueReg)
-
-	if len(config.whenExprs) == 0 {
-		c.ctx.Program.Emitter.EmitJumpIfTrue(condReg, successLabel)
-	} else {
+	if config.mode == waitForPredicateModeValue {
 		retryLabel := c.ctx.Program.Emitter.NewLabel()
-		c.ctx.Program.Emitter.EmitJumpIfFalse(condReg, retryLabel)
+		c.ctx.Program.Emitter.EmitJumpIfNone(valueReg, retryLabel)
 		c.emitWaitPredicateWhenConditions(config, valueReg, retryLabel)
 		c.ctx.Program.Emitter.EmitJump(successLabel)
 		c.ctx.Program.Emitter.MarkLabel(retryLabel)
+	} else {
+		condReg := c.emitWaitPredicateCondition(config.mode, valueReg)
+
+		if len(config.whenExprs) == 0 {
+			c.ctx.Program.Emitter.EmitJumpIfTrue(condReg, successLabel)
+		} else {
+			retryLabel := c.ctx.Program.Emitter.NewLabel()
+			c.ctx.Program.Emitter.EmitJumpIfFalse(condReg, retryLabel)
+			c.emitWaitPredicateWhenConditions(config, valueReg, retryLabel)
+			c.ctx.Program.Emitter.EmitJump(successLabel)
+			c.ctx.Program.Emitter.MarkLabel(retryLabel)
+		}
 	}
 
 	elapsedReg := c.emitWaitPredicateTimeoutCheck(config.timeoutReg, state.startReg, state.unitReg, timeoutLabel)
@@ -210,7 +226,7 @@ func (c *WaitCompiler) emitWaitPredicateWhenConditions(
 
 func (c *WaitCompiler) emitWaitPredicateCondition(mode waitForPredicateMode, valueReg bytecode.Operand) bytecode.Operand {
 	switch mode {
-	case waitForPredicateModeValue, waitForPredicateModeExists:
+	case waitForPredicateModeExists:
 		return c.emitExistsCheck(valueReg)
 	case waitForPredicateModeNotExists:
 		existsReg := c.emitExistsCheck(valueReg)

--- a/test/benchmarks/bench_waitfor_test.go
+++ b/test/benchmarks/bench_waitfor_test.go
@@ -1,0 +1,14 @@
+package benchmarks_test
+
+import "testing"
+
+const waitForValuePresentQuery = `
+RETURN WAITFOR VALUE @candidate`
+
+func BenchmarkWaitForValuePresent_O0(b *testing.B) {
+	RunBenchmarkO0(b, waitForValuePresentQuery, WithParam("candidate", []any{1}))
+}
+
+func BenchmarkWaitForValuePresent_O1(b *testing.B) {
+	RunBenchmarkO1(b, waitForValuePresentQuery, WithParam("candidate", []any{1}))
+}

--- a/test/integration/compiler/compiler_dispatch_test.go
+++ b/test/integration/compiler/compiler_dispatch_test.go
@@ -116,7 +116,7 @@ func TestDispatchGroupedTargetsCompile(t *testing.T) {
 			DISPATCH "click" IN (QUERY ONE "#search-form button[type='submit']" IN page USING css)
 
 			LET result = WAITFOR VALUE (QUERY ONE "#form-result" IN page USING css)
-				WHEN .attributes.disabled == false
+				WHEN .textContent != ""
 				TIMEOUT 10s
 
 			RETURN result.textContent

--- a/test/integration/compiler/compiler_waitfor_test.go
+++ b/test/integration/compiler/compiler_waitfor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
 	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/compile"
@@ -158,6 +159,19 @@ func TestWaitforPredicateWhenCompiles(t *testing.T) {
 				RETURN i
 		`, noCompilerError, "WAITFOR EVENT should compile as a FOR loop body statement"),
 	})
+}
+
+func TestWaitforValuePresenceLowering(t *testing.T) {
+	RunSpecsLevels(t, []spec.Spec{
+		Opcode(`RETURN WAITFOR VALUE @candidate TIMEOUT 1ms`, OpcodeExistence{
+			Exists:    []bytecode.Opcode{bytecode.OpJumpIfNone},
+			NotExists: []bytecode.Opcode{bytecode.OpExists},
+		}, "WAITFOR VALUE should use NONE presence without EXISTS semantics"),
+		Opcode(`RETURN WAITFOR EXISTS @candidate TIMEOUT 1ms`, OpcodeExistence{
+			Exists:    []bytecode.Opcode{bytecode.OpExists},
+			NotExists: []bytecode.Opcode{bytecode.OpJumpIfNone},
+		}, "WAITFOR EXISTS should preserve EXISTS semantics"),
+	}, compiler.O0, compiler.O1)
 }
 
 func noCompilerError(*bytecode.Program) error {

--- a/test/integration/optimization/waitfor_fastpath_test.go
+++ b/test/integration/optimization/waitfor_fastpath_test.go
@@ -26,6 +26,18 @@ func TestWaitforFastPath(t *testing.T) {
 			NotExists: []bytecode.Opcode{bytecode.OpJump, bytecode.OpJumpIfTrue, bytecode.OpJumpIfFalse},
 		}, nil, "should include sleep for none value"),
 
+		Opcode(`RETURN WAITFOR VALUE [] TIMEOUT 10ms`, compile.OpcodeExistence{
+			NotExists: []bytecode.Opcode{bytecode.OpSleep},
+		}, []any{}, "should skip sleep for empty array value"),
+
+		Opcode(`RETURN WAITFOR VALUE {} TIMEOUT 10ms`, compile.OpcodeExistence{
+			NotExists: []bytecode.Opcode{bytecode.OpSleep},
+		}, map[string]any{}, "should skip sleep for empty object value"),
+
+		Opcode(`RETURN WAITFOR VALUE "" TIMEOUT 10ms`, compile.OpcodeExistence{
+			NotExists: []bytecode.Opcode{bytecode.OpSleep},
+		}, "", "should skip sleep for empty string value"),
+
 		Opcode(`RETURN WAITFOR EXISTS [] TIMEOUT 10ms`, compile.OpcodeExistence{
 			Exists:    []bytecode.Opcode{bytecode.OpSleep},
 			NotExists: []bytecode.Opcode{bytecode.OpJump, bytecode.OpJumpIfTrue, bytecode.OpJumpIfFalse},

--- a/test/integration/vm/vm_waitfor_predicate_test.go
+++ b/test/integration/vm/vm_waitfor_predicate_test.go
@@ -48,20 +48,32 @@ func TestWaitforPredicate(t *testing.T) {
 			RETURN token
 		`, "ok", "Should return value once it exists"),
 		S(`
+			RETURN WAITFOR VALUE "" TIMEOUT 20ms
+		`, "", "Should return an empty string value immediately"),
+		Object(`
+			RETURN WAITFOR VALUE {} TIMEOUT 20ms
+		`, map[string]any{}, "Should return an empty object value immediately"),
+		Array(`
+			RETURN WAITFOR VALUE [] TIMEOUT 20ms
+		`, []any{}, "Should return an empty array value immediately"),
+		Array(`
+			RETURN WAITFOR VALUE [] WHEN LENGTH(.) == 0 TIMEOUT 20ms
+		`, []any{}, "Should evaluate WHEN for an empty non-NONE value"),
+		S(`
 			LET start = NOW()
 			LET ok = WAITFOR EXISTS (DATE_DIFF(start, NOW(), "f") > 20 ? { foo: 1 } : {}) TIMEOUT 0.5s EVERY 10ms
 			RETURN ok
 		`, true, "Should wait for non-empty object with EXISTS"),
 		Object(`
 			LET start = NOW()
-			LET obj = WAITFOR VALUE (DATE_DIFF(start, NOW(), "f") > 20 ? { foo: 1 } : {}) TIMEOUT 0.5s EVERY 10ms
+			LET obj = WAITFOR VALUE (DATE_DIFF(start, NOW(), "f") > 20 ? { foo: 1 } : {}) WHEN LENGTH(.) > 0 TIMEOUT 0.5s EVERY 10ms
 			RETURN obj
-		`, map[string]any{"foo": 1}, "Should return object once it exists"),
+		`, map[string]any{"foo": 1}, "Should return object once WHEN accepts the candidate"),
 		Array(`
 			LET start = NOW()
-			LET arr = WAITFOR VALUE (DATE_DIFF(start, NOW(), "f") > 20 ? [1, 2] : []) TIMEOUT 0.5s EVERY 10ms
+			LET arr = WAITFOR VALUE (DATE_DIFF(start, NOW(), "f") > 20 ? [1, 2] : []) WHEN LENGTH(.) > 0 TIMEOUT 0.5s EVERY 10ms
 			RETURN arr
-		`, []any{1, 2}, "Should return array once it exists"),
+		`, []any{1, 2}, "Should return array once WHEN accepts the candidate"),
 		S(`
 			LET start = NOW()
 			LET ok = WAITFOR EXISTS (DATE_DIFF(start, NOW(), "f") > 20 ? "ok" : "") TIMEOUT 0.5s EVERY 10ms
@@ -181,6 +193,10 @@ func TestWaitforPredicateWhenSkipsPredicateUntilBasePasses(t *testing.T) {
 					LET ok = WAITFOR EXISTS NONE WHEN PREDICATE(.) TIMEOUT 20ms EVERY 1ms ON TIMEOUT RETURN false
 					RETURN ok
 				`, false, "WAITFOR EXISTS WHEN should not evaluate the predicate before existence passes"),
+				Nil(`
+					LET value = WAITFOR VALUE NONE WHEN PREDICATE(.) TIMEOUT 20ms EVERY 1ms ON TIMEOUT RETURN NONE
+					RETURN value
+				`, "WAITFOR VALUE WHEN should not evaluate the predicate before presence passes"),
 			},
 			vm.WithFunction("PREDICATE", func(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 				predicateCalls++


### PR DESCRIPTION
This pull request introduces and refines the semantics for the `WAITFOR VALUE` construct, ensuring it distinguishes between "presence" (non-NONE values, including empty containers and strings) and "existence" (non-empty values). The changes clarify and optimize how the compiler and VM handle these modes, especially around fast-path optimizations and code generation, and add comprehensive tests to validate the new behavior.

**Core logic and semantics improvements:**

* Added a new helper function `literalPresentFromExpression` to detect value presence (non-NONE), which is now used to distinguish `WAITFOR VALUE` from `WAITFOR EXISTS` in the compiler's fast-path logic (`wait_helpers.go`, `wait_polling.go`). [[1]](diffhunk://#diff-fdeb6ca8335ae642c3ea3bbf69c347bb9941a418f40f8309a23688ba73fa9409R140-R148) [[2]](diffhunk://#diff-e1074fc4d1a8c3d86d776f120a1180beff8557990044825195b3967d44651414R41-R56)
* Updated the polling and code generation logic so that `WAITFOR VALUE` returns immediately for present (non-NONE) values—including empty strings, arrays, and objects—while `WAITFOR EXISTS` continues to require non-empty values. [[1]](diffhunk://#diff-e1074fc4d1a8c3d86d776f120a1180beff8557990044825195b3967d44651414R171-R177) [[2]](diffhunk://#diff-e1074fc4d1a8c3d86d776f120a1180beff8557990044825195b3967d44651414R189) [[3]](diffhunk://#diff-e1074fc4d1a8c3d86d776f120a1180beff8557990044825195b3967d44651414L213-R229)

**Test coverage and validation:**

* Added new and updated existing integration, VM, and benchmark tests to check the behavior of `WAITFOR VALUE` and `WAITFOR EXISTS`, especially for empty strings, arrays, and objects, and for the interaction with `WHEN` clauses. [[1]](diffhunk://#diff-b2fba0e3d3b2f38b02f606a0cf8a54826ca06ec69f55a2bea67c15b2f5aefe5dR50-R76) [[2]](diffhunk://#diff-b2fba0e3d3b2f38b02f606a0cf8a54826ca06ec69f55a2bea67c15b2f5aefe5dR196-R199) [[3]](diffhunk://#diff-5065e68f85a2335b20333ef38763e6a6073609913c3a49b69e14b0f8acbabd1dR29-R40) [[4]](diffhunk://#diff-fcceae75168e5bb984ece5b53b37543026a991c74c58e48ce242d48448eb506aR164-R176) [[5]](diffhunk://#diff-ee738e0a4befd7b0e98728179a11772a0b7edeb210eb29850ed8d12f31c33435R1-R14)
* Adjusted test queries and expectations to align with the new semantics, ensuring that empty but present values are handled correctly and that predicates in `WHEN` clauses are only evaluated after presence checks pass. [[1]](diffhunk://#diff-06f139ca080ef85193cbdee7e392f2a5cdba76e5afb5c30a85b6724a604105e0L119-R119) [[2]](diffhunk://#diff-b2fba0e3d3b2f38b02f606a0cf8a54826ca06ec69f55a2bea67c15b2f5aefe5dR50-R76)

**Refactoring and code cleanup:**

* Removed redundant condition checks for `WAITFOR VALUE` in the fast-path and code generation logic, since the new presence semantics no longer require them.
* Added missing imports and minor test harness improvements for clarity and maintainability.

These changes ensure that `WAITFOR VALUE` now consistently and efficiently waits for any non-NONE value, regardless of its "emptiness," and that the codebase and tests accurately reflect and enforce this distinction.