### PR TITLE
Feat/http client adapter

### DIFF
--- a/pkg/net/http/client.go
+++ b/pkg/net/http/client.go
@@ -65,8 +65,9 @@ func NewWithClient(client *stdhttp.Client, options ...PolicyOption) (Client, err
 	}
 
 	stdClient := *client
+	transport, isStandardTransport := stdClient.Transport.(*stdhttp.Transport)
 
-	if stdClient.Transport == nil {
+	if stdClient.Transport == nil || (isStandardTransport && transport == nil) {
 		dialer := newPolicyDialer(policy)
 		stdClient.Transport = newPolicyTransport(dialer, policy.MaxResponseHeaderSize())
 	}

--- a/pkg/net/http/client.go
+++ b/pkg/net/http/client.go
@@ -40,7 +40,7 @@ func New(options ...PolicyOption) (Client, error) {
 	dialer := newPolicyDialer(policy)
 
 	return newDefaultHTTPClient(policy, stdhttp.Client{
-		Transport: newPolicyTransport(dialer, policy.maxResponseHeaderSize),
+		Transport: newPolicyTransport(dialer, policy.MaxResponseHeaderSize()),
 	}), nil
 }
 
@@ -68,7 +68,7 @@ func NewWithClient(client *stdhttp.Client, options ...PolicyOption) (Client, err
 
 	if stdClient.Transport == nil {
 		dialer := newPolicyDialer(policy)
-		stdClient.Transport = newPolicyTransport(dialer, policy.maxResponseHeaderSize)
+		stdClient.Transport = newPolicyTransport(dialer, policy.MaxResponseHeaderSize())
 	}
 
 	return newDefaultHTTPClient(policy, stdClient), nil
@@ -81,9 +81,9 @@ func newDefaultHTTPClient(policy *Policy, client stdhttp.Client) *defaultHTTPCli
 		policy: policy,
 		client: client,
 	}
-	result.client.Transport = newResponseValidatingTransport(result.client.Transport)
-	result.client.Timeout = policy.timeout
-	result.client.CheckRedirect = result.checkRedirect
+	result.client.Transport = newNilResponseGuardTransport(result.client.Transport)
+	result.client.Timeout = policy.Timeout()
+	result.client.CheckRedirect = policy.CheckRedirect
 
 	return result
 }
@@ -117,17 +117,4 @@ func (d *defaultHTTPClient) Do(ctx context.Context, req *Request) (*Response, er
 
 func (d *defaultHTTPClient) CloseIdleConnections() {
 	d.client.CloseIdleConnections()
-}
-
-func (d *defaultHTTPClient) checkRedirect(req *stdhttp.Request, via []*stdhttp.Request) error {
-	if !d.policy.followRedirects {
-		return stdhttp.ErrUseLastResponse
-	}
-
-	limit := d.policy.maxRedirects
-	if len(via) > limit {
-		return &RedirectLimitError{Limit: limit}
-	}
-
-	return d.policy.eval(req, PolicyTargetRedirect)
 }

--- a/pkg/net/http/client.go
+++ b/pkg/net/http/client.go
@@ -38,17 +38,54 @@ func New(options ...PolicyOption) (Client, error) {
 	}
 
 	dialer := newPolicyDialer(policy)
-	transport := newResponseValidatingTransport(
-		newPolicyTransport(dialer, policy.maxResponseHeaderSize),
-	)
 
-	return &defaultHTTPClient{
+	return newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: newPolicyTransport(dialer, policy.maxResponseHeaderSize),
+	}), nil
+}
+
+// NewWithClient constructs a policy-aware client from a standard-library
+// client. It snapshots the supplied client's fields without mutating it.
+// Policy timeout and redirect settings take precedence over the corresponding
+// client fields.
+//
+// A nil Transport is replaced with Ferret's policy-aware transport. A non-nil
+// Transport is preserved and remains responsible for proxy behavior, DNS and
+// concrete-address enforcement, and response-header limits. The transport and
+// cookie jar remain shared with the supplied client; closing idle connections
+// through the returned Client affects the shared transport pool.
+func NewWithClient(client *stdhttp.Client, options ...PolicyOption) (Client, error) {
+	if client == nil {
+		return nil, ErrNilClient
+	}
+
+	policy, err := NewPolicy(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	stdClient := *client
+
+	if stdClient.Transport == nil {
+		dialer := newPolicyDialer(policy)
+		stdClient.Transport = newPolicyTransport(dialer, policy.maxResponseHeaderSize)
+	}
+
+	return newDefaultHTTPClient(policy, stdClient), nil
+}
+
+// newDefaultHTTPClient snapshots and normalizes a standard-library client so
+// the stored client can be reused safely across concurrent requests.
+func newDefaultHTTPClient(policy *Policy, client stdhttp.Client) *defaultHTTPClient {
+	result := &defaultHTTPClient{
 		policy: policy,
-		client: stdhttp.Client{
-			Transport: transport,
-			Timeout:   policy.timeout,
-		},
-	}, nil
+		client: client,
+	}
+	result.client.Transport = newResponseValidatingTransport(result.client.Transport)
+	result.client.Timeout = policy.timeout
+	result.client.CheckRedirect = result.checkRedirect
+
+	return result
 }
 
 func (d *defaultHTTPClient) Do(ctx context.Context, req *Request) (*Response, error) {
@@ -56,25 +93,16 @@ func (d *defaultHTTPClient) Do(ctx context.Context, req *Request) (*Response, er
 		ctx = context.Background()
 	}
 
-	p := d.policy
-	if p == nil {
-		p = &Policy{}
-	}
-
 	stdReq, err := toStdRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	if err := p.Prepare(stdReq); err != nil {
+
+	if err := d.policy.Prepare(stdReq); err != nil {
 		return nil, err
 	}
 
-	client := d.client
-	client.Transport = newResponseValidatingTransport(client.Transport)
-	client.Timeout = p.timeout
-	client.CheckRedirect = d.checkRedirect
-
-	res, err := client.Do(stdReq)
+	res, err := d.client.Do(stdReq)
 	if err != nil {
 		var policyErr *PolicyError
 		if errors.As(err, &policyErr) {
@@ -84,7 +112,7 @@ func (d *defaultHTTPClient) Do(ctx context.Context, req *Request) (*Response, er
 		return nil, err
 	}
 
-	return fromStdResponse(res, p)
+	return fromStdResponse(res, d.policy)
 }
 
 func (d *defaultHTTPClient) CloseIdleConnections() {
@@ -92,20 +120,14 @@ func (d *defaultHTTPClient) CloseIdleConnections() {
 }
 
 func (d *defaultHTTPClient) checkRedirect(req *stdhttp.Request, via []*stdhttp.Request) error {
-	p := d.policy
-
-	if p == nil {
-		p = &Policy{}
-	}
-
-	if !p.followRedirects {
+	if !d.policy.followRedirects {
 		return stdhttp.ErrUseLastResponse
 	}
 
-	limit := p.maxRedirects
+	limit := d.policy.maxRedirects
 	if len(via) > limit {
 		return &RedirectLimitError{Limit: limit}
 	}
 
-	return p.eval(req, PolicyTargetRedirect)
+	return d.policy.eval(req, PolicyTargetRedirect)
 }

--- a/pkg/net/http/client.go
+++ b/pkg/net/http/client.go
@@ -44,6 +44,20 @@ func New(options ...PolicyOption) (Client, error) {
 	}), nil
 }
 
+// NewWithTransport constructs a policy-aware client that uses transport. The
+// supplied transport is shared with the returned Client, so closing idle
+// connections affects its connection pool.
+//
+// A nil transport, including a typed-nil *net/http.Transport, selects Ferret's
+// policy-aware transport. A non-nil transport remains responsible for proxy
+// behavior, DNS and concrete-address enforcement, and response-header limits.
+func NewWithTransport(
+	transport stdhttp.RoundTripper,
+	options ...PolicyOption,
+) (Client, error) {
+	return NewWithClient(&stdhttp.Client{Transport: transport}, options...)
+}
+
 // NewWithClient constructs a policy-aware client from a standard-library
 // client. It snapshots the supplied client's fields without mutating it.
 // Policy timeout and redirect settings take precedence over the corresponding

--- a/pkg/net/http/client_benchmark_test.go
+++ b/pkg/net/http/client_benchmark_test.go
@@ -88,19 +88,16 @@ func benchmarkClientDoPolicy(b *testing.B, policy *Policy) {
 }
 
 func benchmarkClientDoPolicyRequest(b *testing.B, policy *Policy, req *Request) {
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{
-			Transport: newResponseValidatingTransport(testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
-				return &stdhttp.Response{
-					StatusCode: stdhttp.StatusOK,
-					Status:     "200 OK",
-					Header:     make(stdhttp.Header),
-					Body:       io.NopCloser(strings.NewReader("ok")),
-				}, nil
-			})),
-		},
-	}
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+			return &stdhttp.Response{
+				StatusCode: stdhttp.StatusOK,
+				Status:     "200 OK",
+				Header:     make(stdhttp.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+			}, nil
+		}),
+	})
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/net/http/client_benchmark_test.go
+++ b/pkg/net/http/client_benchmark_test.go
@@ -111,13 +111,14 @@ func benchmarkClientDoPolicyRequest(b *testing.B, policy *Policy, req *Request) 
 
 func BenchmarkReadResponseBodyBounded(b *testing.B) {
 	body := strings.Repeat("x", 4<<10)
+	policy := newTestPolicy(b, WithMaxResponseSize(8<<10))
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(body)))
 	b.ResetTimer()
 
 	for b.Loop() {
-		if _, err := readResponseBody(strings.NewReader(body), 8<<10); err != nil {
+		if _, err := policy.ReadResponseBody(strings.NewReader(body)); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/net/http/client_constructor_test.go
+++ b/pkg/net/http/client_constructor_test.go
@@ -119,9 +119,9 @@ func TestNewWithClientSnapshotsClientAndSharesResources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected built-in client, got %T", client)
 	}
-	validatingTransport, ok := adapted.client.Transport.(*responseValidatingTransport)
+	validatingTransport, ok := adapted.client.Transport.(*nilResponseGuardTransport)
 	if !ok {
-		t.Fatalf("expected response-validating transport, got %T", adapted.client.Transport)
+		t.Fatalf("expected nil-response-guard transport, got %T", adapted.client.Transport)
 	}
 	if validatingTransport.next != originalTransport {
 		t.Fatalf("expected original underlying transport, got %T", validatingTransport.next)

--- a/pkg/net/http/client_constructor_test.go
+++ b/pkg/net/http/client_constructor_test.go
@@ -80,6 +80,36 @@ func TestNewWithClientInstallsPolicyTransportWhenMissing(t *testing.T) {
 	}
 }
 
+func TestNewWithClientInstallsPolicyTransportForTypedNilStandardTransport(t *testing.T) {
+	var typedNilTransport *stdhttp.Transport
+	stdClient := &stdhttp.Client{Transport: typedNilTransport}
+
+	client, err := NewWithClient(stdClient)
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+
+	originalTransport, ok := stdClient.Transport.(*stdhttp.Transport)
+	if !ok || originalTransport != nil {
+		t.Fatalf("expected supplied typed-nil transport to remain unchanged, got %T", stdClient.Transport)
+	}
+
+	adapted, ok := client.(*defaultHTTPClient)
+	if !ok {
+		t.Fatalf("expected built-in client, got %T", client)
+	}
+	transport := policyTransportForTest(t, adapted.client.Transport)
+	if transport == nil {
+		t.Fatal("expected non-nil policy transport")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected ambient proxy lookup to be disabled")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected policy-aware dialer")
+	}
+}
+
 func TestNewWithClientSnapshotsClientAndSharesResources(t *testing.T) {
 	originalTransport := &trackingIdleTransport{}
 	replacementTransport := &trackingIdleTransport{}

--- a/pkg/net/http/client_constructor_test.go
+++ b/pkg/net/http/client_constructor_test.go
@@ -1,0 +1,226 @@
+package http
+
+import (
+	"context"
+	"errors"
+	stdhttp "net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewWithClientRejectsNilClientBeforePolicyValidation(t *testing.T) {
+	client, err := NewWithClient(nil, WithMaxRequestSize(-1))
+	if client != nil {
+		t.Fatalf("expected no client, got %T", client)
+	}
+	if !errors.Is(err, ErrNilClient) {
+		t.Fatalf("expected ErrNilClient, got %v", err)
+	}
+	if errors.Is(err, ErrInvalidPolicyConfiguration) {
+		t.Fatalf("expected nil client validation to take precedence, got %v", err)
+	}
+}
+
+func TestNewWithClientRejectsInvalidPolicyConfiguration(t *testing.T) {
+	client, err := NewWithClient(
+		&stdhttp.Client{},
+		WithMaxRequestSize(-1),
+		WithMaxResponseSize(-2),
+	)
+	if client != nil {
+		t.Fatalf("expected no client, got %T", client)
+	}
+	if !errors.Is(err, ErrInvalidPolicyConfiguration) {
+		t.Fatalf("expected ErrInvalidPolicyConfiguration, got %v", err)
+	}
+}
+
+func TestNewWithClientInstallsPolicyTransportWhenMissing(t *testing.T) {
+	const maxResponseHeaderSize = 2048
+
+	stdClient := &stdhttp.Client{}
+	client, err := NewWithClient(
+		stdClient,
+		WithMaxResponseHeaderSize(maxResponseHeaderSize),
+	)
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+
+	if stdClient.Transport != nil {
+		t.Fatalf("expected supplied client to remain unchanged, got %T", stdClient.Transport)
+	}
+
+	adapted, ok := client.(*defaultHTTPClient)
+	if !ok {
+		t.Fatalf("expected built-in client, got %T", client)
+	}
+
+	transport := policyTransportForTest(t, adapted.client.Transport)
+	if transport.Proxy != nil {
+		t.Fatal("expected ambient proxy lookup to be disabled")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected policy-aware dialer")
+	}
+	if transport.MaxResponseHeaderBytes != maxResponseHeaderSize {
+		t.Fatalf(
+			"expected max response header size %d, got %d",
+			maxResponseHeaderSize,
+			transport.MaxResponseHeaderBytes,
+		)
+	}
+	if adapted.client.Timeout != defaultTimeout {
+		t.Fatalf("expected policy timeout %s, got %s", defaultTimeout, adapted.client.Timeout)
+	}
+	if adapted.client.CheckRedirect == nil {
+		t.Fatal("expected policy redirect callback")
+	}
+}
+
+func TestNewWithClientSnapshotsClientAndSharesResources(t *testing.T) {
+	originalTransport := &trackingIdleTransport{}
+	replacementTransport := &trackingIdleTransport{}
+	originalJar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("construct original cookie jar: %v", err)
+	}
+	replacementJar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("construct replacement cookie jar: %v", err)
+	}
+
+	stdClient := &stdhttp.Client{
+		Transport: originalTransport,
+		Jar:       originalJar,
+		Timeout:   time.Hour,
+	}
+	client, err := NewWithClient(stdClient)
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+	if stdClient.Transport != originalTransport {
+		t.Fatal("expected supplied transport to remain unchanged")
+	}
+	if stdClient.Jar != originalJar {
+		t.Fatal("expected supplied cookie jar to remain unchanged")
+	}
+	if stdClient.Timeout != time.Hour {
+		t.Fatalf("expected supplied timeout %s, got %s", time.Hour, stdClient.Timeout)
+	}
+
+	stdClient.Transport = replacementTransport
+	stdClient.Jar = replacementJar
+	stdClient.Timeout = 2 * time.Hour
+
+	adapted, ok := client.(*defaultHTTPClient)
+	if !ok {
+		t.Fatalf("expected built-in client, got %T", client)
+	}
+	validatingTransport, ok := adapted.client.Transport.(*responseValidatingTransport)
+	if !ok {
+		t.Fatalf("expected response-validating transport, got %T", adapted.client.Transport)
+	}
+	if validatingTransport.next != originalTransport {
+		t.Fatalf("expected original underlying transport, got %T", validatingTransport.next)
+	}
+	if adapted.client.Jar != originalJar {
+		t.Fatal("expected original cookie jar")
+	}
+	if adapted.client.Timeout != defaultTimeout {
+		t.Fatalf("expected policy timeout %s, got %s", defaultTimeout, adapted.client.Timeout)
+	}
+
+	closer, ok := client.(IdleConnectionCloser)
+	if !ok {
+		t.Fatalf("expected client to implement IdleConnectionCloser, got %T", client)
+	}
+	closer.CloseIdleConnections()
+
+	if !originalTransport.closed.Load() {
+		t.Fatal("expected idle connection cleanup to reach original transport")
+	}
+	if replacementTransport.closed.Load() {
+		t.Fatal("expected replacement transport to remain untouched")
+	}
+}
+
+func TestNewWithClientPolicyTimeoutOverridesClientTimeout(t *testing.T) {
+	var remaining time.Duration
+	transport := testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			t.Fatal("expected request deadline")
+		}
+
+		remaining = time.Until(deadline)
+
+		return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
+	})
+
+	client, err := NewWithClient(
+		&stdhttp.Client{
+			Transport: transport,
+			Timeout:   time.Hour,
+		},
+		WithTimeout(10*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+
+	if _, err := client.Do(
+		context.Background(),
+		&Request{URL: "https://example.com"},
+	); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if remaining <= 0 || remaining >= time.Minute {
+		t.Fatalf("expected policy timeout to override client timeout, got %s", remaining)
+	}
+}
+
+func TestNewWithClientPolicyRedirectOverridesClientCallback(t *testing.T) {
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/start", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		stdhttp.Redirect(w, r, "/done", stdhttp.StatusFound)
+	})
+	mux.HandleFunc("/done", func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_, _ = w.Write([]byte("done"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	suppliedCallbackCalled := false
+	client, err := NewWithClient(
+		&stdhttp.Client{
+			CheckRedirect: func(*stdhttp.Request, []*stdhttp.Request) error {
+				suppliedCallbackCalled = true
+
+				return errors.New("supplied redirect callback")
+			},
+		},
+		WithAllowLocalhost(true),
+	)
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+
+	res, err := client.Do(
+		context.Background(),
+		&Request{URL: server.URL + "/start"},
+	)
+	if err != nil {
+		t.Fatalf("redirect request failed: %v", err)
+	}
+	if got := string(res.Body); got != "done" {
+		t.Fatalf("expected followed redirect body %q, got %q", "done", got)
+	}
+	if suppliedCallbackCalled {
+		t.Fatal("expected policy redirect callback to replace supplied callback")
+	}
+}

--- a/pkg/net/http/client_constructor_test.go
+++ b/pkg/net/http/client_constructor_test.go
@@ -37,6 +37,102 @@ func TestNewWithClientRejectsInvalidPolicyConfiguration(t *testing.T) {
 	}
 }
 
+func TestNewWithTransportRejectsInvalidPolicyConfiguration(t *testing.T) {
+	client, err := NewWithTransport(
+		&trackingIdleTransport{},
+		WithMaxRequestSize(-1),
+		WithMaxResponseSize(-2),
+	)
+	if client != nil {
+		t.Fatalf("expected no client, got %T", client)
+	}
+	if !errors.Is(err, ErrInvalidPolicyConfiguration) {
+		t.Fatalf("expected ErrInvalidPolicyConfiguration, got %v", err)
+	}
+}
+
+func TestNewWithTransportInstallsPolicyTransportWhenMissing(t *testing.T) {
+	const maxResponseHeaderSize = 2048
+
+	var typedNilTransport *stdhttp.Transport
+	tests := []struct {
+		transport stdhttp.RoundTripper
+		name      string
+	}{
+		{name: "nil"},
+		{name: "typed nil standard transport", transport: typedNilTransport},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewWithTransport(
+				tt.transport,
+				WithMaxResponseHeaderSize(maxResponseHeaderSize),
+			)
+			if err != nil {
+				t.Fatalf("construct HTTP client: %v", err)
+			}
+
+			adapted, ok := client.(*defaultHTTPClient)
+			if !ok {
+				t.Fatalf("expected built-in client, got %T", client)
+			}
+
+			transport := policyTransportForTest(t, adapted.client.Transport)
+			if transport.Proxy != nil {
+				t.Fatal("expected ambient proxy lookup to be disabled")
+			}
+			if transport.DialContext == nil {
+				t.Fatal("expected policy-aware dialer")
+			}
+			if transport.MaxResponseHeaderBytes != maxResponseHeaderSize {
+				t.Fatalf(
+					"expected max response header size %d, got %d",
+					maxResponseHeaderSize,
+					transport.MaxResponseHeaderBytes,
+				)
+			}
+		})
+	}
+}
+
+func TestNewWithTransportSharesAndNormalizesCustomTransport(t *testing.T) {
+	const timeout = time.Second
+
+	transport := &trackingIdleTransport{}
+	client, err := NewWithTransport(transport, WithTimeout(timeout))
+	if err != nil {
+		t.Fatalf("construct HTTP client: %v", err)
+	}
+
+	adapted, ok := client.(*defaultHTTPClient)
+	if !ok {
+		t.Fatalf("expected built-in client, got %T", client)
+	}
+	guard, ok := adapted.client.Transport.(*nilResponseGuardTransport)
+	if !ok {
+		t.Fatalf("expected nil-response-guard transport, got %T", adapted.client.Transport)
+	}
+	if guard.next != transport {
+		t.Fatalf("expected supplied transport to be shared, got %T", guard.next)
+	}
+	if adapted.client.Timeout != timeout {
+		t.Fatalf("expected policy timeout %s, got %s", timeout, adapted.client.Timeout)
+	}
+	if adapted.client.CheckRedirect == nil {
+		t.Fatal("expected policy redirect callback")
+	}
+
+	closer, ok := client.(IdleConnectionCloser)
+	if !ok {
+		t.Fatalf("expected client to implement IdleConnectionCloser, got %T", client)
+	}
+	closer.CloseIdleConnections()
+	if !transport.closed.Load() {
+		t.Fatal("expected idle connection cleanup to reach supplied transport")
+	}
+}
+
 func TestNewWithClientInstallsPolicyTransportWhenMissing(t *testing.T) {
 	const maxResponseHeaderSize = 2048
 

--- a/pkg/net/http/client_hardening_test.go
+++ b/pkg/net/http/client_hardening_test.go
@@ -13,13 +13,12 @@ import (
 func TestClientNormalizesConfiguredMethod(t *testing.T) {
 	var seenMethod string
 	policy := newTestPolicy(t, WithAllowedMethods("custom-method"))
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			seenMethod = req.Method
 			return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{
 		Method: " custom-method ",
@@ -36,9 +35,8 @@ func TestClientNormalizesConfiguredMethod(t *testing.T) {
 func TestClientRejectsCredentialedRedirect(t *testing.T) {
 	requested := make(map[string]int)
 	policy := newTestPolicy(t)
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			requested[req.URL.String()]++
 			return responseWithBody(
 				stdhttp.StatusFound,
@@ -46,7 +44,7 @@ func TestClientRejectsCredentialedRedirect(t *testing.T) {
 				stdhttp.Header{"Location": {"https://user:password@1.1.1.1/secret"}},
 			), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://1.1.1.1/start"})
 	policyErr := requirePolicyError(t, err, PolicyTargetRedirect)
@@ -65,9 +63,8 @@ func TestClientAppliesMethodPolicyToRedirects(t *testing.T) {
 	t.Run("rewritten method denied", func(t *testing.T) {
 		roundTrips := 0
 		policy := newTestPolicy(t, WithAllowedMethods(stdhttp.MethodPost))
-		client := &defaultHTTPClient{
-			policy: policy,
-			client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+		client := newDefaultHTTPClient(policy, stdhttp.Client{
+			Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 				roundTrips++
 				if roundTrips == 1 {
 					if req.Method != stdhttp.MethodPost {
@@ -82,7 +79,7 @@ func TestClientAppliesMethodPolicyToRedirects(t *testing.T) {
 
 				return responseWithBody(stdhttp.StatusOK, "unexpected", nil), nil
 			})},
-		}
+		)
 
 		_, err := client.Do(context.Background(), &Request{
 			Method: stdhttp.MethodPost,
@@ -100,9 +97,8 @@ func TestClientAppliesMethodPolicyToRedirects(t *testing.T) {
 	t.Run("preserved method allowed", func(t *testing.T) {
 		roundTrips := 0
 		policy := newTestPolicy(t, WithAllowedMethods(stdhttp.MethodPost))
-		client := &defaultHTTPClient{
-			policy: policy,
-			client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+		client := newDefaultHTTPClient(policy, stdhttp.Client{
+			Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 				roundTrips++
 				if req.Method != stdhttp.MethodPost {
 					t.Fatalf("expected POST on round trip %d, got %q", roundTrips, req.Method)
@@ -117,7 +113,7 @@ func TestClientAppliesMethodPolicyToRedirects(t *testing.T) {
 
 				return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 			})},
-		}
+		)
 
 		res, err := client.Do(context.Background(), &Request{
 			Method: stdhttp.MethodPost,
@@ -136,9 +132,8 @@ func TestClientAppliesMethodPolicyToRedirects(t *testing.T) {
 func TestClientAppliesHeaderPolicyToRedirects(t *testing.T) {
 	roundTrips := 0
 	policy := newTestPolicy(t, WithBlockedRequestHeaders("Referer"))
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			roundTrips++
 			if roundTrips == 1 {
 				return responseWithBody(
@@ -150,7 +145,7 @@ func TestClientAppliesHeaderPolicyToRedirects(t *testing.T) {
 
 			return responseWithBody(stdhttp.StatusOK, "unexpected", nil), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://example.com/start"})
 	policyErr := requirePolicyError(t, err, PolicyTargetRedirect)
@@ -176,9 +171,9 @@ func TestClientPreservesPreparedHeadersOnSameOriginRedirect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			roundTrips := 0
 			seen := make([]string, 0, 2)
-			client := &defaultHTTPClient{
-				policy: newTestPolicy(t, WithDefaultHeader("X-Value", "default")),
-				client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+			client := newDefaultHTTPClient(
+				newTestPolicy(t, WithDefaultHeader("X-Value", "default")),
+				stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 					roundTrips++
 					seen = append(seen, req.Header.Get("X-Value"))
 					if roundTrips == 1 {
@@ -191,7 +186,7 @@ func TestClientPreservesPreparedHeadersOnSameOriginRedirect(t *testing.T) {
 
 					return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 				})},
-			}
+			)
 
 			if _, err := client.Do(context.Background(), &Request{
 				URL:     "https://example.com/start",
@@ -209,9 +204,9 @@ func TestClientPreservesPreparedHeadersOnSameOriginRedirect(t *testing.T) {
 func TestClientDoesNotReapplySensitiveDefaultAcrossOriginRedirect(t *testing.T) {
 	roundTrips := 0
 	seen := make([]string, 0, 2)
-	client := &defaultHTTPClient{
-		policy: newTestPolicy(t, WithDefaultHeader("Authorization", "Bearer default-token")),
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(
+		newTestPolicy(t, WithDefaultHeader("Authorization", "Bearer default-token")),
+		stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			roundTrips++
 			seen = append(seen, req.Header.Get("Authorization"))
 			if roundTrips == 1 {
@@ -224,7 +219,7 @@ func TestClientDoesNotReapplySensitiveDefaultAcrossOriginRedirect(t *testing.T) 
 
 			return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 		})},
-	}
+	)
 
 	if _, err := client.Do(
 		context.Background(),
@@ -239,16 +234,15 @@ func TestClientDoesNotReapplySensitiveDefaultAcrossOriginRedirect(t *testing.T) 
 
 func TestClientRejectsNonASCIIRedirect(t *testing.T) {
 	policy := newTestPolicy(t)
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return responseWithBody(
 				stdhttp.StatusFound,
 				"",
 				stdhttp.Header{"Location": {"https://K.example/secret"}},
 			), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://1.1.1.1/start"})
 	policyErr := requirePolicyError(t, err, PolicyTargetRedirect)
@@ -262,13 +256,12 @@ func TestClientRejectsBlockedHeaderBeforeRoundTrip(t *testing.T) {
 	policy := newTestPolicy(t,
 		WithBlockedRequestHeaders("Authorization"),
 	)
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			called = true
 			return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{
 		URL:     "https://example.com",
@@ -303,14 +296,13 @@ func TestClientAppliesDefaultHeadersByPresence(t *testing.T) {
 				gotExists bool
 			)
 			policy := newTestPolicy(t, WithDefaultHeader("x-value", "default"))
-			client := &defaultHTTPClient{
-				policy: policy,
-				client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+			client := newDefaultHTTPClient(policy, stdhttp.Client{
+				Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 					gotValues, gotExists = req.Header["X-Value"]
 					gotValues = append([]string(nil), gotValues...)
 					return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 				})},
-			}
+			)
 
 			_, err := client.Do(context.Background(), &Request{
 				URL:     "https://example.com",
@@ -400,13 +392,12 @@ func TestClientSecureTransportDefaultsAndOverrides(t *testing.T) {
 
 func TestClientRequestContextCanShortenPolicyTimeout(t *testing.T) {
 	policy := newTestPolicy(t, WithTimeout(time.Hour))
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			<-req.Context().Done()
 			return nil, req.Context().Err()
 		})},
-	}
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -423,12 +414,11 @@ func TestClientRequestContextCanShortenPolicyTimeout(t *testing.T) {
 func TestClientOrdinaryTransportErrorIsNotPolicyDenial(t *testing.T) {
 	want := errors.New("transport failed")
 	policy := newTestPolicy(t)
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return nil, want
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://example.com"})
 	if !errors.Is(err, want) {

--- a/pkg/net/http/client_security_internal_test.go
+++ b/pkg/net/http/client_security_internal_test.go
@@ -93,9 +93,8 @@ func TestPolicyDialerRejectsMalformedDialAddressAsConnectionTarget(t *testing.T)
 func TestDefaultHTTPClientValidatesRedirectDestinations(t *testing.T) {
 	policies := newTestPolicy(t)
 	requested := make(map[string]int)
-	client := &defaultHTTPClient{
-		policy: policies,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policies, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			requested[req.URL.String()]++
 			switch req.URL.Path {
 			case "/loopback":
@@ -108,7 +107,7 @@ func TestDefaultHTTPClientValidatesRedirectDestinations(t *testing.T) {
 				return responseWithBody(stdhttp.StatusOK, "done", nil), nil
 			}
 		})},
-	}
+	)
 
 	for _, path := range []string{"/loopback", "/private"} {
 		_, err := client.Do(context.Background(), &Request{URL: "https://93.184.216.34" + path})
@@ -131,12 +130,11 @@ func TestDefaultHTTPClientValidatesRedirectDestinations(t *testing.T) {
 
 func TestDefaultHTTPClientNoFollowSkipsRedirectValidation(t *testing.T) {
 	policies := newTestPolicy(t, WithFollowRedirects(false))
-	client := &defaultHTTPClient{
-		policy: policies,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policies, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return responseWithBody(stdhttp.StatusFound, "", stdhttp.Header{"Location": {"http://10.0.0.10/private"}}), nil
 		})},
-	}
+	)
 
 	res, err := client.Do(context.Background(), &Request{URL: "https://93.184.216.34/start"})
 	if err != nil {
@@ -150,13 +148,12 @@ func TestDefaultHTTPClientNoFollowSkipsRedirectValidation(t *testing.T) {
 func TestDefaultHTTPClientUsesStandardRedirectLimit(t *testing.T) {
 	policies := newTestPolicy(t)
 	roundTrips := 0
-	client := &defaultHTTPClient{
-		policy: policies,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policies, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			roundTrips++
 			return responseWithBody(stdhttp.StatusFound, "", stdhttp.Header{"Location": {"/next"}}), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://93.184.216.34/start"})
 	if err == nil || !strings.Contains(err.Error(), "stopped after 10 redirect(s)") {
@@ -171,9 +168,9 @@ func TestDefaultHTTPClientFollowsExactlyConfiguredRedirects(t *testing.T) {
 	for _, limit := range []int{1, 2, 3} {
 		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
 			roundTrips := 0
-			client := &defaultHTTPClient{
-				policy: newTestPolicy(t, WithMaxRedirects(limit)),
-				client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+			client := newDefaultHTTPClient(
+				newTestPolicy(t, WithMaxRedirects(limit)),
+				stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 					roundTrips++
 					return responseWithBody(
 						stdhttp.StatusFound,
@@ -181,7 +178,7 @@ func TestDefaultHTTPClientFollowsExactlyConfiguredRedirects(t *testing.T) {
 						stdhttp.Header{"Location": {"/next"}},
 					), nil
 				})},
-			}
+			)
 
 			_, err := client.Do(context.Background(), &Request{URL: "https://example.com/start"})
 			var limitErr *RedirectLimitError
@@ -207,9 +204,8 @@ func TestRedirectPrivateResolutionUsesConnectionTarget(t *testing.T) {
 	policyTransport := newPolicyTransport(dialer, policy.maxResponseHeaderSize)
 	t.Cleanup(policyTransport.CloseIdleConnections)
 
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			if req.URL.Hostname() == "public.example" {
 				return responseWithBody(
 					stdhttp.StatusFound,
@@ -220,7 +216,7 @@ func TestRedirectPrivateResolutionUsesConnectionTarget(t *testing.T) {
 
 			return policyTransport.RoundTrip(req)
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://public.example/start"})
 	policyErr := requirePolicyError(t, err, PolicyTargetConnection)
@@ -233,12 +229,11 @@ func TestRedirectPrivateResolutionUsesConnectionTarget(t *testing.T) {
 }
 
 func TestDefaultHTTPClientConcurrentDo(t *testing.T) {
-	client := &defaultHTTPClient{
-		policy: newTestPolicy(t),
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 		})},
-	}
+	)
 
 	const (
 		goroutines = 32
@@ -288,12 +283,9 @@ func TestDefaultHTTPClientTimeoutCoversDNSResolution(t *testing.T) {
 			return nil, ctx.Err()
 		},
 	}
-	client := &defaultHTTPClient{
-		policy: policies,
-		client: stdhttp.Client{
-			Transport: newPolicyTransport(dialer, policies.maxResponseHeaderSize),
-		},
-	}
+	client := newDefaultHTTPClient(policies, stdhttp.Client{
+		Transport: newPolicyTransport(dialer, policies.maxResponseHeaderSize),
+	})
 
 	started := time.Now()
 	_, err := client.Do(context.Background(), &Request{URL: "http://timeout.example"})
@@ -350,9 +342,9 @@ func TestNewUsesDedicatedPolicyTransportWithoutProxy(t *testing.T) {
 
 func TestDefaultHTTPClientClosesIdleConnections(t *testing.T) {
 	transport := &trackingIdleTransport{}
-	client := &defaultHTTPClient{
-		client: stdhttp.Client{Transport: newResponseValidatingTransport(transport)},
-	}
+	client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{
+		Transport: transport,
+	})
 
 	client.CloseIdleConnections()
 	if !transport.closed.Load() {

--- a/pkg/net/http/client_security_internal_test.go
+++ b/pkg/net/http/client_security_internal_test.go
@@ -201,7 +201,7 @@ func TestRedirectPrivateResolutionUsesConnectionTarget(t *testing.T) {
 	resolver, dnsQueries := newLoopbackResolver(t)
 	dialer.dialer.Resolver = resolver
 
-	policyTransport := newPolicyTransport(dialer, policy.maxResponseHeaderSize)
+	policyTransport := newPolicyTransport(dialer, policy.MaxResponseHeaderSize())
 	t.Cleanup(policyTransport.CloseIdleConnections)
 
 	client := newDefaultHTTPClient(policy, stdhttp.Client{
@@ -284,7 +284,7 @@ func TestDefaultHTTPClientTimeoutCoversDNSResolution(t *testing.T) {
 		},
 	}
 	client := newDefaultHTTPClient(policies, stdhttp.Client{
-		Transport: newPolicyTransport(dialer, policies.maxResponseHeaderSize),
+		Transport: newPolicyTransport(dialer, policies.MaxResponseHeaderSize()),
 	})
 
 	started := time.Now()

--- a/pkg/net/http/doc.go
+++ b/pkg/net/http/doc.go
@@ -34,10 +34,21 @@
 // body limit, a non-empty body must have a positive, known ContentLength; an
 // unknown-length body is rejected before transport with RequestBodyLengthError.
 //
-// Eval and Prepare are preflight checks. A custom transport remains responsible
-// for validating redirects, DNS results, and concrete dial addresses, and for
-// enforcing timeouts and response-header and response-body limits. Ferret's
-// built-in Client supplies those controls.
+// Eval and Prepare are request preflight checks. Embedders implementing a
+// custom Client must integrate every policy stage exposed by Policy:
+//
+//   - call Prepare or Eval before the initial request;
+//   - apply Timeout to the backend or request context;
+//   - call CheckRedirect before following every redirect;
+//   - call EvalConnection on the resolved address immediately before connect;
+//   - apply MaxResponseHeaderSize before parsing response headers; and
+//   - apply MaxResponseSize natively or materialize with ReadResponseBody.
+//
+// ReadResponseBody does not close its reader. The caller retains response-body
+// ownership. Header limits cannot provide a memory bound when checked only
+// after a backend has parsed the headers. Ferret's built-in Client supplies all
+// of these controls; custom transports passed to NewWithClient retain the
+// documented transport-level responsibilities.
 //
 // Policy.Eval accepting *net/http.Request instead of Ferret's *Request is an
 // intentional source break. Call Prepare when migrating code that needs policy

--- a/pkg/net/http/doc.go
+++ b/pkg/net/http/doc.go
@@ -47,8 +47,8 @@
 // ReadResponseBody does not close its reader. The caller retains response-body
 // ownership. Header limits cannot provide a memory bound when checked only
 // after a backend has parsed the headers. Ferret's built-in Client supplies all
-// of these controls; custom transports passed to NewWithClient retain the
-// documented transport-level responsibilities.
+// of these controls; custom transports passed to NewWithClient or
+// NewWithTransport retain the documented transport-level responsibilities.
 //
 // Policy.Eval accepting *net/http.Request instead of Ferret's *Request is an
 // intentional source break. Call Prepare when migrating code that needs policy

--- a/pkg/net/http/errors.go
+++ b/pkg/net/http/errors.go
@@ -3,6 +3,9 @@ package http
 import "errors"
 
 var (
+	// ErrNilClient indicates a standard-library HTTP client is nil.
+	ErrNilClient = errors.New("http: client is nil")
+
 	// ErrNilRequest indicates an HTTP client received a nil request.
 	ErrNilRequest = errors.New("http: request is nil")
 

--- a/pkg/net/http/header_validation_test.go
+++ b/pkg/net/http/header_validation_test.go
@@ -128,11 +128,11 @@ func TestClientValidatesRedirectHeaders(t *testing.T) {
 		t.Fatalf("parse redirect URL: %v", err)
 	}
 
-	client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{})
+	policy := newTestPolicy(t)
 
 	for _, header := range transportControlledRequestHeadersForTest() {
 		t.Run("reserved_"+header, func(t *testing.T) {
-			err := client.checkRedirect(&stdhttp.Request{
+			err := policy.CheckRedirect(&stdhttp.Request{
 				Method: stdhttp.MethodGet,
 				URL:    redirectURL,
 				Header: stdhttp.Header{strings.ToLower(header): {"value"}},
@@ -145,7 +145,7 @@ func TestClientValidatesRedirectHeaders(t *testing.T) {
 	}
 
 	t.Run("invalid value", func(t *testing.T) {
-		err := client.checkRedirect(&stdhttp.Request{
+		err := policy.CheckRedirect(&stdhttp.Request{
 			Method: stdhttp.MethodGet,
 			URL:    redirectURL,
 			Header: stdhttp.Header{"Authorization": {"Bearer redirect-secret\r\nInjected: true"}},

--- a/pkg/net/http/header_validation_test.go
+++ b/pkg/net/http/header_validation_test.go
@@ -44,13 +44,12 @@ func TestClientRejectsMalformedRequestHeadersBeforeTransport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			called := false
-			client := &defaultHTTPClient{
-				policy: newTestPolicy(t),
-				client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+			client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{
+				Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 					called = true
 					return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 				})},
-			}
+			)
 
 			_, err := client.Do(context.Background(), &Request{
 				URL:     "https://example.com",
@@ -77,9 +76,8 @@ func TestClientRejectsMalformedRequestHeadersBeforeTransport(t *testing.T) {
 
 func TestClientAllowsHorizontalTabInRequestAndDefaultHeaders(t *testing.T) {
 	policy := newTestPolicy(t, WithDefaultHeader("X-Default", "left\tright"))
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(req *stdhttp.Request) (*stdhttp.Response, error) {
 			if got := req.Header.Get("X-Default"); got != "left\tright" {
 				t.Fatalf("expected default HTAB value, got %q", got)
 			}
@@ -88,7 +86,7 @@ func TestClientAllowsHorizontalTabInRequestAndDefaultHeaders(t *testing.T) {
 			}
 			return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 		})},
-	}
+	)
 
 	if _, err := client.Do(context.Background(), &Request{
 		URL:     "https://example.com",
@@ -102,13 +100,12 @@ func TestClientRejectsTransportControlledHeadersBeforeTransport(t *testing.T) {
 	for _, header := range transportControlledRequestHeadersForTest() {
 		t.Run(header, func(t *testing.T) {
 			called := false
-			client := &defaultHTTPClient{
-				policy: newTestPolicy(t),
-				client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+			client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{
+				Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 					called = true
 					return responseWithBody(stdhttp.StatusOK, "ok", nil), nil
 				})},
-			}
+			)
 
 			_, err := client.Do(context.Background(), &Request{
 				URL:     "https://example.com",
@@ -131,7 +128,7 @@ func TestClientValidatesRedirectHeaders(t *testing.T) {
 		t.Fatalf("parse redirect URL: %v", err)
 	}
 
-	client := &defaultHTTPClient{policy: newTestPolicy(t)}
+	client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{})
 
 	for _, header := range transportControlledRequestHeadersForTest() {
 		t.Run("reserved_"+header, func(t *testing.T) {

--- a/pkg/net/http/helpers.go
+++ b/pkg/net/http/helpers.go
@@ -3,7 +3,6 @@ package http
 import (
 	"bytes"
 	"context"
-	"io"
 	"math"
 	stdhttp "net/http"
 	"sort"
@@ -87,7 +86,7 @@ func fromStdResponse(res *stdhttp.Response, p *Policy) (*Response, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := readResponseBody(res.Body, p.maxResponseSize)
+	body, err := p.ReadResponseBody(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -98,28 +97,6 @@ func fromStdResponse(res *stdhttp.Response, p *Policy) (*Response, error) {
 		Headers:    copyHeaders(res.Header),
 		Body:       body,
 	}, nil
-}
-
-func readResponseBody(body io.Reader, limit int64) ([]byte, error) {
-	if limit <= 0 {
-		return io.ReadAll(body)
-	}
-
-	readLimit := saturatedIncrement(limit)
-	data, err := io.ReadAll(io.LimitReader(body, readLimit))
-
-	if int64(len(data)) > limit {
-		return nil, &ResponseBodyLimitError{
-			Size:  saturatedIncrement(limit),
-			Limit: limit,
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
 }
 
 func saturatedIncrement(value int64) int64 {

--- a/pkg/net/http/helpers_test.go
+++ b/pkg/net/http/helpers_test.go
@@ -56,9 +56,9 @@ func policyTransportForTest(tb testing.TB, transport stdhttp.RoundTripper) *stdh
 		return policyTransport
 	}
 
-	validated, ok := transport.(*responseValidatingTransport)
+	validated, ok := transport.(*nilResponseGuardTransport)
 	if !ok {
-		tb.Fatalf("expected policy or response-validating transport, got %T", transport)
+		tb.Fatalf("expected policy or nil-response-guard transport, got %T", transport)
 	}
 	policyTransport, ok := validated.next.(*stdhttp.Transport)
 	if !ok {

--- a/pkg/net/http/nil_response_guard_transport.go
+++ b/pkg/net/http/nil_response_guard_transport.go
@@ -2,14 +2,14 @@ package http
 
 import stdhttp "net/http"
 
-// responseValidatingTransport turns a broken RoundTripper's nil response into
+// nilResponseGuardTransport turns a broken RoundTripper's nil response into
 // Ferret's stable structural error before net/http replaces it with a generic
 // contract error.
-type responseValidatingTransport struct {
+type nilResponseGuardTransport struct {
 	next stdhttp.RoundTripper
 }
 
-func newResponseValidatingTransport(next stdhttp.RoundTripper) stdhttp.RoundTripper {
+func newNilResponseGuardTransport(next stdhttp.RoundTripper) stdhttp.RoundTripper {
 	if next == nil {
 		next = stdhttp.DefaultTransport
 	}
@@ -17,14 +17,14 @@ func newResponseValidatingTransport(next stdhttp.RoundTripper) stdhttp.RoundTrip
 	// The standard transport enforces its own response contract. Keeping it
 	// unwrapped also preserves net/http's optimized cancellation path.
 	switch next.(type) {
-	case *stdhttp.Transport, *responseValidatingTransport:
+	case *stdhttp.Transport, *nilResponseGuardTransport:
 		return next
 	}
 
-	return &responseValidatingTransport{next: next}
+	return &nilResponseGuardTransport{next: next}
 }
 
-func (t *responseValidatingTransport) RoundTrip(req *stdhttp.Request) (*stdhttp.Response, error) {
+func (t *nilResponseGuardTransport) RoundTrip(req *stdhttp.Request) (*stdhttp.Response, error) {
 	res, err := t.next.RoundTrip(req)
 	if res == nil && err == nil {
 		return nil, ErrNilResponse
@@ -33,7 +33,7 @@ func (t *responseValidatingTransport) RoundTrip(req *stdhttp.Request) (*stdhttp.
 	return res, err
 }
 
-func (t *responseValidatingTransport) CloseIdleConnections() {
+func (t *nilResponseGuardTransport) CloseIdleConnections() {
 	if closer, ok := t.next.(interface{ CloseIdleConnections() }); ok && closer != nil {
 		closer.CloseIdleConnections()
 	}
@@ -41,7 +41,7 @@ func (t *responseValidatingTransport) CloseIdleConnections() {
 
 // CancelRequest preserves cancellation for legacy custom transports that do
 // not consume Request.Context.
-func (t *responseValidatingTransport) CancelRequest(req *stdhttp.Request) {
+func (t *nilResponseGuardTransport) CancelRequest(req *stdhttp.Request) {
 	if canceler, ok := t.next.(interface{ CancelRequest(*stdhttp.Request) }); ok {
 		canceler.CancelRequest(req)
 	}

--- a/pkg/net/http/policy.go
+++ b/pkg/net/http/policy.go
@@ -277,6 +277,7 @@ func (p *Policy) addDefaultHeader(option, key, value string) {
 	}
 
 	canonicalKey := stdhttp.CanonicalHeaderKey(key)
+
 	if isReservedRequestHeader(canonicalKey) {
 		p.setConfigurationError(
 			option,

--- a/pkg/net/http/policy.go
+++ b/pkg/net/http/policy.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"io"
 	stdhttp "net/http"
 	"net/netip"
 	"net/url"
@@ -325,6 +326,93 @@ func (p *Policy) Prepare(req *stdhttp.Request) error {
 	}
 
 	return p.Eval(req)
+}
+
+// CheckRedirect validates a redirect using the callback contract expected by
+// net/http.Client. When redirects are disabled it returns net/http.ErrUseLastResponse
+// so callers can retain the redirect response.
+func (p *Policy) CheckRedirect(req *stdhttp.Request, via []*stdhttp.Request) error {
+	if !p.followRedirects {
+		return stdhttp.ErrUseLastResponse
+	}
+
+	limit := p.maxRedirects
+	if len(via) > limit {
+		return &RedirectLimitError{Limit: limit}
+	}
+
+	return p.eval(req, PolicyTargetRedirect)
+}
+
+// EvalConnection validates an already-resolved concrete destination address.
+// Callers must invoke it immediately before connecting so DNS rebinding cannot
+// bypass request-time host validation.
+func (p *Policy) EvalConnection(addr netip.Addr) error {
+	subject := "destination address"
+
+	if addr.IsValid() {
+		subject = addressSubject(addr)
+	}
+
+	return p.validateAddress(PolicyTargetConnection, subject, addr)
+}
+
+// Timeout returns the overall request timeout. Zero means no policy timeout.
+func (p *Policy) Timeout() time.Duration {
+	return p.timeout
+}
+
+// MaxResponseSize returns the materialized response-body limit in bytes. Zero
+// means response bodies are unlimited.
+func (p *Policy) MaxResponseSize() int64 {
+	return p.maxResponseSize
+}
+
+// MaxResponseHeaderSize returns the response-header limit in bytes. Backends
+// must apply it before parsing response headers for the limit to bound memory.
+func (p *Policy) MaxResponseHeaderSize() int64 {
+	return p.maxResponseHeaderSize
+}
+
+// EvalResponseSize validates an observed or materialized response-body size.
+// A negative size represents an unknown length and must instead be enforced
+// while reading, for example with ReadResponseBody.
+func (p *Policy) EvalResponseSize(size int64) error {
+	limit := p.maxResponseSize
+
+	if size < 0 || limit <= 0 || size <= limit {
+		return nil
+	}
+
+	return &ResponseBodyLimitError{
+		Size:  size,
+		Limit: limit,
+	}
+}
+
+// ReadResponseBody materializes a response body while enforcing the configured
+// size limit. It does not close body; ownership remains with the caller.
+func (p *Policy) ReadResponseBody(body io.Reader) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	limit := p.maxResponseSize
+	if limit <= 0 {
+		return io.ReadAll(body)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(body, saturatedIncrement(limit)))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if sizeErr := p.EvalResponseSize(int64(len(data))); sizeErr != nil {
+		return nil, sizeErr
+	}
+
+	return data, nil
 }
 
 func (p *Policy) applyDefaults(req *stdhttp.Request) error {

--- a/pkg/net/http/policy.go
+++ b/pkg/net/http/policy.go
@@ -332,6 +332,10 @@ func (p *Policy) Prepare(req *stdhttp.Request) error {
 // net/http.Client. When redirects are disabled it returns net/http.ErrUseLastResponse
 // so callers can retain the redirect response.
 func (p *Policy) CheckRedirect(req *stdhttp.Request, via []*stdhttp.Request) error {
+	if req == nil {
+		return ErrNilRequest
+	}
+
 	if !p.followRedirects {
 		return stdhttp.ErrUseLastResponse
 	}
@@ -404,12 +408,12 @@ func (p *Policy) ReadResponseBody(body io.Reader) ([]byte, error) {
 
 	data, err := io.ReadAll(io.LimitReader(body, saturatedIncrement(limit)))
 
-	if err != nil {
-		return nil, err
-	}
-
 	if sizeErr := p.EvalResponseSize(int64(len(data))); sizeErr != nil {
 		return nil, sizeErr
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return data, nil

--- a/pkg/net/http/policy_construction_test.go
+++ b/pkg/net/http/policy_construction_test.go
@@ -226,7 +226,7 @@ func TestExplicitUnlimitedBodyOptionsDisableOnlyTheirLimits(t *testing.T) {
 		WithMaxResponseSize(3),
 		WithUnlimitedResponseSize(),
 	)
-	body, err := readResponseBody(strings.NewReader("four"), responsePolicy.maxResponseSize)
+	body, err := responsePolicy.ReadResponseBody(strings.NewReader("four"))
 	if err != nil {
 		t.Fatalf("unlimited response policy rejected body: %v", err)
 	}

--- a/pkg/net/http/policy_dialer.go
+++ b/pkg/net/http/policy_dialer.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"net"
+	"net/netip"
 	"syscall"
 	"time"
 )
@@ -35,28 +36,20 @@ func (d *policyDialer) controlContext(
 	address string,
 	_ syscall.RawConn,
 ) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return newPolicyError(
-			PolicyTargetConnection,
-			"destination address",
-			"invalid address is not allowed",
-		)
-	}
-
-	addr, ok := parseIPAddress(host)
-	if !ok {
-		return newPolicyError(
-			PolicyTargetConnection,
-			"destination address",
-			"invalid address is not allowed",
-		)
-	}
-
 	p := d.policy
 	if p == nil {
 		p = &Policy{}
 	}
 
-	return p.validateAddress(PolicyTargetConnection, addressSubject(addr), addr)
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return p.EvalConnection(netip.Addr{})
+	}
+
+	addr, ok := parseIPAddress(host)
+	if !ok {
+		return p.EvalConnection(netip.Addr{})
+	}
+
+	return p.EvalConnection(addr)
 }

--- a/pkg/net/http/policy_enforcement_test.go
+++ b/pkg/net/http/policy_enforcement_test.go
@@ -93,9 +93,34 @@ func TestPolicyCheckRedirect(t *testing.T) {
 	})
 
 	t.Run("nil request", func(t *testing.T) {
-		err := newTestPolicy(t).CheckRedirect(nil, []*stdhttp.Request{{}})
-		if !errors.Is(err, ErrNilRequest) {
-			t.Fatalf("expected ErrNilRequest, got %v", err)
+		tests := []struct {
+			name   string
+			policy *Policy
+			via    []*stdhttp.Request
+		}{
+			{
+				name:   "enabled",
+				policy: newTestPolicy(t),
+				via:    []*stdhttp.Request{{}},
+			},
+			{
+				name:   "disabled",
+				policy: newTestPolicy(t, WithFollowRedirects(false)),
+			},
+			{
+				name:   "over limit",
+				policy: newTestPolicy(t, WithMaxRedirects(0)),
+				via:    []*stdhttp.Request{{}},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := tt.policy.CheckRedirect(nil, tt.via)
+				if !errors.Is(err, ErrNilRequest) {
+					t.Fatalf("expected ErrNilRequest, got %v", err)
+				}
+			})
 		}
 	})
 }

--- a/pkg/net/http/policy_enforcement_test.go
+++ b/pkg/net/http/policy_enforcement_test.go
@@ -1,0 +1,174 @@
+package http
+
+import (
+	"errors"
+	"math"
+	stdhttp "net/http"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestPolicyEnforcementAccessors(t *testing.T) {
+	defaults := newTestPolicy(t)
+	if defaults.Timeout() != defaultTimeout {
+		t.Fatalf("expected timeout %s, got %s", defaultTimeout, defaults.Timeout())
+	}
+	if defaults.MaxResponseSize() != defaultMaxResponseSize {
+		t.Fatalf(
+			"expected response limit %d, got %d",
+			defaultMaxResponseSize,
+			defaults.MaxResponseSize(),
+		)
+	}
+	if defaults.MaxResponseHeaderSize() != defaultMaxResponseHeaderSize {
+		t.Fatalf(
+			"expected response header limit %d, got %d",
+			defaultMaxResponseHeaderSize,
+			defaults.MaxResponseHeaderSize(),
+		)
+	}
+
+	custom := newTestPolicy(
+		t,
+		WithTimeout(time.Second),
+		WithUnlimitedResponseSize(),
+		WithMaxResponseHeaderSize(2048),
+	)
+	if custom.Timeout() != time.Second {
+		t.Fatalf("expected timeout %s, got %s", time.Second, custom.Timeout())
+	}
+	if custom.MaxResponseSize() != 0 {
+		t.Fatalf("expected unlimited response size, got %d", custom.MaxResponseSize())
+	}
+	if custom.MaxResponseHeaderSize() != 2048 {
+		t.Fatalf("expected response header limit 2048, got %d", custom.MaxResponseHeaderSize())
+	}
+
+	noTimeout := newTestPolicy(t, WithNoTimeout())
+	if noTimeout.Timeout() != 0 {
+		t.Fatalf("expected disabled timeout, got %s", noTimeout.Timeout())
+	}
+}
+
+func TestPolicyCheckRedirect(t *testing.T) {
+	redirect := newTestPolicyGETRequest(t, "https://example.com/next")
+
+	t.Run("disabled", func(t *testing.T) {
+		policy := newTestPolicy(t, WithFollowRedirects(false))
+		if err := policy.CheckRedirect(redirect, nil); !errors.Is(err, stdhttp.ErrUseLastResponse) {
+			t.Fatalf("expected ErrUseLastResponse, got %v", err)
+		}
+	})
+
+	t.Run("exact limit", func(t *testing.T) {
+		policy := newTestPolicy(t, WithMaxRedirects(2))
+		if err := policy.CheckRedirect(
+			redirect,
+			[]*stdhttp.Request{{}, {}},
+		); err != nil {
+			t.Fatalf("expected redirect at configured limit to pass: %v", err)
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		policy := newTestPolicy(t, WithMaxRedirects(2))
+		err := policy.CheckRedirect(
+			redirect,
+			[]*stdhttp.Request{{}, {}, {}},
+		)
+		var limitErr *RedirectLimitError
+		if !errors.As(err, &limitErr) || limitErr.Limit != 2 {
+			t.Fatalf("expected redirect limit error for 2 redirects, got %#v", err)
+		}
+	})
+
+	t.Run("blocked target", func(t *testing.T) {
+		policy := newTestPolicy(t)
+		err := policy.CheckRedirect(
+			newTestPolicyGETRequest(t, "http://127.0.0.1/private"),
+			[]*stdhttp.Request{{}},
+		)
+		requirePolicyError(t, err, PolicyTargetRedirect)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		err := newTestPolicy(t).CheckRedirect(nil, []*stdhttp.Request{{}})
+		if !errors.Is(err, ErrNilRequest) {
+			t.Fatalf("expected ErrNilRequest, got %v", err)
+		}
+	})
+}
+
+func TestPolicyEvalConnection(t *testing.T) {
+	tests := []struct {
+		address netip.Addr
+		name    string
+		wantErr bool
+	}{
+		{name: "public", address: netip.MustParseAddr("93.184.216.34")},
+		{name: "invalid", address: netip.Addr{}, wantErr: true},
+		{name: "loopback", address: netip.MustParseAddr("127.0.0.1"), wantErr: true},
+		{name: "private", address: netip.MustParseAddr("10.0.0.1"), wantErr: true},
+		{name: "link local", address: netip.MustParseAddr("169.254.169.254"), wantErr: true},
+		{name: "nat64 private", address: netip.MustParseAddr("64:ff9b::10.0.0.1"), wantErr: true},
+	}
+
+	policy := newTestPolicy(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := policy.EvalConnection(tt.address)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("expected concrete address to pass: %v", err)
+				}
+				return
+			}
+
+			requirePolicyError(t, err, PolicyTargetConnection)
+		})
+	}
+}
+
+func TestPolicyEvalResponseSize(t *testing.T) {
+	policy := newTestPolicy(t, WithMaxResponseSize(3))
+	for _, size := range []int64{-1, 0, 2, 3} {
+		if err := policy.EvalResponseSize(size); err != nil {
+			t.Fatalf("expected response size %d to pass: %v", size, err)
+		}
+	}
+
+	err := policy.EvalResponseSize(4)
+	limitErr := requireResponseBodyLimitError(t, err)
+	if limitErr.Size != 4 || limitErr.Limit != 3 {
+		t.Fatalf("unexpected response limit error: %#v", limitErr)
+	}
+
+	unlimited := newTestPolicy(t, WithUnlimitedResponseSize())
+	if err := unlimited.EvalResponseSize(math.MaxInt64); err != nil {
+		t.Fatalf("expected unlimited response size to pass: %v", err)
+	}
+}
+
+func TestPolicyReadResponseBodyNilAndOwnership(t *testing.T) {
+	policy := newTestPolicy(t, WithMaxResponseSize(3))
+	body, err := policy.ReadResponseBody(nil)
+	if err != nil {
+		t.Fatalf("read nil body: %v", err)
+	}
+	if body != nil {
+		t.Fatalf("expected nil materialized body, got %q", body)
+	}
+
+	tracked := newTrackedResponseBody(newTerminalErrorReader("ok", nil))
+	body, err = policy.ReadResponseBody(tracked)
+	if err != nil {
+		t.Fatalf("read tracked body: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", body)
+	}
+	if tracked.closed.Load() {
+		t.Fatal("expected caller to retain response-body ownership")
+	}
+}

--- a/pkg/net/http/policy_external_test.go
+++ b/pkg/net/http/policy_external_test.go
@@ -1,0 +1,67 @@
+package http_test
+
+import (
+	"errors"
+	stdhttp "net/http"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
+
+func TestPolicySupportsCustomBackendIntegration(t *testing.T) {
+	policy, err := ferrethttp.NewPolicy(
+		ferrethttp.WithAllowedHosts("api.example.com"),
+		ferrethttp.WithTimeout(2*time.Second),
+		ferrethttp.WithMaxResponseSize(3),
+		ferrethttp.WithMaxResponseHeaderSize(2048),
+	)
+	if err != nil {
+		t.Fatalf("construct policy: %v", err)
+	}
+
+	request, err := stdhttp.NewRequest(stdhttp.MethodGet, "https://api.example.com/start", nil)
+	if err != nil {
+		t.Fatalf("construct request: %v", err)
+	}
+	if err := policy.Prepare(request); err != nil {
+		t.Fatalf("prepare request: %v", err)
+	}
+
+	redirect, err := stdhttp.NewRequest(stdhttp.MethodGet, "https://api.example.com/next", nil)
+	if err != nil {
+		t.Fatalf("construct redirect request: %v", err)
+	}
+	if err := policy.CheckRedirect(redirect, []*stdhttp.Request{request}); err != nil {
+		t.Fatalf("check redirect: %v", err)
+	}
+	if err := policy.EvalConnection(netip.MustParseAddr("93.184.216.34")); err != nil {
+		t.Fatalf("evaluate concrete address: %v", err)
+	}
+
+	if policy.Timeout() != 2*time.Second {
+		t.Fatalf("expected timeout %s, got %s", 2*time.Second, policy.Timeout())
+	}
+	if policy.MaxResponseSize() != 3 {
+		t.Fatalf("expected response limit 3, got %d", policy.MaxResponseSize())
+	}
+	if policy.MaxResponseHeaderSize() != 2048 {
+		t.Fatalf("expected response header limit 2048, got %d", policy.MaxResponseHeaderSize())
+	}
+
+	body, err := policy.ReadResponseBody(strings.NewReader("ok"))
+	if err != nil {
+		t.Fatalf("materialize response body: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", body)
+	}
+
+	err = policy.EvalResponseSize(4)
+	var limitErr *ferrethttp.ResponseBodyLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("expected response body limit error, got %T: %v", err, err)
+	}
+}

--- a/pkg/net/http/response_body_test.go
+++ b/pkg/net/http/response_body_test.go
@@ -18,19 +18,20 @@ func TestReadResponseBodyBoundaries(t *testing.T) {
 		name      string
 		body      string
 		want      string
-		limit     int64
+		options   []PolicyOption
 		wantSize  int64
 		wantLimit int64
 	}{
-		{name: "below", body: "12", limit: 3, want: "12"},
-		{name: "at", body: "123", limit: 3, want: "123"},
-		{name: "above", body: "1234", limit: 3, wantSize: 4, wantLimit: 3},
-		{name: "unlimited", body: "1234", limit: 0, want: "1234"},
+		{name: "below", body: "12", options: []PolicyOption{WithMaxResponseSize(3)}, want: "12"},
+		{name: "at", body: "123", options: []PolicyOption{WithMaxResponseSize(3)}, want: "123"},
+		{name: "above", body: "1234", options: []PolicyOption{WithMaxResponseSize(3)}, wantSize: 4, wantLimit: 3},
+		{name: "unlimited", body: "1234", options: []PolicyOption{WithUnlimitedResponseSize()}, want: "1234"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body, err := readResponseBody(strings.NewReader(tt.body), tt.limit)
+			policy := newTestPolicy(t, tt.options...)
+			body, err := policy.ReadResponseBody(strings.NewReader(tt.body))
 			if tt.wantLimit == 0 {
 				if err != nil {
 					t.Fatalf("read response body: %v", err)
@@ -53,7 +54,8 @@ func TestReadResponseBodyBoundaries(t *testing.T) {
 }
 
 func TestReadResponseBodyMaxInt64DoesNotOverflow(t *testing.T) {
-	body, err := readResponseBody(strings.NewReader("tiny"), math.MaxInt64)
+	policy := newTestPolicy(t, WithMaxResponseSize(math.MaxInt64))
+	body, err := policy.ReadResponseBody(strings.NewReader("tiny"))
 	if err != nil {
 		t.Fatalf("read with maximum limit: %v", err)
 	}
@@ -70,7 +72,7 @@ func TestReadResponseBodyStopsAfterLimitPlusOne(t *testing.T) {
 	)
 
 	source := strings.NewReader(strings.Repeat("x", bodySize))
-	body, err := readResponseBody(source, limit)
+	body, err := newTestPolicy(t, WithMaxResponseSize(limit)).ReadResponseBody(source)
 	if body != nil {
 		t.Fatalf("expected oversized body not to be returned, got %q", body)
 	}
@@ -86,7 +88,8 @@ func TestReadResponseBodyStopsAfterLimitPlusOne(t *testing.T) {
 
 func TestReadResponseBodyLimitTakesPrecedenceAfterExtraByte(t *testing.T) {
 	readErr := errors.New("read failed after data")
-	body, err := readResponseBody(newTerminalErrorReader("four", readErr), 3)
+	body, err := newTestPolicy(t, WithMaxResponseSize(3)).
+		ReadResponseBody(newTerminalErrorReader("four", readErr))
 	if body != nil {
 		t.Fatalf("expected oversized body not to be returned, got %q", body)
 	}

--- a/pkg/net/http/response_body_test.go
+++ b/pkg/net/http/response_body_test.go
@@ -155,12 +155,11 @@ func TestFromStdResponseNilResponse(t *testing.T) {
 }
 
 func TestClientNilResponsePreservesErrNilResponse(t *testing.T) {
-	client := &defaultHTTPClient{
-		policy: newTestPolicy(t),
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(newTestPolicy(t), stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return nil, nil
 		})},
-	}
+	)
 
 	response, err := client.Do(context.Background(), &Request{URL: "https://example.com"})
 	if response != nil {
@@ -178,9 +177,8 @@ func TestClientNilResponsePreservesErrNilResponse(t *testing.T) {
 
 func TestClientEnforcesDefaultResponseBodyLimit(t *testing.T) {
 	policy := newTestPolicy(t)
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			return &stdhttp.Response{
 				StatusCode: stdhttp.StatusOK,
 				Status:     "200 OK",
@@ -191,7 +189,7 @@ func TestClientEnforcesDefaultResponseBodyLimit(t *testing.T) {
 				)),
 			}, nil
 		})},
-	}
+	)
 
 	response, err := client.Do(context.Background(), &Request{URL: "https://example.com"})
 	if response != nil {

--- a/pkg/net/http/typed_errors_test.go
+++ b/pkg/net/http/typed_errors_test.go
@@ -262,7 +262,8 @@ func TestPolicyEvalAllowsUnknownBodyLengthWhenUnlimited(t *testing.T) {
 }
 
 func TestResponseBodyLimitError(t *testing.T) {
-	_, err := readResponseBody(strings.NewReader("four"), 3)
+	_, err := newTestPolicy(t, WithMaxResponseSize(3)).
+		ReadResponseBody(strings.NewReader("four"))
 	if err == nil {
 		t.Fatal("expected response body limit error")
 	}

--- a/pkg/net/http/typed_errors_test.go
+++ b/pkg/net/http/typed_errors_test.go
@@ -283,9 +283,8 @@ func TestResponseBodyLimitError(t *testing.T) {
 func TestRedirectLimitErrorSurvivesURLErrorWrapping(t *testing.T) {
 	roundTrips := 0
 	policy := newTestPolicy(t, WithMaxRedirects(1))
-	client := &defaultHTTPClient{
-		policy: policy,
-		client: stdhttp.Client{Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
+	client := newDefaultHTTPClient(policy, stdhttp.Client{
+		Transport: testRoundTripper(func(*stdhttp.Request) (*stdhttp.Response, error) {
 			roundTrips++
 			return responseWithBody(
 				stdhttp.StatusFound,
@@ -293,7 +292,7 @@ func TestRedirectLimitErrorSurvivesURLErrorWrapping(t *testing.T) {
 				stdhttp.Header{"Location": {"/next"}},
 			), nil
 		})},
-	}
+	)
 
 	_, err := client.Do(context.Background(), &Request{URL: "https://example.com/start"})
 	if err == nil {

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -31,7 +31,19 @@ func New(setters ...Option) (Network, error) {
 	}
 
 	if opts.httpClient == nil {
-		client, err := ferrethttp.New(opts.httpPolicies...)
+		var (
+			client ferrethttp.Client
+			err    error
+		)
+
+		if opts.httpTransport == nil {
+			client, err = ferrethttp.New(opts.httpPolicies...)
+		} else {
+			client, err = ferrethttp.NewWithTransport(
+				opts.httpTransport,
+				opts.httpPolicies...,
+			)
+		}
 
 		if err != nil {
 			return nil, fmt.Errorf("http client: %w", err)

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -30,17 +30,18 @@ func New(setters ...Option) (Network, error) {
 		option(&opts)
 	}
 
-	if opts.http == nil {
-		client, err := ferrethttp.New()
+	if opts.httpClient == nil {
+		client, err := ferrethttp.New(opts.httpPolicies...)
+
 		if err != nil {
 			return nil, fmt.Errorf("http client: %w", err)
 		}
 
-		opts.http = client
+		opts.httpClient = client
 	}
 
 	return &defaultNetwork{
-		http: opts.http,
+		http: opts.httpClient,
 	}, nil
 }
 

--- a/pkg/net/net_test.go
+++ b/pkg/net/net_test.go
@@ -1,0 +1,195 @@
+package net
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
+
+func TestWithHTTPTransportConstructsPolicyAwareClient(t *testing.T) {
+	transport := &trackingHTTPTransport{body: "four"}
+	network, err := New(
+		WithHTTPTransport(
+			transport,
+			ferrethttp.WithMaxResponseSize(3),
+		),
+	)
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+
+	response, err := network.HTTP().Do(
+		context.Background(),
+		&ferrethttp.Request{URL: "https://example.com"},
+	)
+	if response != nil {
+		t.Fatalf("expected no oversized response, got %#v", response)
+	}
+	var limitErr *ferrethttp.ResponseBodyLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("expected ResponseBodyLimitError, got %T: %v", err, err)
+	}
+	if limitErr.Size != 4 || limitErr.Limit != 3 {
+		t.Fatalf("unexpected response limit error: %#v", limitErr)
+	}
+	if got := transport.callCount(); got != 1 {
+		t.Fatalf("expected one transport call, got %d", got)
+	}
+
+	closer, ok := network.(interface{ CloseIdleConnections() })
+	if !ok {
+		t.Fatal("expected network to expose idle-connection cleanup")
+	}
+	closer.CloseIdleConnections()
+	closer.CloseIdleConnections()
+	if got := transport.idleCloseCount(); got != 2 {
+		t.Fatalf("expected cleanup to reach transport twice, got %d", got)
+	}
+}
+
+func TestWithHTTPTransportPreservesPolicyOptionOrder(t *testing.T) {
+	tests := []struct {
+		options func(*trackingHTTPTransport) []Option
+		name    string
+		wantErr bool
+	}{
+		{
+			name: "transport policy last",
+			options: func(transport *trackingHTTPTransport) []Option {
+				return []Option{
+					WithHTTPPolicies(ferrethttp.WithMaxResponseSize(3)),
+					WithHTTPTransport(transport, ferrethttp.WithMaxResponseSize(2)),
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "standalone policy last",
+			options: func(transport *trackingHTTPTransport) []Option {
+				return []Option{
+					WithHTTPTransport(transport, ferrethttp.WithMaxResponseSize(2)),
+					WithHTTPPolicies(ferrethttp.WithMaxResponseSize(3)),
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &trackingHTTPTransport{body: "123"}
+			network, err := New(tt.options(transport)...)
+			if err != nil {
+				t.Fatalf("create network: %v", err)
+			}
+
+			response, err := network.HTTP().Do(
+				context.Background(),
+				&ferrethttp.Request{URL: "https://example.com"},
+			)
+			if tt.wantErr {
+				var limitErr *ferrethttp.ResponseBodyLimitError
+				if !errors.As(err, &limitErr) {
+					t.Fatalf("expected ResponseBodyLimitError, got %T: %v", err, err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("execute request: %v", err)
+			}
+			if got := string(response.Body); got != "123" {
+				t.Fatalf("expected response body %q, got %q", "123", got)
+			}
+		})
+	}
+}
+
+func TestWithHTTPClientTakesPrecedenceOverTransport(t *testing.T) {
+	client := stubHTTPClient{}
+
+	tests := []struct {
+		options func(*trackingHTTPTransport) []Option
+		name    string
+	}{
+		{
+			name: "client first",
+			options: func(transport *trackingHTTPTransport) []Option {
+				return []Option{
+					WithHTTPClient(client),
+					WithHTTPTransport(
+						transport,
+						ferrethttp.WithMaxResponseSize(-1),
+					),
+				}
+			},
+		},
+		{
+			name: "transport first",
+			options: func(transport *trackingHTTPTransport) []Option {
+				return []Option{
+					WithHTTPTransport(
+						transport,
+						ferrethttp.WithMaxResponseSize(-1),
+					),
+					WithHTTPClient(client),
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &trackingHTTPTransport{}
+			network, err := New(tt.options(transport)...)
+			if err != nil {
+				t.Fatalf("create network: %v", err)
+			}
+			if network.HTTP() != client {
+				t.Fatalf("expected supplied client, got %T", network.HTTP())
+			}
+
+			if _, err := network.HTTP().Do(
+				context.Background(),
+				&ferrethttp.Request{URL: "https://example.com"},
+			); err != nil {
+				t.Fatalf("execute request: %v", err)
+			}
+			if got := transport.callCount(); got != 0 {
+				t.Fatalf("expected transport to remain unused, got %d calls", got)
+			}
+		})
+	}
+}
+
+func TestWithHTTPTransportPropagatesPolicyConfigurationError(t *testing.T) {
+	network, err := New(
+		WithHTTPTransport(
+			&trackingHTTPTransport{},
+			ferrethttp.WithMaxResponseSize(-1),
+		),
+	)
+	if network != nil {
+		t.Fatalf("expected no network, got %T", network)
+	}
+	if !errors.Is(err, ferrethttp.ErrInvalidPolicyConfiguration) {
+		t.Fatalf("expected ErrInvalidPolicyConfiguration, got %v", err)
+	}
+	if err == nil || !strings.HasPrefix(err.Error(), "http client: ") {
+		t.Fatalf("expected wrapped HTTP client error, got %v", err)
+	}
+}
+
+func TestWithHTTPTransportNilIsNoOp(t *testing.T) {
+	network, err := New(
+		WithHTTPTransport(nil, ferrethttp.WithMaxResponseSize(-1)),
+	)
+	if err != nil {
+		t.Fatalf("expected nil transport option to be ignored: %v", err)
+	}
+	if network == nil {
+		t.Fatal("expected default network")
+	}
+}

--- a/pkg/net/options.go
+++ b/pkg/net/options.go
@@ -1,13 +1,18 @@
 package net
 
-import ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+import (
+	stdhttp "net/http"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
 
 type (
 	Option func(*options)
 
 	options struct {
-		httpClient   ferrethttp.Client
-		httpPolicies []ferrethttp.PolicyOption
+		httpClient    ferrethttp.Client
+		httpTransport stdhttp.RoundTripper
+		httpPolicies  []ferrethttp.PolicyOption
 	}
 )
 
@@ -30,5 +35,25 @@ func WithHTTPPolicies(policies ...ferrethttp.PolicyOption) Option {
 		}
 
 		opts.httpPolicies = append(opts.httpPolicies, policies...)
+	}
+}
+
+// WithHTTPTransport sets the standard-library transport used by the
+// policy-aware HTTP client. The transport is ignored when WithHTTPClient
+// supplies a client. A nil transport makes this option a no-op.
+//
+// Custom transports remain responsible for proxy behavior, DNS and
+// concrete-address enforcement, and response-header limits.
+func WithHTTPTransport(transport stdhttp.RoundTripper, policies ...ferrethttp.PolicyOption) Option {
+	return func(opts *options) {
+		if transport == nil {
+			return
+		}
+
+		opts.httpTransport = transport
+
+		if len(policies) > 0 {
+			opts.httpPolicies = append(opts.httpPolicies, policies...)
+		}
 	}
 }

--- a/pkg/net/options.go
+++ b/pkg/net/options.go
@@ -6,7 +6,8 @@ type (
 	Option func(*options)
 
 	options struct {
-		http ferrethttp.Client
+		httpClient   ferrethttp.Client
+		httpPolicies []ferrethttp.PolicyOption
 	}
 )
 
@@ -17,6 +18,17 @@ func WithHTTPClient(client ferrethttp.Client) Option {
 			return
 		}
 
-		opts.http = client
+		opts.httpClient = client
+	}
+}
+
+// WithHTTPPolicies sets the HTTP policies used by a Network.
+func WithHTTPPolicies(policies ...ferrethttp.PolicyOption) Option {
+	return func(opts *options) {
+		if len(policies) == 0 {
+			return
+		}
+
+		opts.httpPolicies = append(opts.httpPolicies, policies...)
 	}
 }

--- a/pkg/net/tracking_http_transport_test.go
+++ b/pkg/net/tracking_http_transport_test.go
@@ -1,0 +1,38 @@
+package net
+
+import (
+	"io"
+	stdhttp "net/http"
+	"strings"
+	"sync/atomic"
+)
+
+type trackingHTTPTransport struct {
+	body       string
+	calls      atomic.Int64
+	idleCloses atomic.Int64
+}
+
+func (t *trackingHTTPTransport) RoundTrip(req *stdhttp.Request) (*stdhttp.Response, error) {
+	t.calls.Add(1)
+
+	return &stdhttp.Response{
+		StatusCode: stdhttp.StatusOK,
+		Status:     stdhttp.StatusText(stdhttp.StatusOK),
+		Header:     make(stdhttp.Header),
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Request:    req,
+	}, nil
+}
+
+func (t *trackingHTTPTransport) CloseIdleConnections() {
+	t.idleCloses.Add(1)
+}
+
+func (t *trackingHTTPTransport) callCount() int64 {
+	return t.calls.Load()
+}
+
+func (t *trackingHTTPTransport) idleCloseCount() int64 {
+	return t.idleCloses.Load()
+}


### PR DESCRIPTION
This pull request introduces a new way to construct policy-aware HTTP clients by allowing adaptation of existing `net/http.Client` instances, and refactors the codebase and tests to use this new approach. The main logic is now encapsulated in a new `NewWithClient` constructor, which ensures policy settings take precedence over the supplied client’s configuration. Several tests and benchmarks are updated to use the new constructor, and a comprehensive suite of tests is added for the new functionality.

**Key changes include:**

### New Client Construction and Policy Adaptation

* Added `NewWithClient`, a constructor that adapts an existing `stdhttp.Client` to a policy-aware client, ensuring policy timeouts and redirect settings override the client's own, and properly handling nil or invalid clients. (`pkg/net/http/client.go`, [pkg/net/http/client.goL41-R105](diffhunk://#diff-c614b142beb93c3b75ab75d611e21e15d70343db63a85f28592ab95be622d747L41-R105))
* Refactored the default client construction into a helper, `newDefaultHTTPClient`, to centralize client setup and normalization. (`pkg/net/http/client.go`, [pkg/net/http/client.goL41-R105](diffhunk://#diff-c614b142beb93c3b75ab75d611e21e15d70343db63a85f28592ab95be622d747L41-R105))

### Test and Benchmark Refactoring

* Updated all tests and benchmarks to use `newDefaultHTTPClient` instead of directly constructing `defaultHTTPClient`, ensuring consistency with the new construction logic. (`pkg/net/http/client_benchmark_test.go`, [[1]](diffhunk://#diff-a72a79bbf4168e55c35c824564506d311de14f24378d72b6a5d3eac3fbea19c0L91-R100); `pkg/net/http/client_hardening_test.go`, [[2]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL16-R21) [[3]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL39-R47) [[4]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL68-R67) [[5]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL85-R82) [[6]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL103-R101) [[7]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL120-R116) [[8]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL139-R136) [[9]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL153-R148) [[10]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL179-R176) [[11]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL194-R189) [[12]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL212-R209) [[13]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL227-R222) [[14]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL242-R245) [[15]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL265-R264) [[16]](diffhunk://#diff-34423f7a4f42cfefea5f90d8b939cae9cefde31030a0e04de5aa1e4f567d2d7dL306-R305)

### Comprehensive Testing for New Functionality

* Added a new test file, `client_constructor_test.go`, with thorough tests for `NewWithClient`, covering error handling, resource sharing, transport adaptation, and policy precedence over client settings. (`pkg/net/http/client_constructor_test.go`, [pkg/net/http/client_constructor_test.goR1-R226](diffhunk://#diff-86f17811aa48d88f5d59d2ecdb5874b52f03be65c815d4d135a7ccbe3746bbfcR1-R226))

### Internal Logic Improvements

* Simplified the `Do` and `checkRedirect` methods to consistently use the normalized client and policy, removing redundant code and ensuring all requests and redirects are evaluated with the correct policy. (`pkg/net/http/client.go`, [pkg/net/http/client.goL87-R132](diffhunk://#diff-c614b142beb93c3b75ab75d611e21e15d70343db63a85f28592ab95be622d747L87-R132))

---

These changes improve flexibility for users who need to adapt existing HTTP clients to policy enforcement, ensure policies are always correctly applied, and make the codebase more maintainable and testable.