### PR TITLE
feat: add decode options for stricter field and type validation

### DIFF
--- a/pkg/sdk/conversion_bench_test.go
+++ b/pkg/sdk/conversion_bench_test.go
@@ -64,6 +64,30 @@ func BenchmarkDecodeNested(b *testing.B) {
 	}
 }
 
+func BenchmarkDecodeNestedStrict(b *testing.B) {
+	input, err := sdk.Encode(b.Context(), benchmarkInput)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	options := []sdk.DecodeOption{
+		sdk.RequireType(runtime.TypeMap),
+		sdk.OnlyFields("name", "address", "tags"),
+		sdk.DisallowUnknownFields(),
+		sdk.DisallowNoneValues(),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		var output benchmarkUser
+		if err := sdk.Decode(b.Context(), input, &output, options...); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkTypedBinder(b *testing.B) {
 	left := runtime.NewString("value")
 	right := runtime.NewInt(42)

--- a/pkg/sdk/conversion_path.go
+++ b/pkg/sdk/conversion_path.go
@@ -43,6 +43,10 @@ func (path *conversionPath) Restore(mark int) {
 	path.data = path.data[:mark]
 }
 
+func (path conversionPath) IsRoot() bool {
+	return len(path.data) == 1
+}
+
 func (path conversionPath) String() string {
 	return string(path.data)
 }

--- a/pkg/sdk/decode.go
+++ b/pkg/sdk/decode.go
@@ -12,21 +12,28 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
+var runtimeValueReflectType = reflect.TypeFor[runtime.Value]()
+
 type decodeState struct {
 	ctx    context.Context
+	config *decodeConfig
 	path   conversionPath
-	config decodeConfig
 }
 
 // Decode binds a Ferret runtime value into a non-nil pointer target.
 func Decode(ctx context.Context, src runtime.Value, target any, options ...DecodeOption) error {
 	if ctx == nil {
-		return runtime.Error(runtime.ErrInvalidArgument, "context cannot be nil")
+		return newDecodeErrorWithoutPath(
+			"$",
+			DecodeErrorKindType,
+			runtime.Error(runtime.ErrInvalidArgument, "context cannot be nil"),
+			true,
+		)
 	}
 
 	targetValue, err := validateDecodeTarget(target)
 	if err != nil {
-		return err
+		return newDecodeErrorWithoutPath("$", DecodeErrorKindType, err, true)
 	}
 
 	state := &decodeState{
@@ -34,25 +41,73 @@ func Decode(ctx context.Context, src runtime.Value, target any, options ...Decod
 		path: newConversionPath(),
 	}
 
-	for _, option := range options {
-		if option != nil {
-			option(&state.config)
+	if len(options) > 0 {
+		state.config = &decodeConfig{}
+
+		for _, option := range options {
+			if option != nil {
+				option(state.config)
+			}
 		}
 	}
 
-	return bindRuntimeValue(state, normalizeRuntimeValue(src), targetValue.Elem())
+	if err := validateDecodeConfig(state.config, targetValue.Elem().Type()); err != nil {
+		return newDecodeError("$", DecodeErrorKindType, err, true)
+	}
+
+	src = normalizeRuntimeValue(src)
+
+	if src == runtime.None &&
+		state.config != nil &&
+		state.config.disallowNoneValues &&
+		targetValue.Elem().Type() != runtimeValueReflectType {
+		return newDecodeError(
+			"$",
+			DecodeErrorKindNone,
+			runtime.Error(runtime.ErrInvalidArgument, "none is not allowed"),
+			true,
+		)
+	}
+
+	if state.config != nil && len(state.config.requiredTypes) > 0 {
+		if err := runtime.ValidateType(src, state.config.requiredTypes...); err != nil {
+			return newDecodeError("$", DecodeErrorKindType, err, true)
+		}
+	}
+
+	return bindRuntimeValue(state, src, targetValue.Elem())
 }
 
 func bindRuntimeValue(state *decodeState, src runtime.Value, dst reflect.Value) error {
 	if err := state.ctx.Err(); err != nil {
-		return fmt.Errorf("%s: %w", state.path, err)
+		return newDecodeError(state.path.String(), DecodeErrorKindSource, err, false)
 	}
 
 	if !dst.CanSet() {
-		return fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "target is not settable"))
+		return newDecodeError(
+			state.path.String(),
+			DecodeErrorKindType,
+			runtime.Error(runtime.ErrInvalidArgumentType, "target is not settable"),
+			true,
+		)
 	}
 
 	if src == runtime.None {
+		if dst.Type() == runtimeValueReflectType {
+			dst.Set(reflect.ValueOf(src))
+
+			return nil
+		}
+
+		if state.config != nil && state.config.disallowNoneValues {
+			return newDecodeError(
+				state.path.String(),
+				DecodeErrorKindNone,
+				runtime.Error(runtime.ErrInvalidArgument, "none is not allowed"),
+				true,
+			)
+		}
+
 		dst.Set(reflect.Zero(dst.Type()))
 		return nil
 	}
@@ -142,7 +197,12 @@ func bindRuntimeScalar(state *decodeState, src runtime.Value, dst reflect.Value)
 		}
 
 		if dst.OverflowInt(int64(value)) {
-			return true, fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "integer overflow"))
+			return true, newDecodeError(
+				state.path.String(),
+				DecodeErrorKindRange,
+				runtime.Error(runtime.ErrInvalidArgumentType, "integer overflow"),
+				true,
+			)
 		}
 
 		dst.SetInt(int64(value))
@@ -155,7 +215,12 @@ func bindRuntimeScalar(state *decodeState, src runtime.Value, dst reflect.Value)
 		}
 
 		if value < 0 || dst.OverflowUint(uint64(value)) {
-			return true, fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "unsigned integer overflow"))
+			return true, newDecodeError(
+				state.path.String(),
+				DecodeErrorKindRange,
+				runtime.Error(runtime.ErrInvalidArgumentType, "unsigned integer overflow"),
+				true,
+			)
 		}
 
 		dst.SetUint(uint64(value))
@@ -174,7 +239,12 @@ func bindRuntimeScalar(state *decodeState, src runtime.Value, dst reflect.Value)
 		}
 
 		if dst.OverflowFloat(number) {
-			return true, fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "floating-point overflow"))
+			return true, newDecodeError(
+				state.path.String(),
+				DecodeErrorKindRange,
+				runtime.Error(runtime.ErrInvalidArgumentType, "floating-point overflow"),
+				true,
+			)
 		}
 
 		dst.SetFloat(number)
@@ -193,22 +263,27 @@ func bindRuntimeSlice(state *decodeState, src runtime.Value, dst reflect.Value) 
 
 	iterator, err := iterable.Iterate(state.ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", state.path, err)
+		return newDecodeError(state.path.String(), DecodeErrorKindSource, err, false)
 	}
 
 	defer func() {
-		retErr = errors.Join(retErr, closeIteratorAt(iterator, &state.path))
+		retErr = joinDecodeErrors(retErr, closeIteratorAt(iterator, &state.path), &state.path)
 	}()
 
 	capacity := 0
 	if measurable, ok := src.(runtime.Measurable); ok {
 		length, lengthErr := measurable.Length(state.ctx)
 		if lengthErr != nil {
-			return fmt.Errorf("%s: %w", state.path, lengthErr)
+			return newDecodeError(state.path.String(), DecodeErrorKindSource, lengthErr, false)
 		}
 
 		if length > runtime.Int(int(^uint(0)>>1)) {
-			return fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "collection length overflows int"))
+			return newDecodeError(
+				state.path.String(),
+				DecodeErrorKindRange,
+				runtime.Error(runtime.ErrInvalidArgumentType, "collection length overflows int"),
+				true,
+			)
 		}
 
 		if length > 0 {
@@ -226,7 +301,7 @@ func bindRuntimeSlice(state *decodeState, src runtime.Value, dst reflect.Value) 
 
 		if nextErr != nil {
 			mark := state.path.PushIndex(index)
-			err := fmt.Errorf("%s: %w", state.path, nextErr)
+			err := newDecodeError(state.path.String(), DecodeErrorKindSource, nextErr, false)
 			state.path.Restore(mark)
 
 			return err
@@ -257,11 +332,11 @@ func bindRuntimeArray(state *decodeState, src runtime.Value, dst reflect.Value) 
 
 	iterator, err := iterable.Iterate(state.ctx)
 	if err != nil {
-		return fmt.Errorf("%s: %w", state.path, err)
+		return newDecodeError(state.path.String(), DecodeErrorKindSource, err, false)
 	}
 
 	defer func() {
-		retErr = errors.Join(retErr, closeIteratorAt(iterator, &state.path))
+		retErr = joinDecodeErrors(retErr, closeIteratorAt(iterator, &state.path), &state.path)
 	}()
 
 	for index := 0; ; index++ {
@@ -272,14 +347,19 @@ func bindRuntimeArray(state *decodeState, src runtime.Value, dst reflect.Value) 
 
 		if nextErr != nil {
 			mark := state.path.PushIndex(index)
-			err := fmt.Errorf("%s: %w", state.path, nextErr)
+			err := newDecodeError(state.path.String(), DecodeErrorKindSource, nextErr, false)
 			state.path.Restore(mark)
 
 			return err
 		}
 
 		if index >= dst.Len() {
-			return fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "source has more elements than target array"))
+			return newDecodeError(
+				state.path.String(),
+				DecodeErrorKindRange,
+				runtime.Error(runtime.ErrInvalidArgumentType, "source has more elements than target array"),
+				true,
+			)
 		}
 
 		mark := state.path.PushIndex(index)
@@ -296,7 +376,12 @@ func bindRuntimeArray(state *decodeState, src runtime.Value, dst reflect.Value) 
 
 func bindRuntimeMap(state *decodeState, src runtime.Value, dst reflect.Value) error {
 	if dst.Type().Key().Kind() != reflect.String {
-		return fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "map key type must be string"))
+		return newDecodeError(
+			state.path.String(),
+			DecodeErrorKindType,
+			runtime.Error(runtime.ErrInvalidArgumentType, "map key type must be string"),
+			true,
+		)
 	}
 
 	entries, err := collectRuntimeEntries(state, src)
@@ -331,6 +416,12 @@ func bindRuntimeStruct(state *decodeState, src runtime.Value, dst reflect.Value)
 		return err
 	}
 
+	if state.path.IsRoot() && state.config != nil && state.config.onlyFields != nil {
+		if err := rejectDisallowedFields(state, entries); err != nil {
+			return err
+		}
+	}
+
 	lowerKeys := buildLowerRuntimeKeyMap(entries)
 	used := make(map[string]struct{}, len(entries))
 	visiting := make(map[reflect.Type]bool)
@@ -339,7 +430,7 @@ func bindRuntimeStruct(state *decodeState, src runtime.Value, dst reflect.Value)
 		return err
 	}
 
-	if state.config.disallowUnknownFields {
+	if state.config != nil && state.config.disallowUnknownFields {
 		unknown := make([]string, 0)
 
 		for key := range entries {
@@ -351,10 +442,11 @@ func bindRuntimeStruct(state *decodeState, src runtime.Value, dst reflect.Value)
 		if len(unknown) > 0 {
 			sort.Strings(unknown)
 
-			return fmt.Errorf(
-				"%s: %w",
-				state.path,
+			return newDecodeError(
+				state.path.String(),
+				DecodeErrorKindUnknownField,
 				runtime.Errorf(runtime.ErrInvalidArgument, "unknown field %q", unknown[0]),
+				true,
 			)
 		}
 	}
@@ -534,11 +626,11 @@ func collectRuntimeEntries(state *decodeState, src runtime.Value) (out map[strin
 
 	iterator, err := iterable.Iterate(state.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", state.path, err)
+		return nil, newDecodeError(state.path.String(), DecodeErrorKindSource, err, false)
 	}
 
 	defer func() {
-		retErr = errors.Join(retErr, closeIteratorAt(iterator, &state.path))
+		retErr = joinDecodeErrors(retErr, closeIteratorAt(iterator, &state.path), &state.path)
 	}()
 
 	out = make(map[string]runtime.Value)
@@ -549,18 +641,23 @@ func collectRuntimeEntries(state *decodeState, src runtime.Value) (out map[strin
 		}
 
 		if nextErr != nil {
-			return nil, fmt.Errorf("%s: %w", state.path, nextErr)
+			return nil, newDecodeError(state.path.String(), DecodeErrorKindSource, nextErr, false)
 		}
 
 		key, ok := keyValue.(runtime.String)
 		if !ok {
-			return nil, fmt.Errorf("%s: %w", state.path, runtime.Error(runtime.ErrInvalidArgumentType, "map key type must be string"))
+			return nil, newDecodeError(
+				state.path.String(),
+				DecodeErrorKindType,
+				runtime.Error(runtime.ErrInvalidArgumentType, "map key type must be string"),
+				true,
+			)
 		}
 
 		value, getErr := input.Get(state.ctx, keyValue)
 		if getErr != nil {
 			mark := state.path.PushKey(key.String())
-			err := fmt.Errorf("%s: %w", state.path, getErr)
+			err := newDecodeError(state.path.String(), DecodeErrorKindSource, getErr, false)
 
 			state.path.Restore(mark)
 
@@ -625,17 +722,87 @@ func closeIteratorAt(iterator runtime.Iterator, path *conversionPath) error {
 	}
 
 	if err := closer.Close(); err != nil {
-		return fmt.Errorf("%s: close iterator: %w", path, err)
+		return newDecodeError(
+			path.String(),
+			DecodeErrorKindSource,
+			fmt.Errorf("close iterator: %w", err),
+			false,
+		)
 	}
 
 	return nil
 }
 
 func decodeTypeError(path *conversionPath, src runtime.Value, target reflect.Type) error {
-	return fmt.Errorf(
-		"%s: %w",
-		path,
+	return newDecodeError(
+		path.String(),
+		DecodeErrorKindType,
 		runtime.Errorf(runtime.ErrInvalidArgumentType, "cannot bind %s to %s", runtime.TypeOf(src), target),
+		true,
+	)
+}
+
+func validateDecodeConfig(config *decodeConfig, target reflect.Type) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.err != nil {
+		return config.err
+	}
+
+	if config.onlyFields == nil {
+		return nil
+	}
+
+	for target.Kind() == reflect.Pointer {
+		target = target.Elem()
+	}
+
+	if target.Kind() != reflect.Struct {
+		return runtime.Error(runtime.ErrInvalidArgument, "OnlyFields requires a struct target")
+	}
+
+	return nil
+}
+
+func rejectDisallowedFields(state *decodeState, entries map[string]runtime.Value) error {
+	unknown := make([]string, 0)
+
+	for key := range entries {
+		if _, allowed := state.config.onlyFields[strings.ToLower(key)]; !allowed {
+			unknown = append(unknown, key)
+		}
+	}
+
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	sort.Strings(unknown)
+
+	return newDecodeError(
+		state.path.String(),
+		DecodeErrorKindUnknownField,
+		runtime.Errorf(runtime.ErrInvalidArgument, "unknown field %q", unknown[0]),
+		true,
+	)
+}
+
+func joinDecodeErrors(primary, secondary error, path *conversionPath) error {
+	if secondary == nil {
+		return primary
+	}
+
+	if primary == nil {
+		return secondary
+	}
+
+	return newDecodeErrorWithoutPath(
+		path.String(),
+		DecodeErrorKindSource,
+		errors.Join(primary, secondary),
+		false,
 	)
 }
 

--- a/pkg/sdk/decode_controls_test.go
+++ b/pkg/sdk/decode_controls_test.go
@@ -1,0 +1,357 @@
+package sdk_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/sdk"
+)
+
+type controlledDecodeOptions struct {
+	Raw   runtime.Value `ferret:"raw"`
+	Name  string        `ferret:"name"`
+	Count int8          `ferret:"count"`
+}
+
+type controlledNestedOptions struct {
+	Name   string                  `ferret:"name"`
+	Nested controlledDecodeOptions `ferret:"nested"`
+}
+
+func TestDecodeValue(t *testing.T) {
+	source := runtime.NewObjectWith(map[string]runtime.Value{
+		"name":  runtime.NewString("Ferret"),
+		"count": runtime.NewInt(2),
+	})
+
+	decoded, err := sdk.DecodeValue[controlledDecodeOptions](
+		t.Context(),
+		source,
+		sdk.RequireType(runtime.TypeMap),
+		sdk.DisallowUnknownFields(),
+	)
+	if err != nil {
+		t.Fatalf("decode value: %v", err)
+	}
+	if decoded.Name != "Ferret" || decoded.Count != 2 {
+		t.Fatalf("unexpected value: %#v", decoded)
+	}
+}
+
+func TestRequireType(t *testing.T) {
+	t.Run("accepts any listed runtime type", func(t *testing.T) {
+		decoded, err := sdk.DecodeValue[string](
+			t.Context(),
+			runtime.NewString("Ferret"),
+			sdk.RequireType(runtime.TypeMap, runtime.TypeString),
+		)
+		if err != nil || decoded != "Ferret" {
+			t.Fatalf("got %q, %v", decoded, err)
+		}
+	})
+
+	t.Run("rejects mismatched root type", func(t *testing.T) {
+		_, err := sdk.DecodeValue[string](
+			t.Context(),
+			runtime.NewString("Ferret"),
+			sdk.RequireType(runtime.TypeMap),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidType) {
+			t.Fatalf("expected invalid type, got %v", err)
+		}
+	})
+
+	t.Run("requires at least one expected type", func(t *testing.T) {
+		_, err := sdk.DecodeValue[string](
+			t.Context(),
+			runtime.NewString("Ferret"),
+			sdk.RequireType(),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+
+	t.Run("rejects nil expected types", func(t *testing.T) {
+		_, err := sdk.DecodeValue[string](
+			t.Context(),
+			runtime.NewString("Ferret"),
+			sdk.RequireType(runtime.TypeString, nil),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+}
+
+func TestOnlyFields(t *testing.T) {
+	t.Run("matches root fields case insensitively", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"NAME": runtime.NewString("Ferret"),
+		})
+
+		decoded, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			source,
+			sdk.OnlyFields("name"),
+			sdk.DisallowUnknownFields(),
+		)
+		if err != nil || decoded.Name != "Ferret" {
+			t.Fatalf("got %#v, %v", decoded, err)
+		}
+	})
+
+	t.Run("rejects a tagged but disallowed root field", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"name":  runtime.NewString("Ferret"),
+			"count": runtime.NewInt(2),
+		})
+
+		_, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			source,
+			sdk.OnlyFields("name"),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindUnknownField, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+
+	t.Run("does not restrict nested fields", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"nested": runtime.NewObjectWith(map[string]runtime.Value{
+				"name":  runtime.NewString("Ferret"),
+				"count": runtime.NewInt(2),
+			}),
+		})
+
+		decoded, err := sdk.DecodeValue[controlledNestedOptions](
+			t.Context(),
+			source,
+			sdk.OnlyFields("nested"),
+		)
+		if err != nil {
+			t.Fatalf("decode nested value: %v", err)
+		}
+		if decoded.Nested.Name != "Ferret" || decoded.Nested.Count != 2 {
+			t.Fatalf("unexpected nested value: %#v", decoded)
+		}
+	})
+
+	t.Run("combines with strict nested decoding", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"nested": runtime.NewObjectWith(map[string]runtime.Value{
+				"name":  runtime.NewString("Ferret"),
+				"extra": runtime.True,
+			}),
+		})
+
+		_, err := sdk.DecodeValue[controlledNestedOptions](
+			t.Context(),
+			source,
+			sdk.OnlyFields("nested"),
+			sdk.DisallowUnknownFields(),
+		)
+
+		assertDecodeError(t, err, "$.nested", sdk.DecodeErrorKindUnknownField, true)
+	})
+
+	t.Run("requires a struct target", func(t *testing.T) {
+		_, err := sdk.DecodeValue[map[string]string](
+			t.Context(),
+			runtime.NewObject(),
+			sdk.OnlyFields("name"),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+
+	t.Run("rejects an empty configured field name as an authoring error", func(t *testing.T) {
+		_, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			runtime.NewObject(),
+			sdk.OnlyFields(""),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+}
+
+func TestDisallowNoneValues(t *testing.T) {
+	t.Run("takes precedence over a required root type", func(t *testing.T) {
+		_, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			runtime.None,
+			sdk.RequireType(runtime.TypeMap),
+			sdk.DisallowNoneValues(),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindNone, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+
+	t.Run("rejects None for a native field", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"name": runtime.None,
+		})
+
+		_, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			source,
+			sdk.DisallowNoneValues(),
+		)
+
+		assertDecodeError(t, err, "$.name", sdk.DecodeErrorKindNone, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected invalid argument, got %v", err)
+		}
+	})
+
+	t.Run("preserves None for an exact runtime Value field", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"raw": runtime.None,
+		})
+
+		decoded, err := sdk.DecodeValue[controlledDecodeOptions](
+			t.Context(),
+			source,
+			sdk.DisallowNoneValues(),
+		)
+		if err != nil {
+			t.Fatalf("decode runtime value: %v", err)
+		}
+		if decoded.Raw != runtime.None {
+			t.Fatalf("got %#v, want runtime.None", decoded.Raw)
+		}
+	})
+
+	t.Run("preserves root None for an exact runtime Value", func(t *testing.T) {
+		decoded, err := sdk.DecodeValue[runtime.Value](
+			t.Context(),
+			runtime.None,
+			sdk.DisallowNoneValues(),
+		)
+		if err != nil {
+			t.Fatalf("decode runtime value: %v", err)
+		}
+		if decoded != runtime.None {
+			t.Fatalf("got %#v, want runtime.None", decoded)
+		}
+	})
+
+	t.Run("preserves None in an exact runtime Value slice", func(t *testing.T) {
+		decoded, err := sdk.DecodeValue[[]runtime.Value](
+			t.Context(),
+			runtime.NewArrayWith(runtime.None),
+			sdk.DisallowNoneValues(),
+		)
+		if err != nil {
+			t.Fatalf("decode runtime values: %v", err)
+		}
+		if len(decoded) != 1 || decoded[0] != runtime.None {
+			t.Fatalf("got %#v, want [runtime.None]", decoded)
+		}
+	})
+
+	t.Run("retains default None zeroing", func(t *testing.T) {
+		decoded, err := sdk.DecodeValue[string](t.Context(), runtime.None)
+		if err != nil || decoded != "" {
+			t.Fatalf("got %q, %v", decoded, err)
+		}
+	})
+}
+
+func TestDecodeErrorMetadata(t *testing.T) {
+	t.Run("range failure is safe and keeps its sentinel", func(t *testing.T) {
+		source := runtime.NewObjectWith(map[string]runtime.Value{
+			"count": runtime.NewInt(128),
+		})
+
+		_, err := sdk.DecodeValue[controlledDecodeOptions](t.Context(), source)
+		assertDecodeError(t, err, "$.count", sdk.DecodeErrorKindRange, true)
+		if !errors.Is(err, runtime.ErrInvalidArgumentType) {
+			t.Fatalf("expected invalid argument type, got %v", err)
+		}
+	})
+
+	t.Run("iterator failure is an unsafe source error", func(t *testing.T) {
+		sentinel := runtime.Error(runtime.ErrInvalidArgument, "private source detail")
+		source := &conversionIteratorValue{terminalErr: sentinel}
+
+		_, err := sdk.DecodeValue[[]string](t.Context(), source)
+		assertDecodeError(t, err, "$[0]", sdk.DecodeErrorKindSource, false)
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("expected source sentinel, got %v", err)
+		}
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("expected wrapped runtime sentinel, got %v", err)
+		}
+	})
+
+	t.Run("caller cancellation is an unsafe source error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err := sdk.DecodeValue[string](ctx, runtime.NewString("Ferret"))
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindSource, false)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation, got %v", err)
+		}
+	})
+
+	t.Run("DecodeArg preserves typed metadata", func(t *testing.T) {
+		_, err := sdk.DecodeArg[controlledDecodeOptions](
+			t.Context(),
+			[]runtime.Value{runtime.NewString("wrong")},
+			0,
+			sdk.RequireType(runtime.TypeMap),
+		)
+
+		assertDecodeError(t, err, "$", sdk.DecodeErrorKindType, true)
+		if !errors.Is(err, runtime.ErrInvalidArgument) || !errors.Is(err, runtime.ErrInvalidType) {
+			t.Fatalf("expected argument and type sentinels, got %v", err)
+		}
+	})
+}
+
+func assertDecodeError(
+	t *testing.T,
+	err error,
+	path string,
+	kind sdk.DecodeErrorKind,
+	safe bool,
+) {
+	t.Helper()
+
+	var decodeErr *sdk.DecodeError
+	if !errors.As(err, &decodeErr) {
+		t.Fatalf("expected DecodeError, got %T: %v", err, err)
+	}
+	if decodeErr.Path() != path {
+		t.Fatalf("path = %q, want %q", decodeErr.Path(), path)
+	}
+	if decodeErr.Kind() != kind {
+		t.Fatalf("kind = %q, want %q", decodeErr.Kind(), kind)
+	}
+	if decodeErr.SafeToExpose() != safe {
+		t.Fatalf("safe = %t, want %t", decodeErr.SafeToExpose(), safe)
+	}
+}

--- a/pkg/sdk/decode_error.go
+++ b/pkg/sdk/decode_error.go
@@ -1,0 +1,99 @@
+package sdk
+
+import "fmt"
+
+type (
+	// DecodeErrorKind classifies failures reported by Decode and related helpers.
+	DecodeErrorKind string
+
+	// DecodeError describes a failed Ferret-to-Go conversion.
+	//
+	// SafeToExpose distinguishes deterministic conversion diagnostics from errors
+	// returned by runtime values or callbacks, which may contain sensitive details.
+	DecodeError struct {
+		cause      error
+		path       string
+		kind       DecodeErrorKind
+		safe       bool
+		renderPath bool
+	}
+)
+
+const (
+	// DecodeErrorKindType reports a source or target type mismatch.
+	DecodeErrorKindType DecodeErrorKind = "type"
+	// DecodeErrorKindUnknownField reports an object field rejected by strict decoding.
+	DecodeErrorKindUnknownField DecodeErrorKind = "unknown_field"
+	// DecodeErrorKindNone reports an explicit None rejected by DisallowNoneValues.
+	DecodeErrorKindNone DecodeErrorKind = "none"
+	// DecodeErrorKindRange reports a numeric or collection-size overflow.
+	DecodeErrorKindRange DecodeErrorKind = "range"
+	// DecodeErrorKindSource reports a failure returned by a runtime value, iterator, or caller context.
+	DecodeErrorKindSource DecodeErrorKind = "source"
+)
+
+func newDecodeError(path string, kind DecodeErrorKind, cause error, safe bool) *DecodeError {
+	return &DecodeError{
+		path:       path,
+		kind:       kind,
+		cause:      cause,
+		safe:       safe,
+		renderPath: true,
+	}
+}
+
+func newDecodeErrorWithoutPath(path string, kind DecodeErrorKind, cause error, safe bool) *DecodeError {
+	err := newDecodeError(path, kind, cause, safe)
+	err.renderPath = false
+
+	return err
+}
+
+// Error renders the conversion path followed by the underlying error.
+func (e *DecodeError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.cause == nil {
+		return e.path
+	}
+
+	if !e.renderPath || e.path == "" {
+		return e.cause.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", e.path, e.cause)
+}
+
+// Unwrap returns the underlying conversion or source failure.
+func (e *DecodeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.cause
+}
+
+// Path returns the JSONPath-like location at which decoding failed.
+func (e *DecodeError) Path() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.path
+}
+
+// Kind returns the stable failure category.
+func (e *DecodeError) Kind() DecodeErrorKind {
+	if e == nil {
+		return ""
+	}
+
+	return e.kind
+}
+
+// SafeToExpose reports whether Error contains only SDK-generated conversion detail.
+func (e *DecodeError) SafeToExpose() bool {
+	return e != nil && e.safe
+}

--- a/pkg/sdk/decode_example_test.go
+++ b/pkg/sdk/decode_example_test.go
@@ -1,0 +1,36 @@
+package sdk_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/sdk"
+)
+
+func ExampleDecodeValue() {
+	type options struct {
+		Temperature *float64 `ferret:"temperature"`
+		Name        string   `ferret:"name"`
+	}
+
+	input := runtime.NewObjectWith(map[string]runtime.Value{
+		"NAME":        runtime.NewString("gpt"),
+		"temperature": runtime.NewFloat(0),
+	})
+
+	decoded, err := sdk.DecodeValue[options](
+		context.Background(),
+		input,
+		sdk.RequireType(runtime.TypeMap),
+		sdk.OnlyFields("name", "temperature"),
+		sdk.DisallowUnknownFields(),
+		sdk.DisallowNoneValues(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(decoded.Name, *decoded.Temperature)
+	// Output: gpt 0
+}

--- a/pkg/sdk/decode_option.go
+++ b/pkg/sdk/decode_option.go
@@ -1,15 +1,95 @@
 package sdk
 
-type decodeConfig struct {
-	disallowUnknownFields bool
-}
+import (
+	"strings"
 
-// DecodeOption configures Decode and the argument decoding helpers.
-type DecodeOption func(*decodeConfig)
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	decodeConfig struct {
+		err                   error
+		onlyFields            map[string]struct{}
+		requiredTypes         []runtime.Type
+		disallowUnknownFields bool
+		disallowNoneValues    bool
+	}
+
+	// DecodeOption configures Decode and the argument decoding helpers.
+	DecodeOption func(*decodeConfig)
+)
 
 // DisallowUnknownFields rejects object keys that do not match a tagged struct field.
 func DisallowUnknownFields() DecodeOption {
 	return func(config *decodeConfig) {
 		config.disallowUnknownFields = true
+	}
+}
+
+// RequireType requires the root source value to match at least one expected
+// Ferret runtime type before conversion.
+//
+// Passing no types, or a nil type, is an SDK authoring error.
+func RequireType(expected ...runtime.Type) DecodeOption {
+	copied := append([]runtime.Type(nil), expected...)
+	var optionErr error
+
+	if len(copied) == 0 {
+		optionErr = runtime.Error(runtime.ErrInvalidArgument, "RequireType requires at least one type")
+	}
+
+	if optionErr == nil {
+		for _, expectedType := range copied {
+			if expectedType == nil {
+				optionErr = runtime.Error(runtime.ErrInvalidArgument, "RequireType does not accept nil types")
+
+				break
+			}
+		}
+	}
+
+	return func(config *decodeConfig) {
+		if optionErr != nil {
+			config.err = optionErr
+
+			return
+		}
+
+		config.requiredTypes = copied
+	}
+}
+
+// OnlyFields restricts root object decoding to the named tagged struct fields.
+// Names are matched case-insensitively. The option is valid only for struct targets.
+func OnlyFields(names ...string) DecodeOption {
+	fields := make(map[string]struct{}, len(names))
+	var optionErr error
+
+	for _, name := range names {
+		if name == "" {
+			optionErr = runtime.Error(runtime.ErrInvalidArgument, "OnlyFields does not accept empty field names")
+
+			break
+		}
+
+		fields[strings.ToLower(name)] = struct{}{}
+	}
+
+	return func(config *decodeConfig) {
+		if optionErr != nil {
+			config.err = optionErr
+
+			return
+		}
+
+		config.onlyFields = fields
+	}
+}
+
+// DisallowNoneValues rejects explicit None values decoded into native Go values.
+// Fields whose destination type is exactly runtime.Value preserve runtime.None.
+func DisallowNoneValues() DecodeOption {
+	return func(config *decodeConfig) {
+		config.disallowNoneValues = true
 	}
 }

--- a/pkg/sdk/decode_value.go
+++ b/pkg/sdk/decode_value.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+// DecodeValue binds a Ferret runtime value into T and returns the result.
+func DecodeValue[T any](ctx context.Context, src runtime.Value, options ...DecodeOption) (T, error) {
+	var output T
+
+	if err := Decode(ctx, src, &output, options...); err != nil {
+		return output, err
+	}
+
+	return output, nil
+}

--- a/pkg/sdk/doc.go
+++ b/pkg/sdk/doc.go
@@ -6,10 +6,12 @@
 // on runtime.Value types; the SDK does not invoke arbitrary native Go functions
 // through reflection.
 //
-// Encode, Decode, DecodeArg, and Codec provide context-aware conversion at host
-// boundaries. HostValue represents opaque identity, while IterableValue,
-// IteratorValue, SliceView, and MapView opt in to only the runtime capabilities
-// they implement.
+// Encode, Decode, DecodeValue, DecodeArg, and Codec provide context-aware
+// conversion at host boundaries. Decode options can require a root runtime
+// type, restrict tagged root fields, reject unknown fields, and distinguish
+// explicit None from omitted configuration. HostValue represents opaque
+// identity, while IterableValue, IteratorValue, SliceView, and MapView opt in
+// to only the runtime capabilities they implement.
 //
 // The sdktest subpackage provides an Engine-backed black-box test harness for
 // executing module functions through FQL.


### PR DESCRIPTION
This pull request introduces significant improvements to the decoding logic in the SDK, primarily focused on stricter decoding options, improved error handling, and enhanced test coverage. The main changes include the addition of new decode options for stricter field validation, refactoring error handling to provide more informative and structured errors, and adding a benchmark to test strict decoding scenarios.

### Stricter decoding options and validation:

* Added support for `OnlyFields`, `DisallowUnknownFields`, and `DisallowNoneValues` options in the decode pipeline, allowing the decoder to restrict allowed fields, reject unknown fields, and disallow `None` values, respectively (`decode.go`, `decodeConfig`, `validateDecodeConfig`, `rejectDisallowedFields`). [[1]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R15-R110) [[2]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R419-R424) [[3]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L342-R433) [[4]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L354-R449) [[5]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L628-R805)
* Added validation to ensure that `OnlyFields` is only used with struct targets, returning a clear error otherwise (`validateDecodeConfig`).

### Improved error handling and reporting:

* Replaced generic `fmt.Errorf` error wrapping with a new structured error type (`newDecodeError`), which includes error kind, path information, and better context for decoding failures across all decode helpers (`decode.go`). [[1]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0R15-R110) [[2]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L145-R205) [[3]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L158-R223) [[4]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L177-R247) [[5]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L196-R286) [[6]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L229-R304) [[7]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L260-R339) [[8]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L275-R362) [[9]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L299-R384) [[10]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L537-R633) [[11]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L552-R660) [[12]](diffhunk://#diff-670574df14324861ea79b24b4b553fbb9ad6659792f9c48a66dcb0ee48358dd0L628-R805)
* Introduced `joinDecodeErrors` to combine multiple errors into a single structured error, improving error reporting for iterator closing and other multi-error scenarios (`decode.go`).

### Test and benchmark enhancements:

* Added a new benchmark, `BenchmarkDecodeNestedStrict`, to measure and validate the performance and correctness of decoding with strict options enabled (`conversion_bench_test.go`).

### Internal utilities and helpers:

* Added `IsRoot` helper to `conversionPath` to assist in determining when only root-level field restrictions should apply (`conversion_path.go`).

These changes collectively make the decoding process more robust, configurable, and easier to debug when issues arise.