### PR TITLE
feat: add lifecycle management for network ownership in engine

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -34,8 +34,7 @@ func New(setters ...Option) (*Engine, error) {
 		return nil, err
 	}
 
-	ownsNetwork := opts.network == nil
-
+	ownsNetwork := opts.hostNetwork == false
 	boot, err := newBootstrap(opts)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: %w", err)
@@ -53,7 +52,6 @@ func New(setters ...Option) (*Engine, error) {
 	}
 
 	hooks := boot.hooks.clone()
-
 	// Run init hooks after bootstrap is finalized and before returning the engine.
 	if err := hooks.engine.runInitHooks(); err != nil {
 		initErr := fmt.Errorf("init hooks: %w", err)
@@ -81,7 +79,6 @@ func (e *Engine) Compile(ctx context.Context, src *source.Source) (*Plan, error)
 	}
 
 	prog, err := e.compiler.Compile(src)
-
 	// After-compile hooks always run and receive the compilation error (if any).
 	if hookErr := e.hooks.plan.runAfterCompileHooks(ctx, err); hookErr != nil {
 		return nil, errors.Join(err, fmt.Errorf("after compile hooks: %w", hookErr))

--- a/engine_lifecycle_test.go
+++ b/engine_lifecycle_test.go
@@ -179,6 +179,88 @@ func TestEngineCloseDoesNotCleanInjectedNetwork(t *testing.T) {
 	}
 }
 
+func TestEngineNetworkOwnershipFollowsLastOption(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		managedLast bool
+	}{
+		{name: "network options last", managedLast: true},
+		{name: "injected network last", managedLast: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			managedClient := &recordingHTTPClient{}
+			injectedClient := &recordingHTTPClient{}
+			injectedNetwork := mustNewTestNetwork(t, ferretnet.WithHTTPClient(injectedClient))
+
+			var setters []Option
+			if tt.managedLast {
+				setters = []Option{
+					WithNetwork(injectedNetwork),
+					WithNetworkOptions(ferretnet.WithHTTPClient(managedClient)),
+				}
+			} else {
+				setters = []Option{
+					WithNetworkOptions(ferretnet.WithHTTPClient(managedClient)),
+					WithNetwork(injectedNetwork),
+				}
+			}
+
+			eng := mustNewEngine(t, setters...)
+			if tt.managedLast {
+				if got := eng.host.network.HTTP(); got != managedClient {
+					t.Fatalf("expected network options client, got %T", got)
+				}
+			} else if eng.host.network != injectedNetwork {
+				t.Fatalf("expected injected network, got %T", eng.host.network)
+			}
+
+			if err := eng.Close(); err != nil {
+				t.Fatalf("close engine: %v", err)
+			}
+
+			wantManagedCloses := 0
+			if tt.managedLast {
+				wantManagedCloses = 1
+			}
+
+			if got := managedClient.idleCloseCount(); got != wantManagedCloses {
+				t.Fatalf("expected %d managed network cleanup calls, got %d", wantManagedCloses, got)
+			}
+
+			if got := injectedClient.idleCloseCount(); got != 0 {
+				t.Fatalf("expected injected network to remain caller-owned, got %d cleanup calls", got)
+			}
+		})
+	}
+}
+
+func TestNewCleansNetworkCreatedFromOptionsOnInitFailure(t *testing.T) {
+	t.Parallel()
+
+	initErr := errors.New("init failed")
+	client := &recordingHTTPClient{}
+
+	_, err := New(
+		WithNetworkOptions(ferretnet.WithHTTPClient(client)),
+		WithEngineInitHook(func() error {
+			return initErr
+		}),
+	)
+	if !errors.Is(err, initErr) {
+		t.Fatalf("expected init error, got %v", err)
+	}
+
+	if got := client.idleCloseCount(); got != 1 {
+		t.Fatalf("expected construction-failure cleanup, got %d calls", got)
+	}
+}
+
 func TestNewCleansOwnedNetworkOnRegistrationFailure(t *testing.T) {
 	t.Parallel()
 

--- a/engine_options.go
+++ b/engine_options.go
@@ -28,6 +28,7 @@ type (
 		stdlib            stdlib.Set
 		logger            []logging.Option
 		network           ferretnet.Network
+		hostNetwork       bool
 		compiler          []compiler.Option
 		modules           []module.Module
 		maxActiveSessions int
@@ -597,6 +598,8 @@ func WithFSReadOnly() Option {
 }
 
 // WithNetwork sets the engine network service used by derived executions.
+// If a network is provided, the engine will use it directly and will not manage its lifecycle.
+// The host application is responsible for closing the network when it is no longer needed.
 func WithNetwork(network ferretnet.Network) Option {
 	return func(opts *options) error {
 		if network == nil {
@@ -604,6 +607,28 @@ func WithNetwork(network ferretnet.Network) Option {
 		}
 
 		opts.network = network
+		opts.hostNetwork = true
+
+		return nil
+	}
+}
+
+// WithNetworkOptions creates an Option that constructs a new network service using the provided Ferret network options.
+// If no options are provided, the engine will use the default network service.
+func WithNetworkOptions(setters ...ferretnet.Option) Option {
+	return func(opts *options) error {
+		if len(setters) == 0 {
+			return nil
+		}
+
+		net, err := ferretnet.New(setters...)
+
+		if err != nil {
+			return fmt.Errorf("create network: %w", err)
+		}
+
+		opts.network = net
+		opts.hostNetwork = false
 
 		return nil
 	}

--- a/engine_options.go
+++ b/engine_options.go
@@ -20,20 +20,20 @@ import (
 type (
 	options struct {
 		library           runtime.Library
-		params            runtime.Params
-		encoding          *encoding.Registry
-		programLoader     *artifact.Loader
+		network           ferretnet.Network
 		hooks             *hookRegistry
+		encoding          *encoding.Registry
+		params            runtime.Params
+		programLoader     *artifact.Loader
 		fsRoot            string
 		stdlib            stdlib.Set
-		logger            []logging.Option
-		network           ferretnet.Network
-		hostNetwork       bool
-		compiler          []compiler.Option
 		modules           []module.Module
+		logger            []logging.Option
+		compiler          []compiler.Option
 		maxActiveSessions int
 		maxIdleVMsPerPlan int
 		maxVMsPerPlan     int
+		hostNetwork       bool
 		fsReadOnly        bool
 	}
 

--- a/engine_options_test.go
+++ b/engine_options_test.go
@@ -1,10 +1,13 @@
 package ferret
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	ferretnet "github.com/MontFerret/ferret/v2/pkg/net"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 )
@@ -169,6 +172,40 @@ func TestNewOptionsRejectsBlankFSRoot(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "fs root cannot be empty") {
 		t.Fatalf("expected blank fs root validation error, got: %v", err)
+	}
+}
+
+func TestWithNetworkOptionsWithoutSettersIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	network := mustNewTestNetwork(t)
+	opts := mustNewOptionsForTest(t, WithNetwork(network), WithNetworkOptions())
+
+	if opts.network != network {
+		t.Fatalf("expected injected network to remain configured, got %T", opts.network)
+	}
+
+	if !opts.hostNetwork {
+		t.Fatal("expected injected network to remain caller-owned")
+	}
+}
+
+func TestWithNetworkOptionsReturnsNetworkConstructionError(t *testing.T) {
+	t.Parallel()
+
+	_, err := newOptions([]Option{WithNetworkOptions(
+		ferretnet.WithHTTPPolicies(ferrethttp.WithMaxResponseSize(-1)),
+	)})
+	if err == nil {
+		t.Fatal("expected invalid network options to fail")
+	}
+
+	if !errors.Is(err, ferrethttp.ErrInvalidPolicyConfiguration) {
+		t.Fatalf("expected invalid policy configuration error, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "create network: http client:") {
+		t.Fatalf("expected network construction context, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces improvements to network configuration and lifecycle management in the engine, clarifying ownership semantics and adding new configuration options. It also includes comprehensive tests to ensure correct behavior when injecting or constructing network services.

**Network configuration and lifecycle management:**

* Added a new `WithNetworkOptions` option to construct a managed network service with custom Ferret network options, and clarified that `WithNetwork` injects a caller-owned network.
* Introduced a `hostNetwork` flag in the engine options to track whether the network is caller-owned or managed by the engine, and updated the engine initialization logic to use this flag [[1]](diffhunk://#diff-ddad40baaf11ecae73afcf744735988148486cc4e786e054b58b91027aa20dd7R31) [[2]](diffhunk://#diff-faa39773718bee2c453eb6825bcc4dc5766eff99ab928f1827ddba95d18d15e2L37-R37).
* Updated engine cleanup logic to only close managed networks, and ensured proper cleanup on initialization failure.

**Testing and validation:**

* Added tests to verify that network ownership follows the last-applied option, that injected networks are not closed by the engine, and that managed networks are properly cleaned up on errors.
* Added tests for `WithNetworkOptions` to ensure it is a no-op without setters and returns errors for invalid configuration.

These changes improve clarity and safety for network resource management in the engine, making it easier for users to control network lifecycles and customize network behavior.