### PR TITLE
Split overloaded standard functions

### DIFF
--- a/pkg/stdlib/arrays/append.go
+++ b/pkg/stdlib/arrays/append.go
@@ -17,23 +17,27 @@ func Append(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	list, err := runtime.CastArgAt[runtime.List](args, 0)
+	if len(args) == 2 {
+		return append2(ctx, args[0], args[1])
+	}
+
+	return append3(ctx, args[0], args[1], args[2])
+}
+
+func append2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return append3(ctx, arg1, arg2, runtime.False)
+}
+
+func append3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	list, err := runtime.CastArg[runtime.List](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	arg := args[1]
-	unique := runtime.False
-
-	if len(args) > 2 {
-		arg3, err := runtime.CastArgAt[runtime.Boolean](args, 2)
-
-		if err != nil {
-			return runtime.None, err
-		}
-
-		unique = arg3
+	unique, err := runtime.CastArg[runtime.Boolean](arg3, 2)
+	if err != nil {
+		return runtime.None, err
 	}
 
 	var next runtime.List
@@ -48,7 +52,7 @@ func Append(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	}
 
 	if unique {
-		idx, err := list.IndexOf(ctx, arg)
+		idx, err := list.IndexOf(ctx, arg2)
 
 		if err != nil {
 			return runtime.None, err
@@ -59,7 +63,7 @@ func Append(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		}
 	}
 
-	if err := next.Append(ctx, arg); err != nil {
+	if err := next.Append(ctx, arg2); err != nil {
 		return runtime.None, err
 	}
 

--- a/pkg/stdlib/arrays/flatten.go
+++ b/pkg/stdlib/arrays/flatten.go
@@ -19,7 +19,19 @@ func Flatten(ctx context.Context, args ...runtime.Value) (runtime.Value, error) 
 		return runtime.None, err
 	}
 
-	list, err := runtime.CastArg[runtime.List](args[0], 0)
+	if len(args) == 1 {
+		return flatten1(ctx, args[0])
+	}
+
+	return flatten2(ctx, args[0], args[1])
+}
+
+func flatten1(ctx context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return flatten2(ctx, arg1, runtime.Int(1))
+}
+
+func flatten2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	list, err := runtime.CastArg[runtime.List](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
@@ -31,7 +43,7 @@ func Flatten(ctx context.Context, args ...runtime.Value) (runtime.Value, error) 
 		return runtime.None, err
 	}
 
-	level, err := runtime.CastArgAtOr(args, 1, runtime.Int(1))
+	level, err := runtime.CastArg[runtime.Int](arg2, 1)
 
 	if err != nil {
 		return runtime.None, err

--- a/pkg/stdlib/arrays/lib.go
+++ b/pkg/stdlib/arrays/lib.go
@@ -10,6 +10,7 @@ import (
 func RegisterLib(ns runtime.Namespace) {
 	ns.Function().A1().
 		Add("FIRST", First).
+		Add("FLATTEN", flatten1).
 		Add("LAST", Last).
 		Add("POP", Pop).
 		Add("SHIFT", Shift).
@@ -18,23 +19,31 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("UNIQUE", Unique)
 
 	ns.Function().A2().
+		Add("APPEND", append2).
+		Add("FLATTEN", flatten2).
 		Add("NTH", Nth).
+		Add("POSITION", position2).
+		Add("PUSH", push2).
+		Add("REMOVE_VALUE", removeValue2).
 		Add("REMOVE_NTH", RemoveNth).
-		Add("REMOVE_VALUES", RemoveValues)
+		Add("REMOVE_VALUES", RemoveValues).
+		Add("SLICE", slice2).
+		Add("UNSHIFT", unshift2)
+
+	ns.Function().A3().
+		Add("APPEND", append3).
+		Add("POSITION", position3).
+		Add("PUSH", push3).
+		Add("REMOVE_VALUE", removeValue3).
+		Add("SLICE", slice3).
+		Add("UNSHIFT", unshift3)
 
 	ns.Function().Var().
-		Add("APPEND", Append).
-		Add("FLATTEN", Flatten).
 		Add("INTERSECTION", Intersection).
 		Add("MINUS", Minus).
 		Add("OUTERSECTION", Outersection).
-		Add("POSITION", Position).
-		Add("PUSH", Push).
-		Add("REMOVE_VALUE", RemoveValue).
-		Add("SLICE", Slice).
 		Add("UNION", Union).
-		Add("UNION_DISTINCT", UnionDistinct).
-		Add("UNSHIFT", Unshift)
+		Add("UNION_DISTINCT", UnionDistinct)
 }
 
 func ToUniqueList(ctx context.Context, list runtime.List) (runtime.List, error) {

--- a/pkg/stdlib/arrays/position.go
+++ b/pkg/stdlib/arrays/position.go
@@ -16,20 +16,31 @@ func Position(ctx context.Context, args ...runtime.Value) (runtime.Value, error)
 		return runtime.None, err
 	}
 
-	arr, err := runtime.CastArgAt[runtime.List](args, 0)
+	if len(args) == 2 {
+		return position2(ctx, args[0], args[1])
+	}
+
+	return position3(ctx, args[0], args[1], args[2])
+}
+
+func position2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return position3(ctx, arg1, arg2, runtime.False)
+}
+
+func position3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	arr, err := runtime.CastArg[runtime.List](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	el := args[1]
-	retIdx, err := runtime.CastArgAtOr[runtime.Boolean](args, 2, false)
+	retIdx, err := runtime.CastArg[runtime.Boolean](arg3, 2)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	position, err := arr.IndexOf(ctx, el)
+	position, err := arr.IndexOf(ctx, arg2)
 
 	if err != nil {
 		return runtime.None, err

--- a/pkg/stdlib/arrays/push.go
+++ b/pkg/stdlib/arrays/push.go
@@ -14,3 +14,11 @@ import (
 func Push(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	return Append(ctx, args...)
 }
+
+func push2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return append2(ctx, arg1, arg2)
+}
+
+func push3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return append3(ctx, arg1, arg2, arg3)
+}

--- a/pkg/stdlib/arrays/remove_value.go
+++ b/pkg/stdlib/arrays/remove_value.go
@@ -17,30 +17,33 @@ func RemoveValue(ctx context.Context, args ...runtime.Value) (runtime.Value, err
 		return runtime.None, err
 	}
 
-	arr, err := runtime.CastArgAt[runtime.List](args, 0)
+	if len(args) == 2 {
+		return removeValue2(ctx, args[0], args[1])
+	}
+
+	return removeValue3(ctx, args[0], args[1], args[2])
+}
+
+func removeValue2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return removeValue3(ctx, arg1, arg2, runtime.Int(-1))
+}
+
+func removeValue3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	arr, err := runtime.CastArg[runtime.List](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	value := args[1]
-	var limit runtime.Int
-	limit = -1
-
-	if len(args) > 2 {
-		arg3, err := runtime.CastArgAt[runtime.Int](args, 2)
-
-		if err != nil {
-			return runtime.None, err
-		}
-
-		limit = arg3
+	limit, err := runtime.CastArg[runtime.Int](arg3, 2)
+	if err != nil {
+		return runtime.None, err
 	}
 
 	var counter runtime.Int
 
 	return arr.Filter(ctx, func(ctx context.Context, item runtime.Value, idx runtime.Int) (runtime.Boolean, error) {
-		remove := runtime.CompareValues(item, value) == 0
+		remove := runtime.CompareValues(item, arg2) == 0
 
 		if remove {
 			counter++

--- a/pkg/stdlib/arrays/slice.go
+++ b/pkg/stdlib/arrays/slice.go
@@ -12,8 +12,34 @@ import (
 // @param {Int} [length] - Read indicating how many elements to extract.
 // @return {Any[]} - Sliced array.
 func Slice(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
-	list, start, err := runtime.CastVarArgs2[runtime.List, runtime.Int](args)
+	_, _, err := runtime.CastVarArgs2[runtime.List, runtime.Int](args)
 
+	if err != nil {
+		return runtime.None, err
+	}
+
+	if len(args) == 2 {
+		return slice2(ctx, args[0], args[1])
+	}
+
+	return slice3(ctx, args[0], args[1], args[2])
+}
+
+func slice2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return sliceList(ctx, arg1, arg2, runtime.None, false)
+}
+
+func slice3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return sliceList(ctx, arg1, arg2, arg3, true)
+}
+
+func sliceList(ctx context.Context, arg1, arg2, arg3 runtime.Value, hasLength bool) (runtime.Value, error) {
+	list, err := runtime.CastArg[runtime.List](arg1, 0)
+	if err != nil {
+		return runtime.None, err
+	}
+
+	start, err := runtime.CastArg[runtime.Int](arg2, 1)
 	if err != nil {
 		return runtime.None, err
 	}
@@ -36,19 +62,19 @@ func Slice(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 
 	var end runtime.Int
 
-	if len(args) > 2 {
-		arg3, err := runtime.CastArgAt[runtime.Int](args, 2)
+	if hasLength {
+		length, err := runtime.CastArg[runtime.Int](arg3, 2)
 
 		if err != nil {
 			return runtime.None, err
 		}
 
 		// Handle negative length - return empty array
-		if arg3 < 0 {
+		if length < 0 {
 			return runtime.NewArray(0), nil
 		}
 
-		end = start + arg3
+		end = start + length
 	} else {
 		end = size
 	}

--- a/pkg/stdlib/arrays/slice_test.go
+++ b/pkg/stdlib/arrays/slice_test.go
@@ -171,4 +171,13 @@ func TestSlice_ArgumentValidation(t *testing.T) {
 		_, err = arrays.Slice(ctx, arr, nonInt)
 		So(err, ShouldNotBeNil)
 	})
+
+	Convey("Should preserve direct Go compatibility for extra arguments", t, func() {
+		arr := runtime.NewArrayWith(runtime.NewInt(1), runtime.NewInt(2), runtime.NewInt(3))
+
+		out, err := arrays.Slice(ctx, arr, runtime.NewInt(1), runtime.NewInt(1), runtime.True)
+
+		So(err, ShouldBeNil)
+		So(out.String(), ShouldEqual, "[2]")
+	})
 }

--- a/pkg/stdlib/arrays/unshift.go
+++ b/pkg/stdlib/arrays/unshift.go
@@ -16,21 +16,27 @@ func Unshift(ctx context.Context, args ...runtime.Value) (runtime.Value, error) 
 		return runtime.None, err
 	}
 
-	list, err := runtime.CastArgAt[runtime.List](args, 0)
+	if len(args) == 2 {
+		return unshift2(ctx, args[0], args[1])
+	}
+
+	return unshift3(ctx, args[0], args[1], args[2])
+}
+
+func unshift2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return unshift3(ctx, arg1, arg2, runtime.False)
+}
+
+func unshift3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	list, err := runtime.CastArg[runtime.List](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	value := args[1]
-	uniq := runtime.False
-
-	if len(args) > 2 {
-		uniq, err = runtime.CastArgAt[runtime.Boolean](args, 2)
-
-		if err != nil {
-			return runtime.None, err
-		}
+	uniq, err := runtime.CastArg[runtime.Boolean](arg3, 2)
+	if err != nil {
+		return runtime.None, err
 	}
 
 	size, err := list.Length(ctx)
@@ -42,7 +48,7 @@ func Unshift(ctx context.Context, args ...runtime.Value) (runtime.Value, error) 
 	result := runtime.NewArray64(size + 1)
 
 	if !uniq {
-		_ = result.Append(ctx, value)
+		_ = result.Append(ctx, arg2)
 
 		err = list.ForEach(ctx, func(ctx context.Context, value runtime.Value, idx runtime.Int) (runtime.Boolean, error) {
 			_ = result.Append(ctx, value)
@@ -57,10 +63,10 @@ func Unshift(ctx context.Context, args ...runtime.Value) (runtime.Value, error) 
 		return result, nil
 	}
 
-	_ = result.Append(ctx, value)
+	_ = result.Append(ctx, arg2)
 
 	err = list.ForEach(ctx, func(ctx context.Context, el runtime.Value, idx runtime.Int) (runtime.Boolean, error) {
-		if runtime.CompareValues(el, value) != 0 {
+		if runtime.CompareValues(el, arg2) != 0 {
 			_ = result.Append(ctx, el)
 		}
 

--- a/pkg/stdlib/datetime/compare.go
+++ b/pkg/stdlib/datetime/compare.go
@@ -14,35 +14,43 @@ import (
 // @param {String} unitRangeStart - Unit to start from.
 // @param {String} [unitRangeEnd="millisecond"] - Unit to end with. Error will be returned if unitRangeStart unit less that unitRangeEnd.
 // @return {Boolean} - True if the dates match, else false.
-func DateCompare(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func DateCompare(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 3, 4); err != nil {
 		return runtime.None, err
 	}
 
-	if err := runtime.AssertDateTime(args[0]); err != nil {
+	if len(args) == 3 {
+		return dateCompare3(ctx, args[0], args[1], args[2])
+	}
+
+	return dateCompare4(ctx, args[0], args[1], args[2], args[3])
+}
+
+func dateCompare3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return dateCompare4(ctx, arg1, arg2, arg3, runtime.NewString("millisecond"))
+}
+
+func dateCompare4(_ context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	if err := runtime.AssertDateTime(arg1); err != nil {
 		return runtime.None, err
 	}
 
-	if err := runtime.AssertDateTime(args[1]); err != nil {
+	if err := runtime.AssertDateTime(arg2); err != nil {
 		return runtime.None, err
 	}
 
-	if err := runtime.AssertString(args[2]); err != nil {
+	if err := runtime.AssertString(arg3); err != nil {
 		return runtime.None, err
 	}
 
-	date1 := args[0].(runtime.DateTime)
-	date2 := args[1].(runtime.DateTime)
-	rangeStart := args[2].(runtime.String)
-	rangeEnd := runtime.NewString("millisecond")
-
-	if len(args) == 4 {
-		if err := runtime.AssertString(args[3]); err != nil {
-			return runtime.None, err
-		}
-
-		rangeEnd = args[3].(runtime.String)
+	if err := runtime.AssertString(arg4); err != nil {
+		return runtime.None, err
 	}
+
+	date1 := arg1.(runtime.DateTime)
+	date2 := arg2.(runtime.DateTime)
+	rangeStart := arg3.(runtime.String)
+	rangeEnd := arg4.(runtime.String)
 
 	unitStart, err := UnitFromString(rangeStart.String())
 	if err != nil {

--- a/pkg/stdlib/datetime/date.go
+++ b/pkg/stdlib/datetime/date.go
@@ -11,30 +11,35 @@ import (
 // @param {String} time - String representation of DateTime.
 // @param {String} [layout = "2006-01-02T15:04:05Z07:00"] - String layout.
 // @return {DateTime} - New DateTime object derived from timeString.
-func Date(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Date(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 1, 2); err != nil {
 		return runtime.None, err
 	}
 
-	str, err := runtime.CastArgAt[runtime.String](args, 0)
+	if len(args) == 1 {
+		return date1(ctx, args[0])
+	}
+
+	return date2(ctx, args[0], args[1])
+}
+
+func date1(ctx context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return date2(ctx, arg1, runtime.NewString(runtime.DefaultTimeLayout))
+}
+
+func date2(_ context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	str, err := runtime.CastArg[runtime.String](arg1, 0)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	layout := runtime.DefaultTimeLayout
-
-	if len(args) > 1 {
-		l, err := runtime.CastArgAt[runtime.String](args, 1)
-
-		if err != nil {
-			return runtime.None, err
-		}
-
-		layout = string(l)
+	layout, err := runtime.CastArg[runtime.String](arg2, 1)
+	if err != nil {
+		return runtime.None, err
 	}
 
-	t, err := time.Parse(layout, str.String())
+	t, err := time.Parse(layout.String(), str.String())
 
 	if err != nil {
 		return runtime.None, err

--- a/pkg/stdlib/datetime/diff.go
+++ b/pkg/stdlib/datetime/diff.go
@@ -12,18 +12,30 @@ import (
 // @param {String} unit - Time unit to return the difference in.
 // @param {Boolean} [asFloat=False] - If true amount of unit will be as float.
 // @return {Int | Float} - Difference between date1 and date2.
-func DateDiff(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func DateDiff(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 3, 4); err != nil {
 		return runtime.None, err
 	}
 
-	date1, date2, unit, err := runtime.CastVarArgs3[runtime.DateTime, runtime.DateTime, runtime.String](args)
+	if len(args) == 3 {
+		return dateDiff3(ctx, args[0], args[1], args[2])
+	}
+
+	return dateDiff4(ctx, args[0], args[1], args[2], args[3])
+}
+
+func dateDiff3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return dateDiff4(ctx, arg1, arg2, arg3, runtime.False)
+}
+
+func dateDiff4(_ context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	date1, date2, unit, err := runtime.CastArgs3[runtime.DateTime, runtime.DateTime, runtime.String](arg1, arg2, arg3)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	isFloat, err := runtime.CastArgAtOr[runtime.Boolean](args, 3, runtime.False)
+	isFloat, err := runtime.CastArg[runtime.Boolean](arg4, 3)
 
 	if err != nil {
 		return runtime.None, err

--- a/pkg/stdlib/datetime/lib.go
+++ b/pkg/stdlib/datetime/lib.go
@@ -9,6 +9,7 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("NOW", Now)
 
 	ns.Function().A1().
+		Add("DATE", date1).
 		Add("DATE_DAYOFWEEK", DateDayOfWeek).
 		Add("DATE_YEAR", DateYear).
 		Add("DATE_MONTH", DateMonth).
@@ -23,14 +24,16 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("DATE_DAYS_IN_MONTH", DateDaysInMonth)
 
 	ns.Function().A2().
+		Add("DATE", date2).
 		Add("DATE_FORMAT", DateFormat)
 
 	ns.Function().A3().
 		Add("DATE_ADD", DateAdd).
+		Add("DATE_COMPARE", dateCompare3).
+		Add("DATE_DIFF", dateDiff3).
 		Add("DATE_SUBTRACT", DateSubtract)
 
-	ns.Function().Var().
-		Add("DATE", Date).
-		Add("DATE_COMPARE", DateCompare).
-		Add("DATE_DIFF", DateDiff)
+	ns.Function().A4().
+		Add("DATE_COMPARE", dateCompare4).
+		Add("DATE_DIFF", dateDiff4)
 }

--- a/pkg/stdlib/io/fs/lib.go
+++ b/pkg/stdlib/io/fs/lib.go
@@ -12,6 +12,9 @@ func RegisterLib(ns runtime.Namespace) {
 	ns.Function().A1().
 		Add("READ", Read)
 
-	ns.Function().Var().
-		Add("WRITE", Write)
+	ns.Function().A2().
+		Add("WRITE", write2)
+
+	ns.Function().A3().
+		Add("WRITE", write3)
 }

--- a/pkg/stdlib/io/fs/write.go
+++ b/pkg/stdlib/io/fs/write.go
@@ -22,28 +22,38 @@ func Write(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	fpath, err := runtime.CastArg[runtime.String](args[0], 0)
+	if len(args) == 2 {
+		return write2(ctx, args[0], args[1])
+	}
+
+	return write3(ctx, args[0], args[1], args[2])
+}
+
+func write2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return writeFile(ctx, arg1, arg2, defaultParams)
+}
+
+func write3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	params, err := parseParams(arg3, 2)
+	if err != nil {
+		return runtime.None, runtime.Error(
+			err,
+			"parse `params` argument",
+		)
+	}
+
+	return writeFile(ctx, arg1, arg2, params)
+}
+
+func writeFile(ctx context.Context, arg1, arg2 runtime.Value, params parsedParams) (runtime.Value, error) {
+	fpath, err := runtime.CastArg[runtime.String](arg1, 0)
 	if err != nil {
 		return runtime.None, err
 	}
 
-	data, err := runtime.CastArg[runtime.Binary](args[1], 1)
+	data, err := runtime.CastArg[runtime.Binary](arg2, 1)
 	if err != nil {
 		return runtime.None, err
-	}
-	params := defaultParams
-
-	if len(args) == 3 {
-		p, err := parseParams(args[2], 2)
-
-		if err != nil {
-			return runtime.None, runtime.Error(
-				err,
-				"parse `params` argument",
-			)
-		}
-
-		params = p
 	}
 
 	filesystem, err := fs.FileSystemFrom(ctx)

--- a/pkg/stdlib/math/lib.go
+++ b/pkg/stdlib/math/lib.go
@@ -15,7 +15,8 @@ const (
 
 func RegisterLib(ns runtime.Namespace) {
 	ns.Function().A0().
-		Add("PI", Pi)
+		Add("PI", Pi).
+		Add("RAND", rand0)
 
 	ns.Function().A1().
 		Add("ABS", Abs).
@@ -36,6 +37,7 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("MEDIAN", Median).
 		Add("MIN", Min).
 		Add("RADIANS", Radians).
+		Add("RAND", rand1).
 		Add("ROUND", Round).
 		Add("SIN", Sin).
 		Add("SQRT", Sqrt).
@@ -48,12 +50,14 @@ func RegisterLib(ns runtime.Namespace) {
 
 	ns.Function().A2().
 		Add("ATAN2", Atan2).
-		Add("POW", Pow)
+		Add("PERCENTILE", percentile2).
+		Add("POW", Pow).
+		Add("RAND", rand2).
+		Add("RANGE", range2)
 
-	ns.Function().Var().
-		Add("PERCENTILE", Percentile).
-		Add("RAND", Rand).
-		Add("RANGE", Range)
+	ns.Function().A3().
+		Add("PERCENTILE", percentile3).
+		Add("RANGE", range3)
 }
 
 func toFloat(arg runtime.Value) float64 {

--- a/pkg/stdlib/math/percentile.go
+++ b/pkg/stdlib/math/percentile.go
@@ -2,11 +2,10 @@ package math
 
 import (
 	"context"
+	"errors"
 	"math"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
-
-	"errors"
 )
 
 // PERCENTILE returns the nth percentile of the values in a given array.
@@ -19,11 +18,32 @@ func Percentile(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 		return runtime.None, err
 	}
 
-	if err := runtime.ValidateArgValueAt(args, 0, runtime.AssertList); err != nil {
+	if len(args) == 2 {
+		return percentile2(ctx, args[0], args[1])
+	}
+
+	return percentile3(ctx, args[0], args[1], args[2])
+}
+
+func percentile2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return percentile(ctx, arg1, arg2, "rank")
+}
+
+func percentile3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	method, err := runtime.CastArg[runtime.String](arg3, 2)
+	if err != nil {
 		return runtime.None, err
 	}
 
-	arr := args[0].(runtime.List)
+	return percentile(ctx, arg1, arg2, method.String())
+}
+
+func percentile(ctx context.Context, arg1, arg2 runtime.Value, method string) (runtime.Value, error) {
+	if err := runtime.ValidateArgValue(arg1, 0, runtime.AssertList); err != nil {
+		return runtime.None, err
+	}
+
+	arr := arg1.(runtime.List)
 	size, err := arr.Length(ctx)
 
 	if err != nil {
@@ -34,25 +54,13 @@ func Percentile(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 		return runtime.NewFloat(math.NaN()), nil
 	}
 
-	num, err := runtime.CastArg[runtime.Int](args[1], 1)
+	num, err := runtime.CastArg[runtime.Int](arg2, 1)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
 	percent := runtime.Float(num)
-
-	method := "rank"
-
-	if len(args) > 2 {
-		if err := runtime.ValidateArgType(args[2], 2, runtime.TypeString); err != nil {
-			return runtime.None, err
-		}
-
-		if args[2].String() == "interpolation" {
-			method = "interpolation"
-		}
-	}
 
 	if percent <= 0 || percent > 100 {
 		return runtime.NaN(), errors.New("input is outside of range")

--- a/pkg/stdlib/math/rand.go
+++ b/pkg/stdlib/math/rand.go
@@ -15,32 +15,42 @@ func Rand(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	if len(args) == 0 {
-		return runtime.NewFloat(runtime.RandomDefault()), nil
+	switch len(args) {
+	case 0:
+		return rand0(ctx)
+	case 1:
+		return rand1(ctx, args[0])
+	default:
+		return rand2(ctx, args[0], args[1])
+	}
+}
+
+func rand0(context.Context) (runtime.Value, error) {
+	return runtime.NewFloat(runtime.RandomDefault()), nil
+}
+
+func rand1(ctx context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	max, err := runtime.ToFloat(ctx, arg1)
+	if err != nil {
+		return runtime.None, err
 	}
 
-	arg1, err := runtime.ToFloat(ctx, args[0])
+	upper, lower := runtime.NumberBoundaries(float64(max))
+
+	return runtime.NewFloat(runtime.Random(upper, lower)), nil
+}
+
+func rand2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	max, err := runtime.ToFloat(ctx, arg1)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	var max float64
-	var min float64
-
-	max = float64(arg1)
-
-	if len(args) > 1 {
-		arg2, err := runtime.ToFloat(ctx, args[1])
-
-		if err != nil {
-			return runtime.None, err
-		}
-
-		min = float64(arg2)
-	} else {
-		max, min = runtime.NumberBoundaries(max)
+	min, err := runtime.ToFloat(ctx, arg2)
+	if err != nil {
+		return runtime.None, err
 	}
 
-	return runtime.NewFloat(runtime.Random(max, min)), nil
+	return runtime.NewFloat(runtime.Random(float64(max), float64(min))), nil
 }

--- a/pkg/stdlib/math/range.go
+++ b/pkg/stdlib/math/range.go
@@ -16,26 +16,33 @@ func Range(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	if err := runtime.ValidateArgValueAt(args, 0, runtime.AssertNumber); err != nil {
+	if len(args) == 2 {
+		return range2(ctx, args[0], args[1])
+	}
+
+	return range3(ctx, args[0], args[1], args[2])
+}
+
+func range2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return range3(ctx, arg1, arg2, runtime.Float(1))
+}
+
+func range3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	if err := runtime.ValidateArgValue(arg1, 0, runtime.AssertNumber); err != nil {
 		return runtime.None, err
 	}
 
-	if err := runtime.ValidateArgValueAt(args, 1, runtime.AssertNumber); err != nil {
+	if err := runtime.ValidateArgValue(arg2, 1, runtime.AssertNumber); err != nil {
 		return runtime.None, err
 	}
 
-	var step float64 = 1
-
-	if len(args) > 2 {
-		if err := runtime.ValidateArgValueAt(args, 2, runtime.AssertNumber); err != nil {
-			return runtime.None, err
-		}
-
-		step = toFloat(args[2])
+	if err := runtime.ValidateArgValue(arg3, 2, runtime.AssertNumber); err != nil {
+		return runtime.None, err
 	}
 
-	start := toFloat(args[0])
-	end := toFloat(args[1])
+	step := toFloat(arg3)
+	start := toFloat(arg1)
+	end := toFloat(arg2)
 
 	arr := runtime.NewArray(int(end))
 

--- a/pkg/stdlib/math/range.go
+++ b/pkg/stdlib/math/range.go
@@ -2,6 +2,7 @@ package math
 
 import (
 	"context"
+	stdmath "math"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
@@ -9,7 +10,7 @@ import (
 // RANGE returns an array of numbers in the specified range, optionally with increments other than 1.
 // @param {Int | Float} start - The value to start the range at (inclusive).
 // @param {Int | Float} end - The value to end the range with (inclusive).
-// @param {Int | Float} [step=1.0] - How much to increment in every step.
+// @param {Int | Float} [step=1.0] - How much to change the value in every step. Positive steps ascend, negative steps descend, and zero is invalid.
 // @return {Int[] | Float[]} - arrayList of numbers in the specified range, optionally with increments other than 1.
 func Range(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 2, 3); err != nil {
@@ -44,11 +45,120 @@ func range3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value,
 	start := toFloat(arg1)
 	end := toFloat(arg2)
 
-	arr := runtime.NewArray(int(end))
+	if err := validateRangeNumber(start, 0, "start"); err != nil {
+		return runtime.None, err
+	}
 
-	for i := start; i <= end; i += step {
-		_ = arr.Append(ctx, runtime.NewFloat(i))
+	if err := validateRangeNumber(end, 1, "end"); err != nil {
+		return runtime.None, err
+	}
+
+	if err := validateRangeNumber(step, 2, "step"); err != nil {
+		return runtime.None, err
+	}
+
+	if step == 0 {
+		return runtime.None, rangeStepError("step must not be zero")
+	}
+
+	ascending := step > 0
+	if (ascending && start > end) || (!ascending && start < end) {
+		return runtime.NewArray(0), nil
+	}
+
+	if start != end && start+step == start {
+		return runtime.None, rangeStepError("step is too small to advance the range")
+	}
+
+	capacity, err := rangeCapacity(start, end, step)
+	if err != nil {
+		return runtime.None, err
+	}
+
+	arr := runtime.NewArray(capacity)
+
+	if ascending {
+		err = appendAscendingRange(ctx, arr, start, end, step)
+	} else {
+		err = appendDescendingRange(ctx, arr, start, end, step)
+	}
+
+	if err != nil {
+		return runtime.None, err
 	}
 
 	return arr, nil
+}
+
+func appendAscendingRange(ctx context.Context, arr *runtime.Array, start, end, step float64) error {
+	for value := start; value <= end; {
+		_ = arr.Append(ctx, runtime.NewFloat(value))
+
+		if value == end {
+			return nil
+		}
+
+		next := value + step
+		if next == value {
+			return rangeStepError("step is too small to advance the range")
+		}
+
+		value = next
+	}
+
+	return nil
+}
+
+func appendDescendingRange(ctx context.Context, arr *runtime.Array, start, end, step float64) error {
+	for value := start; value >= end; {
+		_ = arr.Append(ctx, runtime.NewFloat(value))
+
+		if value == end {
+			return nil
+		}
+
+		next := value + step
+		if next == value {
+			return rangeStepError("step is too small to advance the range")
+		}
+
+		value = next
+	}
+
+	return nil
+}
+
+func validateRangeNumber(value float64, pos int, name string) error {
+	if stdmath.IsNaN(value) || stdmath.IsInf(value, 0) {
+		return runtime.ArgError(
+			runtime.Error(runtime.ErrInvalidArgument, name+" must be finite"),
+			pos,
+		)
+	}
+
+	return nil
+}
+
+func rangeStepError(message string) error {
+	return runtime.ArgError(runtime.Error(runtime.ErrInvalidArgument, message), 2)
+}
+
+// rangeCapacity divides the endpoints separately when their subtraction overflows,
+// preserving finite cardinalities for wide ranges that also use large steps.
+func rangeCapacity(start, end, step float64) (int, error) {
+	distance := stdmath.Abs(end - start)
+	stepSize := stdmath.Abs(step)
+
+	if stdmath.IsInf(distance, 0) {
+		distance = stdmath.Abs(end/stepSize - start/stepSize)
+	} else {
+		distance /= stepSize
+	}
+
+	capacity := stdmath.Floor(distance) + 1
+	if stdmath.IsNaN(capacity) || stdmath.IsInf(capacity, 0) || capacity >= float64(stdmath.MaxInt) {
+		return 0, runtime.Error(runtime.ErrRange, "range length exceeds array capacity")
+	}
+
+	return int(capacity), nil
 }

--- a/pkg/stdlib/math/range_test.go
+++ b/pkg/stdlib/math/range_test.go
@@ -2,6 +2,8 @@ package math_test
 
 import (
 	"context"
+	"errors"
+	stdmath "math"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -100,4 +102,164 @@ func TestRange(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(out, ShouldEqual, runtime.None)
 	})
+}
+
+func TestRangeDirectionAndSafety(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ascending negative endpoints", func(t *testing.T) {
+		out, err := math.Range(ctx, runtime.NewInt(-3), runtime.NewInt(-1))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := out.String(), "[-3,-2,-1]"; got != want {
+			t.Fatalf("Range() = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("descending ranges", func(t *testing.T) {
+		tests := []struct {
+			name string
+			want string
+			args []runtime.Value
+		}{
+			{name: "integer", want: "[3,2,1]", args: []runtime.Value{runtime.NewInt(3), runtime.NewInt(1), runtime.NewInt(-1)}},
+			{name: "float", want: "[2.5,2,1.5]", args: []runtime.Value{runtime.NewFloat(2.5), runtime.NewFloat(1.5), runtime.NewFloat(-0.5)}},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				out, err := math.Range(ctx, test.args...)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if got := out.String(); got != test.want {
+					t.Fatalf("Range() = %s, want %s", got, test.want)
+				}
+			})
+		}
+	})
+
+	t.Run("mismatched direction", func(t *testing.T) {
+		tests := [][]runtime.Value{
+			{runtime.NewInt(1), runtime.NewInt(3), runtime.NewInt(-1)},
+			{runtime.NewInt(3), runtime.NewInt(1), runtime.NewInt(1)},
+		}
+
+		for _, args := range tests {
+			out, err := math.Range(ctx, args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := out.String(); got != "[]" {
+				t.Fatalf("Range(%v) = %s, want []", args, got)
+			}
+		}
+	})
+
+	t.Run("zero step", func(t *testing.T) {
+		out, err := math.Range(ctx, runtime.NewInt(1), runtime.NewInt(3), runtime.ZeroInt)
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("Range() error = %v, want ErrInvalidArgument", err)
+		}
+		if pos, ok, _ := runtime.InvalidArgumentDetails(err); !ok || pos != 2 {
+			t.Fatalf("Range() argument position = %d, %t, want 2, true", pos, ok)
+		}
+
+		if out != runtime.None {
+			t.Fatalf("Range() = %v, want None", out)
+		}
+	})
+
+	t.Run("non-finite arguments", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			args     []runtime.Value
+			position int
+		}{
+			{name: "nan start", args: []runtime.Value{runtime.NewFloat(stdmath.NaN()), runtime.NewInt(1)}, position: 0},
+			{name: "infinite end", args: []runtime.Value{runtime.NewInt(0), runtime.NewFloat(stdmath.Inf(1))}, position: 1},
+			{name: "nan step", args: []runtime.Value{runtime.NewInt(0), runtime.NewInt(1), runtime.NewFloat(stdmath.NaN())}, position: 2},
+			{name: "infinite step", args: []runtime.Value{runtime.NewInt(0), runtime.NewInt(1), runtime.NewFloat(stdmath.Inf(-1))}, position: 2},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				out, err := math.Range(ctx, test.args...)
+				if !errors.Is(err, runtime.ErrInvalidArgument) {
+					t.Fatalf("Range() error = %v, want ErrInvalidArgument", err)
+				}
+				if pos, ok, _ := runtime.InvalidArgumentDetails(err); !ok || pos != test.position {
+					t.Fatalf("Range() argument position = %d, %t, want %d, true", pos, ok, test.position)
+				}
+
+				if out != runtime.None {
+					t.Fatalf("Range() = %v, want None", out)
+				}
+			})
+		}
+	})
+
+	t.Run("step cannot advance", func(t *testing.T) {
+		start := 1e20
+		end := stdmath.Nextafter(start, stdmath.Inf(1))
+		out, err := math.Range(ctx, runtime.NewFloat(start), runtime.NewFloat(end), runtime.NewFloat(1))
+		if !errors.Is(err, runtime.ErrInvalidArgument) {
+			t.Fatalf("Range() error = %v, want ErrInvalidArgument", err)
+		}
+		if pos, ok, _ := runtime.InvalidArgumentDetails(err); !ok || pos != 2 {
+			t.Fatalf("Range() argument position = %d, %t, want 2, true", pos, ok)
+		}
+
+		if out != runtime.None {
+			t.Fatalf("Range() = %v, want None", out)
+		}
+	})
+
+	t.Run("length exceeds array capacity", func(t *testing.T) {
+		out, err := math.Range(
+			ctx,
+			runtime.ZeroFloat,
+			runtime.NewFloat(stdmath.MaxFloat64),
+			runtime.NewFloat(stdmath.SmallestNonzeroFloat64),
+		)
+		if !errors.Is(err, runtime.ErrRange) {
+			t.Fatalf("Range() error = %v, want ErrRange", err)
+		}
+
+		if out != runtime.None {
+			t.Fatalf("Range() = %v, want None", out)
+		}
+	})
+}
+
+var rangeBenchmarkResult runtime.Value
+
+func BenchmarkRange(b *testing.B) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		args []runtime.Value
+	}{
+		{name: "default_step", args: []runtime.Value{runtime.NewInt(1), runtime.NewInt(100)}},
+		{name: "custom_step", args: []runtime.Value{runtime.NewInt(10), runtime.NewInt(100), runtime.NewInt(2)}},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			for range b.N {
+				result, err := math.Range(ctx, test.args...)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				rangeBenchmarkResult = result
+			}
+		})
+	}
 }

--- a/pkg/stdlib/objects/keys.go
+++ b/pkg/stdlib/objects/keys.go
@@ -15,20 +15,28 @@ func Keys(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	if err := runtime.ValidateArgTypeAt(args, 0, runtime.TypeMap); err != nil {
+	if len(args) == 1 {
+		return keys1(ctx, args[0])
+	}
+
+	return keys2(ctx, args[0], args[1])
+}
+
+func keys1(ctx context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return keys2(ctx, arg1, runtime.False)
+}
+
+func keys2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	if err := runtime.ValidateArgType(arg1, 0, runtime.TypeMap); err != nil {
 		return runtime.None, err
 	}
 
-	target := args[0].(runtime.Map)
-	needSort := runtime.False
-
-	if len(args) == 2 {
-		if err := runtime.ValidateArgTypeAt(args, 1, runtime.TypeBoolean); err != nil {
-			return runtime.None, err
-		}
-
-		needSort = args[1].(runtime.Boolean)
+	if err := runtime.ValidateArgType(arg2, 1, runtime.TypeBoolean); err != nil {
+		return runtime.None, err
 	}
+
+	target := arg1.(runtime.Map)
+	needSort := arg2.(runtime.Boolean)
 
 	keys, err := target.Keys(ctx)
 

--- a/pkg/stdlib/objects/lib.go
+++ b/pkg/stdlib/objects/lib.go
@@ -4,12 +4,13 @@ import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
 func RegisterLib(ns runtime.Namespace) {
 	ns.Function().A1().
+		Add("KEYS", keys1).
 		Add("VALUES", Values)
 	ns.Function().A2().
 		Add("HAS", Has).
+		Add("KEYS", keys2).
 		Add("ZIP", Zip)
 	ns.Function().Var().
-		Add("KEYS", Keys).
 		Add("KEEP_KEYS", KeepKeys).
 		Add("MERGE", Merge).
 		Add("MERGE_RECURSIVE", MergeRecursive)

--- a/pkg/stdlib/overload_test.go
+++ b/pkg/stdlib/overload_test.go
@@ -1,0 +1,159 @@
+package stdlib_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib"
+)
+
+func TestBoundedFunctionsUseFixedArityRegistrations(t *testing.T) {
+	t.Parallel()
+
+	functions := buildFunctions(t, stdlib.Full())
+	expected := boundedFunctionArities()
+
+	if len(expected) != 69 {
+		t.Fatalf("bounded function matrix has %d names, want 69", len(expected))
+	}
+
+	for name, arities := range expected {
+		name, arities := name, arities
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if functions.Var().Has(name) {
+				t.Fatalf("%s unexpectedly has a variadic fallback", name)
+			}
+
+			for arity := 0; arity <= 4; arity++ {
+				if got, want := hasFixedArity(functions, name, arity), slices.Contains(arities, arity); got != want {
+					t.Fatalf("%s fixed arity %d registered = %t, want %t; expected arities %v", name, arity, got, want, arities)
+				}
+			}
+		})
+	}
+}
+
+func TestRepeatedArgumentFunctionsRemainVariadicOnly(t *testing.T) {
+	t.Parallel()
+
+	functions := buildFunctions(t, stdlib.Full())
+	names := []string{
+		"INTERSECTION",
+		"MINUS",
+		"OUTERSECTION",
+		"UNION",
+		"UNION_DISTINCT",
+		"KEEP_KEYS",
+		"MERGE",
+		"MERGE_RECURSIVE",
+		"JOIN",
+		"CONCAT",
+		"CONCAT_SEPARATOR",
+		"FMT",
+		"PRINT",
+	}
+
+	for _, name := range names {
+		if !functions.Var().Has(name) {
+			t.Fatalf("%s is not registered as variadic", name)
+		}
+
+		for arity := 0; arity <= 4; arity++ {
+			if hasFixedArity(functions, name, arity) {
+				t.Fatalf("%s unexpectedly has fixed arity %d", name, arity)
+			}
+		}
+	}
+}
+
+func boundedFunctionArities() map[string][]int {
+	functions := map[string][]int{
+		"APPEND":        {2, 3},
+		"FLATTEN":       {1, 2},
+		"POSITION":      {2, 3},
+		"PUSH":          {2, 3},
+		"REMOVE_VALUE":  {2, 3},
+		"SLICE":         {2, 3},
+		"UNSHIFT":       {2, 3},
+		"DATE":          {1, 2},
+		"DATE_COMPARE":  {3, 4},
+		"DATE_DIFF":     {3, 4},
+		"IO::FS::WRITE": {2, 3},
+		"PERCENTILE":    {2, 3},
+		"RAND":          {0, 1, 2},
+		"RANGE":         {2, 3},
+		"KEYS":          {1, 2},
+		"TO_DATETIME":   {1, 2},
+		"CONTAINS":      {2, 3},
+		"FIND_FIRST":    {2, 3, 4},
+		"FIND_LAST":     {2, 3, 4},
+		"LIKE":          {2, 3},
+		"LTRIM":         {1, 2},
+		"REGEX_MATCH":   {2, 3},
+		"REGEX_SPLIT":   {2, 3, 4},
+		"REGEX_TEST":    {2, 3},
+		"REGEX_REPLACE": {3, 4},
+		"RTRIM":         {1, 2},
+		"SPLIT":         {2, 3},
+		"SUBSTITUTE":    {2, 3, 4},
+		"SUBSTRING":     {2, 3},
+		"TRIM":          {1, 2},
+		"T::FAIL":       {0, 1},
+	}
+
+	unaryAssertions := []string{
+		"EMPTY",
+		"FALSE",
+		"NONE",
+		"TRUE",
+		"STRING",
+		"INT",
+		"FLOAT",
+		"DATETIME",
+		"ARRAY",
+		"OBJECT",
+		"BINARY",
+	}
+	binaryAssertions := []string{
+		"EQ",
+		"GT",
+		"GTE",
+		"INCLUDE",
+		"LEN",
+		"MATCH",
+		"LT",
+		"LTE",
+	}
+
+	for _, name := range unaryAssertions {
+		functions["T::"+name] = []int{1, 2}
+		functions["T::NOT::"+name] = []int{1, 2}
+	}
+
+	for _, name := range binaryAssertions {
+		functions["T::"+name] = []int{2, 3}
+		functions["T::NOT::"+name] = []int{2, 3}
+	}
+
+	return functions
+}
+
+func hasFixedArity(functions *runtime.Functions, name string, arity int) bool {
+	switch arity {
+	case 0:
+		return functions.A0().Has(name)
+	case 1:
+		return functions.A1().Has(name)
+	case 2:
+		return functions.A2().Has(name)
+	case 3:
+		return functions.A3().Has(name)
+	case 4:
+		return functions.A4().Has(name)
+	default:
+		return false
+	}
+}

--- a/pkg/stdlib/strings/contains.go
+++ b/pkg/stdlib/strings/contains.go
@@ -11,18 +11,26 @@ import (
 // @param {String} search - The string to seek.
 // @param {Boolean} [returnIndex=False] - Values which indicates whether to return the character position of the match is returned instead of a boolean.
 // @return {Boolean | Int} - A value indicating whether a specified substring occurs within a string.
-func Contains(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Contains(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 2, 3); err != nil {
 		return runtime.False, err
 	}
 
-	text := runtime.CastOr[runtime.String](args[0], runtime.EmptyString)
-	search := runtime.CastOr[runtime.String](args[1], runtime.EmptyString)
-	returnIndex := runtime.False
-
-	if len(args) > 2 {
-		returnIndex = runtime.CastOr[runtime.Boolean](args[2], runtime.False)
+	if len(args) == 2 {
+		return contains2(ctx, args[0], args[1])
 	}
+
+	return contains3(ctx, args[0], args[1], args[2])
+}
+
+func contains2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return contains3(ctx, arg1, arg2, runtime.False)
+}
+
+func contains3(_ context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	text := runtime.CastOr[runtime.String](arg1, runtime.EmptyString)
+	search := runtime.CastOr[runtime.String](arg2, runtime.EmptyString)
+	returnIndex := runtime.CastOr[runtime.Boolean](arg3, runtime.False)
 
 	if returnIndex == runtime.True {
 		return text.IndexOf(search), nil

--- a/pkg/stdlib/strings/find.go
+++ b/pkg/stdlib/strings/find.go
@@ -3,6 +3,7 @@ package strings
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
@@ -11,7 +12,7 @@ import (
 // @param {String} str - The source string.
 // @param {String} search - The string to seek.
 // @param {Int} [start] - Limit the search to a subset of the text, beginning at start.
-// @param {Int} [end] - Limit the search to a subset of the text, ending at end
+// @param {Int} [end] - Limit the search to a subset of the text, ending before end.
 // @return {Int} - The character position of the match. If search is not contained in text, -1 is returned. If search is empty, start is returned.
 func FindFirst(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 4)
@@ -31,29 +32,38 @@ func FindFirst(ctx context.Context, args ...runtime.Value) (runtime.Value, error
 }
 
 func findFirst2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
-	return findFirst(ctx, arg1, arg2, runtime.ZeroInt, runtime.Int(len(arg1.String())))
+	return findFirst(ctx, arg1, arg2, runtime.ZeroInt, runtime.ZeroInt, false)
 }
 
 func findFirst3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
 	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
-	return findFirst(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
+	return findFirst(ctx, arg1, arg2, start, runtime.ZeroInt, false)
 }
 
 func findFirst4(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
 	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
-	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
-	return findFirst(ctx, arg1, arg2, start, end)
+	end, hasEnd := arg4.(runtime.Int)
+	return findFirst(ctx, arg1, arg2, start, end, hasEnd)
 }
 
-func findFirst(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {
+func findFirst(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int, hasEnd bool) (runtime.Value, error) {
 	text := arg1.String()
 	runes := []rune(text)
 	search := arg2.String()
+	if !hasEnd {
+		end = runtime.Int(len(runes))
+	}
 
-	found := strings.Index(string(runes[start:end]), search)
+	startIndex, endIndex, ok := normalizeFindBounds(len(runes), start, end)
+	if !ok {
+		return runtime.NewInt(-1), nil
+	}
+
+	window := string(runes[startIndex:endIndex])
+	found := strings.Index(window, search)
 
 	if found > -1 {
-		return runtime.NewInt(found + int(start)), nil
+		return runtime.NewInt(startIndex + utf8.RuneCountInString(window[:found])), nil
 	}
 
 	return runtime.NewInt(found), nil
@@ -63,8 +73,8 @@ func findFirst(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.I
 // @param {String} src - The source string.
 // @param {String} search - The string to seek.
 // @param {Int} [start] - Limit the search to a subset of the text, beginning at start.
-// @param {Int} [end] - Limit the search to a subset of the text, ending at end
-// @return {Int} - The character position of the match. If search is not contained in text, -1 is returned. If search is empty, start is returned.
+// @param {Int} [end] - Limit the search to a subset of the text, ending before end.
+// @return {Int} - The character position of the match. If search is not contained in text, -1 is returned. If search is empty, end is returned.
 func FindLast(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 4)
 
@@ -83,30 +93,57 @@ func FindLast(ctx context.Context, args ...runtime.Value) (runtime.Value, error)
 }
 
 func findLast2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
-	return findLast(ctx, arg1, arg2, runtime.ZeroInt, runtime.Int(len(arg1.String())))
+	return findLast(ctx, arg1, arg2, runtime.ZeroInt, runtime.ZeroInt, false)
 }
 
 func findLast3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
 	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
-	return findLast(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
+	return findLast(ctx, arg1, arg2, start, runtime.ZeroInt, false)
 }
 
 func findLast4(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
 	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
-	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
-	return findLast(ctx, arg1, arg2, start, end)
+	end, hasEnd := arg4.(runtime.Int)
+	return findLast(ctx, arg1, arg2, start, end, hasEnd)
 }
 
-func findLast(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {
+func findLast(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int, hasEnd bool) (runtime.Value, error) {
 	text := arg1.String()
 	runes := []rune(text)
 	search := arg2.String()
+	if !hasEnd {
+		end = runtime.Int(len(runes))
+	}
 
-	found := strings.LastIndex(string(runes[start:end]), search)
+	startIndex, endIndex, ok := normalizeFindBounds(len(runes), start, end)
+	if !ok {
+		return runtime.NewInt(-1), nil
+	}
+
+	window := string(runes[startIndex:endIndex])
+	found := strings.LastIndex(window, search)
 
 	if found > -1 {
-		return runtime.NewInt(found + int(start)), nil
+		return runtime.NewInt(startIndex + utf8.RuneCountInString(window[:found])), nil
 	}
 
 	return runtime.NewInt(found), nil
+}
+
+func normalizeFindBounds(size int, start, end runtime.Int) (int, int, bool) {
+	limit := runtime.Int(size)
+
+	if start < 0 {
+		start = 0
+	} else if start > limit {
+		start = limit
+	}
+
+	if end < 0 {
+		end = 0
+	} else if end > limit {
+		end = limit
+	}
+
+	return int(start), int(end), start <= end
 }

--- a/pkg/stdlib/strings/find.go
+++ b/pkg/stdlib/strings/find.go
@@ -39,9 +39,10 @@ func findFirst3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Va
 	return findFirst(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
 }
 
-func findFirst4(ctx context.Context, arg1, arg2, _, arg4 runtime.Value) (runtime.Value, error) {
+func findFirst4(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
 	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
-	return findFirst(ctx, arg1, arg2, runtime.ZeroInt, end)
+	return findFirst(ctx, arg1, arg2, start, end)
 }
 
 func findFirst(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {
@@ -90,9 +91,10 @@ func findLast3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Val
 	return findLast(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
 }
 
-func findLast4(ctx context.Context, arg1, arg2, _, arg4 runtime.Value) (runtime.Value, error) {
+func findLast4(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
 	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
-	return findLast(ctx, arg1, arg2, runtime.ZeroInt, end)
+	return findLast(ctx, arg1, arg2, start, end)
 }
 
 func findLast(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {

--- a/pkg/stdlib/strings/find.go
+++ b/pkg/stdlib/strings/find.go
@@ -13,36 +13,41 @@ import (
 // @param {Int} [start] - Limit the search to a subset of the text, beginning at start.
 // @param {Int} [end] - Limit the search to a subset of the text, ending at end
 // @return {Int} - The character position of the match. If search is not contained in text, -1 is returned. If search is empty, start is returned.
-func FindFirst(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func FindFirst(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 4)
 
 	if err != nil {
 		return runtime.NewInt(-1), err
 	}
 
-	argsCount := len(args)
+	switch len(args) {
+	case 2:
+		return findFirst2(ctx, args[0], args[1])
+	case 3:
+		return findFirst3(ctx, args[0], args[1], args[2])
+	default:
+		return findFirst4(ctx, args[0], args[1], args[2], args[3])
+	}
+}
 
-	text := args[0].String()
+func findFirst2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return findFirst(ctx, arg1, arg2, runtime.ZeroInt, runtime.Int(len(arg1.String())))
+}
+
+func findFirst3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
+	return findFirst(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
+}
+
+func findFirst4(ctx context.Context, arg1, arg2, _, arg4 runtime.Value) (runtime.Value, error) {
+	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
+	return findFirst(ctx, arg1, arg2, runtime.ZeroInt, end)
+}
+
+func findFirst(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {
+	text := arg1.String()
 	runes := []rune(text)
-	search := args[1].String()
-	start := runtime.NewInt(0)
-	end := runtime.NewInt(len(text))
-
-	if argsCount == 3 {
-		arg3, ok := args[2].(runtime.Int)
-
-		if ok {
-			start = arg3
-		}
-	}
-
-	if argsCount == 4 {
-		arg4, ok := args[3].(runtime.Int)
-
-		if ok {
-			end = arg4
-		}
-	}
+	search := arg2.String()
 
 	found := strings.Index(string(runes[start:end]), search)
 
@@ -59,36 +64,41 @@ func FindFirst(_ context.Context, args ...runtime.Value) (runtime.Value, error) 
 // @param {Int} [start] - Limit the search to a subset of the text, beginning at start.
 // @param {Int} [end] - Limit the search to a subset of the text, ending at end
 // @return {Int} - The character position of the match. If search is not contained in text, -1 is returned. If search is empty, start is returned.
-func FindLast(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func FindLast(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 4)
 
 	if err != nil {
 		return runtime.NewInt(-1), err
 	}
 
-	argsCount := len(args)
+	switch len(args) {
+	case 2:
+		return findLast2(ctx, args[0], args[1])
+	case 3:
+		return findLast3(ctx, args[0], args[1], args[2])
+	default:
+		return findLast4(ctx, args[0], args[1], args[2], args[3])
+	}
+}
 
-	text := args[0].String()
+func findLast2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return findLast(ctx, arg1, arg2, runtime.ZeroInt, runtime.Int(len(arg1.String())))
+}
+
+func findLast3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	start := runtime.CastOr[runtime.Int](arg3, runtime.ZeroInt)
+	return findLast(ctx, arg1, arg2, start, runtime.Int(len(arg1.String())))
+}
+
+func findLast4(ctx context.Context, arg1, arg2, _, arg4 runtime.Value) (runtime.Value, error) {
+	end := runtime.CastOr[runtime.Int](arg4, runtime.Int(len(arg1.String())))
+	return findLast(ctx, arg1, arg2, runtime.ZeroInt, end)
+}
+
+func findLast(_ context.Context, arg1, arg2 runtime.Value, start, end runtime.Int) (runtime.Value, error) {
+	text := arg1.String()
 	runes := []rune(text)
-	search := args[1].String()
-	start := runtime.NewInt(0)
-	end := runtime.NewInt(len(text))
-
-	if argsCount == 3 {
-		arg3, ok := args[2].(runtime.Int)
-
-		if ok {
-			start = arg3
-		}
-	}
-
-	if argsCount == 4 {
-		arg4, ok := args[3].(runtime.Int)
-
-		if ok {
-			end = arg4
-		}
-	}
+	search := arg2.String()
 
 	found := strings.LastIndex(string(runes[start:end]), search)
 

--- a/pkg/stdlib/strings/find_test.go
+++ b/pkg/stdlib/strings/find_test.go
@@ -72,6 +72,18 @@ func TestFindFirst(t *testing.T) {
 
 			So(out, ShouldEqual, -1)
 		})
+
+		Convey("FindFirst('foobarbaz', 'ba', 4, 9) should return 6", func() {
+			out, _ := strings.FindFirst(
+				context.Background(),
+				runtime.NewString("foobarbaz"),
+				runtime.NewString("ba"),
+				runtime.NewInt(4),
+				runtime.NewInt(9),
+			)
+
+			So(out, ShouldEqual, 6)
+		})
 	})
 }
 
@@ -124,6 +136,18 @@ func TestFindLast(t *testing.T) {
 			)
 
 			So(out, ShouldEqual, 3)
+		})
+
+		Convey("FindLast('foobarbaz', 'ba', 4, 6) should return -1", func() {
+			out, _ := strings.FindLast(
+				context.Background(),
+				runtime.NewString("foobarbaz"),
+				runtime.NewString("ba"),
+				runtime.NewInt(4),
+				runtime.NewInt(6),
+			)
+
+			So(out, ShouldEqual, -1)
 		})
 	})
 }

--- a/pkg/stdlib/strings/find_test.go
+++ b/pkg/stdlib/strings/find_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/stdlib/strings"
 )
 
+var findBenchmarkResult runtime.Value
+
 func TestFindFirst(t *testing.T) {
 	Convey("When args are not passed", t, func() {
 		Convey("It should return an error", func() {
@@ -150,4 +152,168 @@ func TestFindLast(t *testing.T) {
 			So(out, ShouldEqual, -1)
 		})
 	})
+}
+
+func TestFindUnicodeAndBounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func(context.Context, ...runtime.Value) (runtime.Value, error)
+		args     []runtime.Value
+		expected runtime.Int
+	}{
+		{
+			name:     "first two arguments use character position",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a")},
+			expected: runtime.NewInt(1),
+		},
+		{
+			name:     "first three arguments use character bounds",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(2)},
+			expected: runtime.NewInt(3),
+		},
+		{
+			name:     "first four arguments use character bounds",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éaéaéa"), runtime.NewString("a"), runtime.NewInt(2), runtime.NewInt(6)},
+			expected: runtime.NewInt(3),
+		},
+		{
+			name:     "last two arguments use character position",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a")},
+			expected: runtime.NewInt(3),
+		},
+		{
+			name:     "last three arguments use character bounds",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(2)},
+			expected: runtime.NewInt(3),
+		},
+		{
+			name:     "last four arguments use character bounds",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéaéa"), runtime.NewString("a"), runtime.NewInt(2), runtime.NewInt(6)},
+			expected: runtime.NewInt(5),
+		},
+		{
+			name:     "first clamps negative start and oversized end",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(-10), runtime.NewInt(100)},
+			expected: runtime.NewInt(1),
+		},
+		{
+			name:     "last clamps negative start and oversized end",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(-10), runtime.NewInt(100)},
+			expected: runtime.NewInt(3),
+		},
+		{
+			name:     "first rejects reversed normalized bounds",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(3), runtime.NewInt(1)},
+			expected: runtime.NewInt(-1),
+		},
+		{
+			name:     "last rejects reversed normalized bounds",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(3), runtime.NewInt(1)},
+			expected: runtime.NewInt(-1),
+		},
+		{
+			name:     "oversized start clamps to end",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éa"), runtime.NewString("a"), runtime.NewInt(100)},
+			expected: runtime.NewInt(-1),
+		},
+		{
+			name:     "negative end clamps to zero",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éa"), runtime.NewString("a"), runtime.NewInt(0), runtime.NewInt(-1)},
+			expected: runtime.NewInt(-1),
+		},
+		{
+			name:     "first empty search returns effective start",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éa"), runtime.EmptyString, runtime.NewInt(1), runtime.NewInt(100)},
+			expected: runtime.NewInt(1),
+		},
+		{
+			name:     "last empty search returns effective end",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éa"), runtime.EmptyString, runtime.NewInt(1), runtime.NewInt(100)},
+			expected: runtime.NewInt(2),
+		},
+		{
+			name:     "invalid start falls back to zero",
+			fn:       strings.FindFirst,
+			args:     []runtime.Value{runtime.NewString("éa"), runtime.NewString("a"), runtime.True},
+			expected: runtime.NewInt(1),
+		},
+		{
+			name:     "invalid end falls back to character length",
+			fn:       strings.FindLast,
+			args:     []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.ZeroInt, runtime.True},
+			expected: runtime.NewInt(3),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.fn(context.Background(), test.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result != test.expected {
+				t.Fatalf("expected %d, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func BenchmarkFind(b *testing.B) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		fn   func(context.Context, ...runtime.Value) (runtime.Value, error)
+		args []runtime.Value
+	}{
+		{
+			name: "first_ascii",
+			fn:   strings.FindFirst,
+			args: []runtime.Value{runtime.NewString("foobarbaz"), runtime.NewString("ba")},
+		},
+		{
+			name: "last_ascii",
+			fn:   strings.FindLast,
+			args: []runtime.Value{runtime.NewString("foobarbaz"), runtime.NewString("ba")},
+		},
+		{
+			name: "first_unicode_bounded",
+			fn:   strings.FindFirst,
+			args: []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(0), runtime.NewInt(4)},
+		},
+		{
+			name: "last_unicode_bounded",
+			fn:   strings.FindLast,
+			args: []runtime.Value{runtime.NewString("éaéa"), runtime.NewString("a"), runtime.NewInt(0), runtime.NewInt(4)},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				result, err := test.fn(ctx, test.args...)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				findBenchmarkResult = result
+			}
+		})
+	}
 }

--- a/pkg/stdlib/strings/lib.go
+++ b/pkg/stdlib/strings/lib.go
@@ -17,30 +17,52 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("JSON_PARSE", JSONParse).
 		Add("JSON_STRINGIFY", JSONStringify).
 		Add("LOWER", Lower).
+		Add("LTRIM", lTrim1).
 		Add("UPPER", Upper).
 		Add("RANDOM_TOKEN", RandomToken).
+		Add("RTRIM", rTrim1).
+		Add("TRIM", trim1).
 		Add("UNESCAPE_HTML", UnescapeHTML)
 
 	ns.Function().A2().
+		Add("CONTAINS", contains2).
+		Add("FIND_FIRST", findFirst2).
+		Add("FIND_LAST", findLast2).
 		Add("LEFT", Left).
-		Add("RIGHT", Right)
+		Add("LIKE", like2).
+		Add("LTRIM", lTrim2).
+		Add("REGEX_MATCH", regexMatch2).
+		Add("REGEX_SPLIT", regexSplit2).
+		Add("REGEX_TEST", regexTest2).
+		Add("RIGHT", Right).
+		Add("RTRIM", rTrim2).
+		Add("SPLIT", split2).
+		Add("SUBSTITUTE", substitute2).
+		Add("SUBSTRING", substring2).
+		Add("TRIM", trim2)
+
+	ns.Function().A3().
+		Add("CONTAINS", contains3).
+		Add("FIND_FIRST", findFirst3).
+		Add("FIND_LAST", findLast3).
+		Add("LIKE", like3).
+		Add("REGEX_MATCH", regexMatch3).
+		Add("REGEX_REPLACE", regexReplace3).
+		Add("REGEX_SPLIT", regexSplit3).
+		Add("REGEX_TEST", regexTest3).
+		Add("SPLIT", split3).
+		Add("SUBSTITUTE", substitute3).
+		Add("SUBSTRING", substring3)
+
+	ns.Function().A4().
+		Add("FIND_FIRST", findFirst4).
+		Add("FIND_LAST", findLast4).
+		Add("REGEX_REPLACE", regexReplace4).
+		Add("REGEX_SPLIT", regexSplit4).
+		Add("SUBSTITUTE", substitute4)
 
 	ns.Function().Var().
 		Add("CONCAT", Concat).
 		Add("CONCAT_SEPARATOR", ConcatWithSeparator).
-		Add("CONTAINS", Contains).
-		Add("FIND_FIRST", FindFirst).
-		Add("FIND_LAST", FindLast).
-		Add("LIKE", Like).
-		Add("LTRIM", LTrim).
-		Add("REGEX_MATCH", RegexMatch).
-		Add("REGEX_SPLIT", RegexSplit).
-		Add("REGEX_TEST", RegexTest).
-		Add("REGEX_REPLACE", RegexReplace).
-		Add("RTRIM", RTrim).
-		Add("SPLIT", Split).
-		Add("SUBSTITUTE", Substitute).
-		Add("SUBSTRING", Substring).
-		Add("TRIM", Trim).
 		Add("FMT", Fmt)
 }

--- a/pkg/stdlib/strings/like.go
+++ b/pkg/stdlib/strings/like.go
@@ -19,15 +19,27 @@ var (
 // @param {String} search - A search pattern that can contain the wildcard characters.
 // @param {Boolean} caseInsensitive - If set to true, the matching will be case-insensitive. The default is false.
 // @return {Boolean} - Returns true if the pattern is contained in text, and false otherwise.
-func Like(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Like(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 3)
 
 	if err != nil {
 		return runtime.False, err
 	}
 
-	str := args[0].String()
-	pattern := args[1].String()
+	if len(args) == 2 {
+		return like2(ctx, args[0], args[1])
+	}
+
+	return like3(ctx, args[0], args[1], args[2])
+}
+
+func like2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return like3(ctx, arg1, arg2, runtime.False)
+}
+
+func like3(_ context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	str := arg1.String()
+	pattern := arg2.String()
 
 	if len(pattern) == 0 {
 		return runtime.NewBoolean(len(str) == 0), nil
@@ -49,11 +61,9 @@ func Like(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
 
 	pattern = string(replaced)
 
-	if len(args) > 2 {
-		if runtime.ToBoolean(args[2]) {
-			str = strings.ToLower(str)
-			pattern = strings.ToLower(pattern)
-		}
+	if runtime.ToBoolean(arg3) {
+		str = strings.ToLower(str)
+		pattern = strings.ToLower(pattern)
 	}
 
 	g, err := glob.Compile(pattern)

--- a/pkg/stdlib/strings/regex.go
+++ b/pkg/stdlib/strings/regex.go
@@ -17,13 +17,23 @@ func RegexMatch(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 		return runtime.None, err
 	}
 
-	text := args[0].String()
-	exp := args[1].String()
+	if len(args) == 2 {
+		return regexMatch2(ctx, args[0], args[1])
+	}
 
-	if len(args) > 2 {
-		if args[2] == runtime.True {
-			exp = "(?i)" + exp
-		}
+	return regexMatch3(ctx, args[0], args[1], args[2])
+}
+
+func regexMatch2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return regexMatch3(ctx, arg1, arg2, runtime.False)
+}
+
+func regexMatch3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	text := arg1.String()
+	exp := arg2.String()
+
+	if arg3 == runtime.True {
+		exp = "(?i)" + exp
 	}
 
 	reg, err := regexp.Compile(exp)
@@ -59,17 +69,32 @@ func RegexSplit(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 		return runtime.None, err
 	}
 
-	text := args[0].String()
-	exp := args[1].String()
-	limit := -1
-
-	if len(args) > 2 {
-		arg2, ok := args[2].(runtime.Int)
-
-		if ok {
-			limit = int(arg2)
-		}
+	switch len(args) {
+	case 2:
+		return regexSplit2(ctx, args[0], args[1])
+	case 3:
+		return regexSplit3(ctx, args[0], args[1], args[2])
+	default:
+		return regexSplit4(ctx, args[0], args[1], args[2], args[3])
 	}
+}
+
+func regexSplit2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return regexSplit(ctx, arg1, arg2, -1)
+}
+
+func regexSplit3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	limit := runtime.CastOr[runtime.Int](arg3, runtime.Int(-1))
+	return regexSplit(ctx, arg1, arg2, int(limit))
+}
+
+func regexSplit4(ctx context.Context, arg1, arg2, arg3, _ runtime.Value) (runtime.Value, error) {
+	return regexSplit3(ctx, arg1, arg2, arg3)
+}
+
+func regexSplit(ctx context.Context, arg1, arg2 runtime.Value, limit int) (runtime.Value, error) {
+	text := arg1.String()
+	exp := arg2.String()
 
 	reg, err := regexp.Compile(exp)
 
@@ -96,20 +121,30 @@ func RegexSplit(ctx context.Context, args ...runtime.Value) (runtime.Value, erro
 // @param {String} expression - A regular expression to use for splitting the text.
 // @param {Boolean} [caseInsensitive=False] - If set to true, the matching will be case-insensitive.
 // @return {Boolean} - Returns true if the pattern is contained in text, and false otherwise.
-func RegexTest(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func RegexTest(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 3)
 
 	if err != nil {
 		return runtime.None, err
 	}
 
-	text := args[0].String()
-	exp := args[1].String()
+	if len(args) == 2 {
+		return regexTest2(ctx, args[0], args[1])
+	}
 
-	if len(args) > 2 {
-		if args[2] == runtime.True {
-			exp = "(?i)" + exp
-		}
+	return regexTest3(ctx, args[0], args[1], args[2])
+}
+
+func regexTest2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return regexTest3(ctx, arg1, arg2, runtime.False)
+}
+
+func regexTest3(_ context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	text := arg1.String()
+	exp := arg2.String()
+
+	if arg3 == runtime.True {
+		exp = "(?i)" + exp
 	}
 
 	reg, err := regexp.Compile(exp)
@@ -129,21 +164,31 @@ func RegexTest(_ context.Context, args ...runtime.Value) (runtime.Value, error) 
 // @param {String} replacement - The string to replace the search pattern with
 // @param {Boolean} [caseInsensitive=False] - If set to true, the matching will be case-insensitive.
 // @return {String} - Returns the string text with the search regex pattern replaced with the replacement string wherever the pattern exists in text
-func RegexReplace(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func RegexReplace(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 3, 4)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
-	exp := args[1].String()
-	repl := args[2].String()
+	if len(args) == 3 {
+		return regexReplace3(ctx, args[0], args[1], args[2])
+	}
 
-	if len(args) > 3 {
-		if args[3] == runtime.True {
-			exp = "(?i)" + exp
-		}
+	return regexReplace4(ctx, args[0], args[1], args[2], args[3])
+}
+
+func regexReplace3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return regexReplace4(ctx, arg1, arg2, arg3, runtime.False)
+}
+
+func regexReplace4(_ context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	text := arg1.String()
+	exp := arg2.String()
+	repl := arg3.String()
+
+	if arg4 == runtime.True {
+		exp = "(?i)" + exp
 	}
 
 	reg, err := regexp.Compile(exp)

--- a/pkg/stdlib/strings/regex_test.go
+++ b/pkg/stdlib/strings/regex_test.go
@@ -73,6 +73,19 @@ func TestRegexSplit(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(out.String(), ShouldEqual, `["This is a line"," This is yet another line",""," This again is a line"," Mac line "]`)
 	})
+
+	Convey("Should preserve limit and ignored fourth argument behavior", t, func() {
+		out, err := strings.RegexSplit(
+			context.Background(),
+			runtime.NewString("a,b,c"),
+			runtime.NewString(","),
+			runtime.NewInt(2),
+			runtime.True,
+		)
+
+		So(err, ShouldBeNil)
+		So(out.String(), ShouldEqual, `["a","b,c"]`)
+	})
 }
 
 func TestRegexTest(t *testing.T) {

--- a/pkg/stdlib/strings/split.go
+++ b/pkg/stdlib/strings/split.go
@@ -19,17 +19,25 @@ func Split(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 		return runtime.None, err
 	}
 
-	text := args[0].String()
-	separator := args[1].String()
-	limit := -1
-
-	if len(args) > 2 {
-		args2, ok := args[2].(runtime.Int)
-
-		if ok {
-			limit = int(args2)
-		}
+	if len(args) == 2 {
+		return split2(ctx, args[0], args[1])
 	}
+
+	return split3(ctx, args[0], args[1], args[2])
+}
+
+func split2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return split(ctx, arg1, arg2, -1)
+}
+
+func split3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	limit := runtime.CastOr[runtime.Int](arg3, runtime.Int(-1))
+	return split(ctx, arg1, arg2, int(limit))
+}
+
+func split(ctx context.Context, arg1, arg2 runtime.Value, limit int) (runtime.Value, error) {
+	text := arg1.String()
+	separator := arg2.String()
 
 	var strs []string
 

--- a/pkg/stdlib/strings/substitute.go
+++ b/pkg/stdlib/strings/substitute.go
@@ -13,29 +13,40 @@ import (
 // @param {String} replace - The string representing a replace value
 // @param {Int} limit - The cap the number of replacements to this value.
 // @return {String} - Returns a string with replace substring.
-func Substitute(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Substitute(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 2, 4)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
-	search := args[1].String()
-	replace := ""
-	limit := -1
-
-	if len(args) > 2 {
-		replace = args[2].String()
+	switch len(args) {
+	case 2:
+		return substitute2(ctx, args[0], args[1])
+	case 3:
+		return substitute3(ctx, args[0], args[1], args[2])
+	default:
+		return substitute4(ctx, args[0], args[1], args[2], args[3])
 	}
+}
 
-	if len(args) > 3 {
-		arg3, ok := args[3].(runtime.Int)
+func substitute2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return substitute(ctx, arg1, arg2, runtime.EmptyString, -1)
+}
 
-		if ok {
-			limit = int(arg3)
-		}
-	}
+func substitute3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return substitute(ctx, arg1, arg2, arg3, -1)
+}
+
+func substitute4(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+	limit := runtime.CastOr[runtime.Int](arg4, runtime.Int(-1))
+	return substitute(ctx, arg1, arg2, arg3, int(limit))
+}
+
+func substitute(_ context.Context, arg1, arg2, arg3 runtime.Value, limit int) (runtime.Value, error) {
+	text := arg1.String()
+	search := arg2.String()
+	replace := arg3.String()
 
 	out := strings.Replace(text, search, replace, limit)
 

--- a/pkg/stdlib/strings/substr.go
+++ b/pkg/stdlib/strings/substr.go
@@ -11,29 +11,41 @@ import (
 // @param {Int} offset - Start at offset, offsets start at position 0.
 // @param {Int} [length] - At most length characters, omit to get the substring from offset to the end of the string.
 // @return {String} - A substring of value.
-func Substring(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Substring(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	if err := runtime.ValidateArgs(args, 2, 3); err != nil {
 		return runtime.EmptyString, err
 	}
 
-	offsetArg, err := runtime.CastArg[runtime.Int](args[1], 1)
+	if len(args) == 2 {
+		return substring2(ctx, args[0], args[1])
+	}
+
+	return substring3(ctx, args[0], args[1], args[2])
+}
+
+func substring2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return substring(ctx, arg1, arg2, runtime.None, false)
+}
+
+func substring3(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+	return substring(ctx, arg1, arg2, arg3, true)
+}
+
+func substring(_ context.Context, arg1, arg2, arg3 runtime.Value, hasLength bool) (runtime.Value, error) {
+	offsetArg, err := runtime.CastArg[runtime.Int](arg2, 1)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
+	text := arg1.String()
 	runes := []rune(text)
 	size := len(runes)
 	offset := int(offsetArg)
 	length := size
 
-	if len(args) > 2 {
-		arg2, ok := args[2].(runtime.Int)
-
-		if ok {
-			length = int(arg2)
-		}
+	if hasLength {
+		length = int(runtime.CastOr[runtime.Int](arg3, runtime.Int(size)))
 	}
 
 	// Handle edge cases for bounds checking

--- a/pkg/stdlib/strings/trim.go
+++ b/pkg/stdlib/strings/trim.go
@@ -11,60 +11,76 @@ import (
 // @param {String} str - The string.
 // @param {String} chars - Overrides the characters that should be removed from the string. It defaults to \r\n \t.
 // @return {String} - The string without chars on both sides.
-func Trim(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func Trim(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 1, 2)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
-
-	if len(args) > 1 {
-		return runtime.NewString(strings.Trim(text, args[1].String())), nil
+	if len(args) == 1 {
+		return trim1(ctx, args[0])
 	}
 
-	return runtime.NewString(strings.TrimSpace(text)), nil
+	return trim2(ctx, args[0], args[1])
+}
+
+func trim1(_ context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.TrimSpace(arg1.String())), nil
+}
+
+func trim2(_ context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.Trim(arg1.String(), arg2.String())), nil
 }
 
 // LTRIM returns the string value with whitespace stripped from the start only.
 // @param {String} str - The string.
 // @param {String} chars - Overrides the characters that should be removed from the string. It defaults to \r\n \t.
 // @return {String} - The string without chars at the left-hand side.
-func LTrim(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func LTrim(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 1, 2)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
-	chars := " "
-
-	if len(args) > 1 {
-		chars = args[1].String()
+	if len(args) == 1 {
+		return lTrim1(ctx, args[0])
 	}
 
-	return runtime.NewString(strings.TrimLeft(text, chars)), nil
+	return lTrim2(ctx, args[0], args[1])
+}
+
+func lTrim1(_ context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.TrimLeft(arg1.String(), " ")), nil
+}
+
+func lTrim2(_ context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.TrimLeft(arg1.String(), arg2.String())), nil
 }
 
 // RTRIM returns the string value with whitespace stripped from the end only.
 // @param {String} str - The string.
 // @param {String} chars - Overrides the characters that should be removed from the string. It defaults to \r\n \t.
 // @return {String} - The string without chars at the right-hand side.
-func RTrim(_ context.Context, args ...runtime.Value) (runtime.Value, error) {
+func RTrim(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
 	err := runtime.ValidateArgs(args, 1, 2)
 
 	if err != nil {
 		return runtime.EmptyString, err
 	}
 
-	text := args[0].String()
-	chars := " "
-
-	if len(args) > 1 {
-		chars = args[1].String()
+	if len(args) == 1 {
+		return rTrim1(ctx, args[0])
 	}
 
-	return runtime.NewString(strings.TrimRight(text, chars)), nil
+	return rTrim2(ctx, args[0], args[1])
+}
+
+func rTrim1(_ context.Context, arg1 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.TrimRight(arg1.String(), " ")), nil
+}
+
+func rTrim2(_ context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return runtime.NewString(strings.TrimRight(arg1.String(), arg2.String())), nil
 }

--- a/pkg/stdlib/testing/lib.go
+++ b/pkg/stdlib/testing/lib.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
-	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
 )
 
 // @namespace T
@@ -11,50 +10,48 @@ func RegisterLib(ns runtime.Namespace) {
 
 	registerNOT(t)
 
-	t.Function().Var().
-		Add("EMPTY", base.NewPositiveAssertion(Empty)).
-		Add("EQ", base.NewPositiveAssertion(Equal)).
-		Add("FAIL", base.NewPositiveAssertion(Fail)).
-		Add("FALSE", base.NewPositiveAssertion(False)).
-		Add("GT", base.NewPositiveAssertion(Gt)).
-		Add("GTE", base.NewPositiveAssertion(Gte)).
-		Add("INCLUDE", base.NewPositiveAssertion(Include)).
-		Add("LEN", base.NewPositiveAssertion(Len)).
-		Add("MATCH", base.NewPositiveAssertion(Match)).
-		Add("LT", base.NewPositiveAssertion(Lt)).
-		Add("LTE", base.NewPositiveAssertion(Lte)).
-		Add("NONE", base.NewPositiveAssertion(None)).
-		Add("TRUE", base.NewPositiveAssertion(True)).
-		Add("STRING", base.NewPositiveAssertion(String)).
-		Add("INT", base.NewPositiveAssertion(Int)).
-		Add("FLOAT", base.NewPositiveAssertion(Float)).
-		Add("DATETIME", base.NewPositiveAssertion(DateTime)).
-		Add("ARRAY", base.NewPositiveAssertion(Array)).
-		Add("OBJECT", base.NewPositiveAssertion(Object)).
-		Add("BINARY", base.NewPositiveAssertion(Binary))
+	registerPositive(t, "EMPTY", Empty)
+	registerPositive(t, "EQ", Equal)
+	registerPositive(t, "FAIL", Fail)
+	registerPositive(t, "FALSE", False)
+	registerPositive(t, "GT", Gt)
+	registerPositive(t, "GTE", Gte)
+	registerPositive(t, "INCLUDE", Include)
+	registerPositive(t, "LEN", Len)
+	registerPositive(t, "MATCH", Match)
+	registerPositive(t, "LT", Lt)
+	registerPositive(t, "LTE", Lte)
+	registerPositive(t, "NONE", None)
+	registerPositive(t, "TRUE", True)
+	registerPositive(t, "STRING", String)
+	registerPositive(t, "INT", Int)
+	registerPositive(t, "FLOAT", Float)
+	registerPositive(t, "DATETIME", DateTime)
+	registerPositive(t, "ARRAY", Array)
+	registerPositive(t, "OBJECT", Object)
+	registerPositive(t, "BINARY", Binary)
 }
 
 func registerNOT(ns runtime.Namespace) {
 	t := ns.Namespace("NOT")
 
-	t.Function().Var().
-		Add("EMPTY", base.NewNegativeAssertion(Empty)).
-		Add("EQ", base.NewNegativeAssertion(Equal)).
-		Add("FALSE", base.NewNegativeAssertion(False)).
-		Add("GT", base.NewNegativeAssertion(Gt)).
-		Add("GTE", base.NewNegativeAssertion(Gte)).
-		Add("INCLUDE", base.NewNegativeAssertion(Include)).
-		Add("LEN", base.NewNegativeAssertion(Len)).
-		Add("MATCH", base.NewNegativeAssertion(Match)).
-		Add("LT", base.NewNegativeAssertion(Lt)).
-		Add("LTE", base.NewNegativeAssertion(Lte)).
-		Add("NONE", base.NewNegativeAssertion(None)).
-		Add("TRUE", base.NewNegativeAssertion(True)).
-		Add("STRING", base.NewNegativeAssertion(String)).
-		Add("INT", base.NewNegativeAssertion(Int)).
-		Add("FLOAT", base.NewNegativeAssertion(Float)).
-		Add("DATETIME", base.NewNegativeAssertion(DateTime)).
-		Add("ARRAY", base.NewNegativeAssertion(Array)).
-		Add("OBJECT", base.NewNegativeAssertion(Object)).
-		Add("BINARY", base.NewNegativeAssertion(Binary))
+	registerNegative(t, "EMPTY", Empty)
+	registerNegative(t, "EQ", Equal)
+	registerNegative(t, "FALSE", False)
+	registerNegative(t, "GT", Gt)
+	registerNegative(t, "GTE", Gte)
+	registerNegative(t, "INCLUDE", Include)
+	registerNegative(t, "LEN", Len)
+	registerNegative(t, "MATCH", Match)
+	registerNegative(t, "LT", Lt)
+	registerNegative(t, "LTE", Lte)
+	registerNegative(t, "NONE", None)
+	registerNegative(t, "TRUE", True)
+	registerNegative(t, "STRING", String)
+	registerNegative(t, "INT", Int)
+	registerNegative(t, "FLOAT", Float)
+	registerNegative(t, "DATETIME", DateTime)
+	registerNegative(t, "ARRAY", Array)
+	registerNegative(t, "OBJECT", Object)
+	registerNegative(t, "BINARY", Binary)
 }

--- a/pkg/stdlib/testing/registration.go
+++ b/pkg/stdlib/testing/registration.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/testing/base"
+)
+
+func registerPositive(ns runtime.Namespace, name string, assertion base.Assertion) {
+	registerAssertion(ns, name, assertion, base.NewPositiveAssertion(assertion))
+}
+
+func registerNegative(ns runtime.Namespace, name string, assertion base.Assertion) {
+	registerAssertion(ns, name, assertion, base.NewNegativeAssertion(assertion))
+}
+
+func registerAssertion(ns runtime.Namespace, name string, assertion base.Assertion, fn runtime.Function) {
+	for arity := assertion.Args.Min; arity <= assertion.Args.Max; arity++ {
+		switch arity {
+		case 0:
+			ns.Function().A0().Add(name, func(ctx context.Context) (runtime.Value, error) {
+				return fn(ctx)
+			})
+		case 1:
+			ns.Function().A1().Add(name, func(ctx context.Context, arg1 runtime.Value) (runtime.Value, error) {
+				return fn(ctx, arg1)
+			})
+		case 2:
+			ns.Function().A2().Add(name, func(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+				return fn(ctx, arg1, arg2)
+			})
+		case 3:
+			ns.Function().A3().Add(name, func(ctx context.Context, arg1, arg2, arg3 runtime.Value) (runtime.Value, error) {
+				return fn(ctx, arg1, arg2, arg3)
+			})
+		case 4:
+			ns.Function().A4().Add(name, func(ctx context.Context, arg1, arg2, arg3, arg4 runtime.Value) (runtime.Value, error) {
+				return fn(ctx, arg1, arg2, arg3, arg4)
+			})
+		default:
+			panic(fmt.Sprintf("unsupported assertion arity %d for %s", arity, name))
+		}
+	}
+}

--- a/pkg/stdlib/types/lib.go
+++ b/pkg/stdlib/types/lib.go
@@ -27,9 +27,10 @@ func RegisterLib(ns runtime.Namespace) {
 		Add("IS_MAP", IsMap).
 		Add("IS_OBJECT", IsObject).
 		Add("IS_BINARY", IsBinary).
-		Add("IS_NAN", IsNaN)
+		Add("IS_NAN", IsNaN).
+		Add("TO_DATETIME", ToDateTime)
 
-	ns.Function().Var().Add("TO_DATETIME", toDateTime)
+	ns.Function().A2().Add("TO_DATETIME", toDateTime2)
 }
 
 func isTypeof(value runtime.Value, ctype runtime.Type) runtime.Value {

--- a/pkg/stdlib/types/to_date_time.go
+++ b/pkg/stdlib/types/to_date_time.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ToDateTime converts one native DateTime or RFC3339 value.
-// Numeric epoch conversion is exposed to FQL through the registered variadic adapter.
+// Numeric epoch conversion is exposed to FQL through the two-argument overload.
 func ToDateTime(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 	return runtime.ToDateTime(ctx, arg)
 }
@@ -17,14 +17,6 @@ func ToDateTime(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 // @param {DateTime|String|Int|Float} value - A DateTime, RFC3339 string, or numeric Unix epoch value.
 // @param {String} [unit] - Epoch unit: s, ms, us, or ns. Aliases include sec, second, seconds, millisecond, milliseconds, µs, μs, microsecond, microseconds, nanosecond, and nanoseconds. Valid only for numeric values.
 // @return {DateTime} - Parsed DateTime.
-func toDateTime(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
-	if err := runtime.ValidateArgs(args, 1, 2); err != nil {
-		return runtime.None, err
-	}
-
-	if len(args) == 1 {
-		return runtime.ToDateTime(ctx, args[0])
-	}
-
-	return runtime.ToDateTimeEpoch(ctx, args[0], args[1])
+func toDateTime2(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return runtime.ToDateTimeEpoch(ctx, arg1, arg2)
 }

--- a/pkg/stdlib/types/to_date_time_test.go
+++ b/pkg/stdlib/types/to_date_time_test.go
@@ -34,52 +34,39 @@ func TestToDateTime(t *testing.T) {
 	}
 }
 
-func TestToDateTimeVariadic(t *testing.T) {
+func TestToDateTimeEpoch(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		expected time.Time
+		value    runtime.Value
+		unit     runtime.Value
 		name     string
-		args     []runtime.Value
 	}{
 		{
-			name:     "RFC3339",
-			args:     []runtime.Value{runtime.NewString("2026-08-02T12:00:00Z")},
-			expected: time.Date(2026, time.August, 2, 12, 0, 0, 0, time.UTC),
-		},
-		{
 			name:     "integer epoch",
-			args:     []runtime.Value{runtime.NewInt(1), runtime.NewString("s")},
+			value:    runtime.NewInt(1),
+			unit:     runtime.NewString("s"),
 			expected: time.Unix(1, 0).UTC(),
 		},
 		{
 			name:     "float epoch",
-			args:     []runtime.Value{runtime.NewFloat(1.5), runtime.NewString("s")},
+			value:    runtime.NewFloat(1.5),
+			unit:     runtime.NewString("s"),
 			expected: time.Unix(1, 500_000_000).UTC(),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			value, err := toDateTime(t.Context(), test.args...)
+			value, err := toDateTime2(t.Context(), test.value, test.unit)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			actual, ok := value.(runtime.DateTime)
 			if !ok || !actual.Equal(test.expected) {
-				t.Fatalf("toDateTime(%v) = %v, want %v", test.args, value, test.expected)
-			}
-		})
-	}
-
-	for name, args := range map[string][]runtime.Value{
-		"missing": nil,
-		"extra":   {runtime.NewInt(1), runtime.NewString("s"), runtime.True},
-	} {
-		t.Run(name, func(t *testing.T) {
-			if _, err := toDateTime(t.Context(), args...); !errors.Is(err, runtime.ErrInvalidArgumentNumber) {
-				t.Fatalf("toDateTime(%v) error = %v, want ErrInvalidArgumentNumber", args, err)
+				t.Fatalf("toDateTime2(%v, %v) = %v, want %v", test.value, test.unit, value, test.expected)
 			}
 		})
 	}
@@ -95,10 +82,10 @@ func TestToDateTimeRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !functions.Var().Has("TO_DATETIME") {
-		t.Fatal("TO_DATETIME is not registered as variadic")
+	if functions.Var().Has("TO_DATETIME") {
+		t.Fatal("TO_DATETIME unexpectedly remains registered as variadic")
 	}
-	if functions.A1().Has("TO_DATETIME") {
-		t.Fatal("TO_DATETIME unexpectedly remains registered as fixed arity")
+	if !functions.A1().Has("TO_DATETIME") || !functions.A2().Has("TO_DATETIME") {
+		t.Fatal("TO_DATETIME is not registered at arities 1 and 2")
 	}
 }

--- a/test/benchmarks/bench_stdlib_overload_test.go
+++ b/test/benchmarks/bench_stdlib_overload_test.go
@@ -1,0 +1,24 @@
+package benchmarks_test
+
+import "testing"
+
+const (
+	trimDefaultQuery = `RETURN TRIM("  value  ")`
+	trimCharsQuery   = `RETURN TRIM("xxvaluexx", "x")`
+)
+
+func BenchmarkStdlibTrimDefault_O0(b *testing.B) {
+	RunBenchmarkO0(b, trimDefaultQuery)
+}
+
+func BenchmarkStdlibTrimDefault_O1(b *testing.B) {
+	RunBenchmarkO1(b, trimDefaultQuery)
+}
+
+func BenchmarkStdlibTrimChars_O0(b *testing.B) {
+	RunBenchmarkO0(b, trimCharsQuery)
+}
+
+func BenchmarkStdlibTrimChars_O1(b *testing.B) {
+	RunBenchmarkO1(b, trimCharsQuery)
+}

--- a/test/integration/vm/vm_duration_test.go
+++ b/test/integration/vm/vm_duration_test.go
@@ -163,12 +163,22 @@ func TestDateTimeOperators(t *testing.T) {
 			Contains: []string{"out of range", "supported DateTime range", ":1:8"},
 		}),
 		spec.NewSpec(`RETURN TO_DATETIME()`).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-			Message:  "invalid number of arguments",
-			Contains: []string{"expected number of arguments 1-2", ":1:8"},
+			Message: "invalid number of arguments",
+			Contains: []string{
+				"wrong number of arguments in call to TO_DATETIME",
+				"Note: TO_DATETIME expects 1 or 2 arguments, but got 0",
+				"Hint: Pass 1 or 2 arguments to TO_DATETIME",
+				":1:8",
+			},
 		}),
 		spec.NewSpec(`RETURN TO_DATETIME(1, "s", true)`).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{
-			Message:  "invalid number of arguments",
-			Contains: []string{"expected number of arguments 1-2", ":1:8"},
+			Message: "invalid number of arguments",
+			Contains: []string{
+				"wrong number of arguments in call to TO_DATETIME",
+				"Note: TO_DATETIME expects 1 or 2 arguments, but got 3",
+				"Hint: Pass 1 or 2 arguments to TO_DATETIME",
+				":1:8",
+			},
 		}),
 		Error(`RETURN TO_DATETIME("invalid")`),
 		spec.NewSpec(`RETURN TO_DATETIME("2026-08-01T12:00:00Z") - "tomorrow"`).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{

--- a/test/integration/vm/vm_stdlib_overload_test.go
+++ b/test/integration/vm/vm_stdlib_overload_test.go
@@ -1,0 +1,50 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/test/spec"
+	. "github.com/MontFerret/ferret/v2/test/spec/exec"
+)
+
+func TestStdlibArityOverloads(t *testing.T) {
+	RunSpecs(t, []spec.Spec{
+		S(`RETURN RAND() >= 0`, true, "zero-argument overload"),
+		S(`RETURN TRIM(" value ")`, "value", "one-argument overload"),
+		S(`RETURN TRIM("xxvaluexx", "x")`, "value", "two-argument overload"),
+		S(`RETURN SUBSTITUTE("aba", "a", "x")`, "xbx", "three-argument overload"),
+		S(`RETURN SUBSTITUTE("aaa", "a", "x", 2)`, "xxa", "four-argument overload"),
+		S(`RETURN TO_DATETIME("1970-01-01T00:00:00Z") == TO_DATETIME(0, "s")`, true, "conversion overloads"),
+		Nil(`RETURN T::EQ(1, 1)`, "positive assertion overload"),
+		Nil(`RETURN T::EQ(1, 1, "unused")`, "positive assertion message overload"),
+		Nil(`RETURN T::NOT::EQ(1, 2)`, "negative assertion overload"),
+		Array(`RETURN REGEX_SPLIT("a,b,c", ",", 2, TRUE)`, []any{"a", "b,c"}, "preserve four-argument regex split behavior"),
+	})
+}
+
+func TestStdlibOverloadArityErrors(t *testing.T) {
+	RunSpecs(t, []spec.Spec{
+		spec.NewSpec(`RETURN TRIM()`, "bounded overload rejects missing arguments").Expect().ExecError(
+			ShouldBeRuntimeError,
+			&ExpectedRuntimeError{
+				Message: "invalid number of arguments",
+				Contains: []string{
+					"wrong number of arguments in call to TRIM",
+					"Note: TRIM expects 1 or 2 arguments, but got 0",
+					"Hint: Pass 1 or 2 arguments to TRIM",
+				},
+			},
+		),
+		spec.NewSpec(`RETURN SLICE([1, 2], 0, 1, TRUE)`, "slice rejects undocumented extra arguments").Expect().ExecError(
+			ShouldBeRuntimeError,
+			&ExpectedRuntimeError{
+				Message: "invalid number of arguments",
+				Contains: []string{
+					"wrong number of arguments in call to SLICE",
+					"Note: SLICE expects 2 or 3 arguments, but got 4",
+					"Hint: Pass 2 or 3 arguments to SLICE",
+				},
+			},
+		),
+	})
+}

--- a/test/integration/vm/vm_stdlib_overload_test.go
+++ b/test/integration/vm/vm_stdlib_overload_test.go
@@ -20,6 +20,8 @@ func TestStdlibArityOverloads(t *testing.T) {
 		Nil(`RETURN T::NOT::EQ(1, 2)`, "negative assertion overload"),
 		Array(`RETURN REGEX_SPLIT("a,b,c", ",", 2, TRUE)`, []any{"a", "b,c"}, "preserve four-argument regex split behavior"),
 		Array(`RETURN [FIND_FIRST("foobarbaz", "ba", 4, 9), FIND_LAST("foobarbaz", "ba", 4, 6)]`, []any{6, -1}, "four-argument string searches honor start and end"),
+		Array(`RETURN [FIND_FIRST("éaéa", "a"), FIND_FIRST("éaéa", "a", 2), FIND_LAST("éaéa", "a"), FIND_LAST("éaéa", "a", 2)]`, []any{1, 3, 3, 3}, "string searches return Unicode character positions"),
+		Array(`RETURN [FIND_FIRST("éaéa", "a", -10, 100), FIND_LAST("éaéa", "a", -10, 100), FIND_FIRST("éaéa", "a", 3, 1), FIND_LAST("éaéa", "a", 3, 1), FIND_FIRST("éa", "", 1, 100), FIND_LAST("éa", "", 1, 100)]`, []any{1, 3, -1, -1, 1, 2}, "string searches clamp character bounds"),
 		Array(`RETURN RANGE(-3, -1)`, []any{-3, -2, -1}, "two-argument range supports negative endpoints"),
 		Array(`RETURN RANGE(3, 1, -1)`, []any{3, 2, 1}, "three-argument range supports descending steps"),
 	})

--- a/test/integration/vm/vm_stdlib_overload_test.go
+++ b/test/integration/vm/vm_stdlib_overload_test.go
@@ -19,6 +19,9 @@ func TestStdlibArityOverloads(t *testing.T) {
 		Nil(`RETURN T::EQ(1, 1, "unused")`, "positive assertion message overload"),
 		Nil(`RETURN T::NOT::EQ(1, 2)`, "negative assertion overload"),
 		Array(`RETURN REGEX_SPLIT("a,b,c", ",", 2, TRUE)`, []any{"a", "b,c"}, "preserve four-argument regex split behavior"),
+		Array(`RETURN [FIND_FIRST("foobarbaz", "ba", 4, 9), FIND_LAST("foobarbaz", "ba", 4, 6)]`, []any{6, -1}, "four-argument string searches honor start and end"),
+		Array(`RETURN RANGE(-3, -1)`, []any{-3, -2, -1}, "two-argument range supports negative endpoints"),
+		Array(`RETURN RANGE(3, 1, -1)`, []any{3, 2, 1}, "three-argument range supports descending steps"),
 	})
 }
 
@@ -43,6 +46,15 @@ func TestStdlibOverloadArityErrors(t *testing.T) {
 					"wrong number of arguments in call to SLICE",
 					"Note: SLICE expects 2 or 3 arguments, but got 4",
 					"Hint: Pass 2 or 3 arguments to SLICE",
+				},
+			},
+		),
+		spec.NewSpec(`RETURN RANGE(1, 3, 0)`, "range rejects a zero step").Expect().ExecError(
+			ShouldBeRuntimeError,
+			&ExpectedRuntimeError{
+				Contains: []string{
+					"argument 3 is invalid",
+					"Note: argument 3: step must not be zero",
 				},
 			},
 		),


### PR DESCRIPTION
This pull request refactors the handling of variadic arguments for several standard library functions in the `arrays`, `datetime`, `io/fs`, and `math` packages. The main improvement is splitting variadic functions into fixed-arity versions, which are then registered for specific argument counts. This enhances argument validation, error handling, and Go interop, while also simplifying the codebase and function registration.

### Arrays package improvements

* Refactored `Append`, `Flatten`, `Position`, `Push`, `RemoveValue`, `Slice`, and `Unshift` to use fixed-arity helper functions (`append2`, `append3`, etc.), improving argument handling and code clarity. Updated function registration in `lib.go` to map fixed-arity versions accordingly. [[1]](diffhunk://#diff-f798b243631b6a585125714f2cc82b9e0cc16811bfd63e8b99dfd1d919fa5557L20-R40) [[2]](diffhunk://#diff-19aad949a17919415a4fa011db8bd93ed4f5b65e66dfad494ddda7ae3a860359L22-R34) [[3]](diffhunk://#diff-0a7cf09bccb17a3a58697e0857d8a974a0dded6c17c1d2c9a835e8f3ef7066adL19-R43) [[4]](diffhunk://#diff-6b1e3ec36f850d702bf099b78a95024bb4fbd2b3e51de197d2f67321fa993818R17-R24) [[5]](diffhunk://#diff-08d829c88d48f6a4f8c044e6136f8d928e591ba735b43f7e78d87a32efe178bfL20-R46) [[6]](diffhunk://#diff-0a30e0f620d826a82f21609628a742cfa491a854c690633b683aa3700adfaf66L15-R46) [[7]](diffhunk://#diff-cded3171b419ecac8abf982caeefcfd42b7853798bc9d23311977593a944a0deL19-R39) [[8]](diffhunk://#diff-d9eed7f61c9d757daef2d8b881dea5320589c4153c2c99a35a6113eebd079491R13) [[9]](diffhunk://#diff-d9eed7f61c9d757daef2d8b881dea5320589c4153c2c99a35a6113eebd079491R22-R46)
* Added or updated tests to ensure Go compatibility and correct argument validation, especially for extra arguments.

### Datetime package improvements

* Refactored `Date`, `DateCompare`, and `DateDiff` into fixed-arity helper functions, improving clarity and error handling. Updated registration in `lib.go` to map arity-specific versions. [[1]](diffhunk://#diff-3a779b00f41c55499b44171f91e878e94e8c2848522f0fdc7bf5e484cf738dffL14-R42) [[2]](diffhunk://#diff-b865b6ee6a236961125f0d8bb7f24c0e2572df0011426e534de306d8301d3c20L15-R38) [[3]](diffhunk://#diff-3e05939754c3c00f5114119a976369780c049837fadf7150121a454df2259328L17-R54) [[4]](diffhunk://#diff-cff7153380a594a34d75f8b45794a363bbf39102376e2476399952760155b4afR12) [[5]](diffhunk://#diff-cff7153380a594a34d75f8b45794a363bbf39102376e2476399952760155b4afR27-R38)

### IO/FS package improvements

* Refactored the `Write` function to use fixed-arity helpers (`write2`, `write3`), improving argument parsing and error handling. Updated registration to use arity-specific versions. [[1]](diffhunk://#diff-ef73a4bdd25b95b080f70743b17357d1f8bc6c952ee59fc72cbcb451289a7f9cL25-R56) [[2]](diffhunk://#diff-8773d139bba7c279b68474bbdc1d83da9f937e02e3ec10644b96fc0777cb7fe0L15-R19)

### Math package update

* Registered a new zero-argument function `RAND` in the math library.