### PR TITLE
feat: add semantic recorder for source-level metadata capture during compilation

### DIFF
--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -108,7 +108,8 @@ func (a *Analysis) FunctionParameters(function SymbolID) []Symbol {
 	return out
 }
 
-// SymbolAt returns the symbol selected or referenced at offset.
+// SymbolAt returns the symbol whose declaration selection or reference contains offset.
+// The offset is a zero-based UTF-8 byte offset into the analyzed source.
 func (a *Analysis) SymbolAt(offset int) (Symbol, bool) {
 	if !a.validOffset(offset) {
 		return Symbol{}, false
@@ -134,7 +135,33 @@ func (a *Analysis) SymbolAt(offset int) (Symbol, bool) {
 	return a.Symbol(found)
 }
 
-// CallAt returns the narrowest call containing offset.
+// ReferenceAt returns the narrowest semantic reference containing offset.
+// Declaration selection spans are not references. The offset is a zero-based
+// UTF-8 byte offset into the analyzed source.
+func (a *Analysis) ReferenceAt(offset int) (Reference, bool) {
+	if !a.validOffset(offset) {
+		return Reference{}, false
+	}
+
+	best := source.Span{}
+	var found Reference
+	ok := false
+
+	for _, reference := range a.data.references {
+		if spanContains(reference.Span, offset) && narrowerSpan(reference.Span, best) {
+			found = reference
+			best = reference.Span
+			ok = true
+		}
+	}
+
+	return found, ok
+}
+
+// CallAt returns the narrowest call whose complete Call.Span contains offset.
+// The offset may be inside the callee or any argument. Consumers that need to
+// detect the callee specifically should test the offset against Call.CalleeSpan.
+// The offset is a zero-based UTF-8 byte offset into the analyzed source.
 func (a *Analysis) CallAt(offset int) (Call, bool) {
 	if !a.validOffset(offset) {
 		return Call{}, false
@@ -159,6 +186,7 @@ func (a *Analysis) CallAt(offset int) (Call, bool) {
 }
 
 // TypeAt returns the narrowest expression type fact containing offset.
+// The offset is a zero-based UTF-8 byte offset into the analyzed source.
 func (a *Analysis) TypeAt(offset int) (TypeFact, bool) {
 	if !a.validOffset(offset) {
 		return TypeFact{}, false
@@ -180,6 +208,7 @@ func (a *Analysis) TypeAt(offset int) (TypeFact, bool) {
 }
 
 // VisibleSymbols returns source-visible symbols active at offset after lexical shadowing.
+// The offset is a zero-based UTF-8 byte offset into the analyzed source.
 func (a *Analysis) VisibleSymbols(offset int) []Symbol {
 	if !a.validOffset(offset) {
 		return nil

--- a/pkg/compiler/analysis.go
+++ b/pkg/compiler/analysis.go
@@ -1,0 +1,253 @@
+package compiler
+
+import (
+	"sort"
+
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+// Analysis is an immutable semantic snapshot produced by Compiler.Analyze.
+// Its accessors return defensive copies.
+type Analysis struct {
+	data analysisData
+}
+
+func newAnalysis(data analysisData) *Analysis {
+	return &Analysis{data: data}
+}
+
+// Symbols returns all source-visible symbols in deterministic analysis-local ID order.
+func (a *Analysis) Symbols() []Symbol {
+	if a == nil {
+		return nil
+	}
+
+	return append([]Symbol(nil), a.data.symbols...)
+}
+
+// Symbol returns the symbol with the analysis-local ID.
+func (a *Analysis) Symbol(id SymbolID) (Symbol, bool) {
+	if a == nil || id == 0 || int(id) > len(a.data.symbols) {
+		return Symbol{}, false
+	}
+
+	return a.data.symbols[int(id)-1], true
+}
+
+// References returns all resolved references in source order.
+func (a *Analysis) References() []Reference {
+	if a == nil {
+		return nil
+	}
+
+	return append([]Reference(nil), a.data.references...)
+}
+
+// ReferencesTo returns references resolved to symbol in source order.
+func (a *Analysis) ReferencesTo(symbol SymbolID) []Reference {
+	if a == nil || symbol == 0 {
+		return nil
+	}
+
+	out := make([]Reference, 0)
+	for _, reference := range a.data.references {
+		if reference.Symbol == symbol {
+			out = append(out, reference)
+		}
+	}
+
+	return out
+}
+
+// Calls returns all resolved calls in source order.
+func (a *Analysis) Calls() []Call {
+	if a == nil {
+		return nil
+	}
+
+	out := make([]Call, len(a.data.calls))
+	for i := range a.data.calls {
+		out[i] = cloneCall(a.data.calls[i])
+	}
+
+	return out
+}
+
+// Diagnostics returns deep copies of all source diagnostics in compiler order.
+func (a *Analysis) Diagnostics() []*diagnostics.Diagnostic {
+	if a == nil {
+		return nil
+	}
+
+	return cloneDiagnostics(a.data.diagnostics)
+}
+
+// TypeFacts returns all compiler-established expression facts in source order.
+func (a *Analysis) TypeFacts() []TypeFact {
+	if a == nil {
+		return nil
+	}
+
+	return append([]TypeFact(nil), a.data.typeFacts...)
+}
+
+// FunctionParameters returns the declared parameters for a UDF symbol.
+func (a *Analysis) FunctionParameters(function SymbolID) []Symbol {
+	if a == nil || function == 0 {
+		return nil
+	}
+
+	out := make([]Symbol, 0)
+	for i, symbol := range a.data.symbols {
+		if symbol.Kind == SymbolKindFunctionParameter && a.data.symbolMetadata[i].Function == function {
+			out = append(out, symbol)
+		}
+	}
+
+	return out
+}
+
+// SymbolAt returns the symbol selected or referenced at offset.
+func (a *Analysis) SymbolAt(offset int) (Symbol, bool) {
+	if !a.validOffset(offset) {
+		return Symbol{}, false
+	}
+
+	best := source.Span{}
+	var found SymbolID
+
+	for _, symbol := range a.data.symbols {
+		if spanContains(symbol.SelectionSpan, offset) && narrowerSpan(symbol.SelectionSpan, best) {
+			found = symbol.ID
+			best = symbol.SelectionSpan
+		}
+	}
+
+	for _, reference := range a.data.references {
+		if spanContains(reference.Span, offset) && narrowerSpan(reference.Span, best) {
+			found = reference.Symbol
+			best = reference.Span
+		}
+	}
+
+	return a.Symbol(found)
+}
+
+// CallAt returns the narrowest call containing offset.
+func (a *Analysis) CallAt(offset int) (Call, bool) {
+	if !a.validOffset(offset) {
+		return Call{}, false
+	}
+
+	best := source.Span{}
+	var found *Call
+
+	for i := range a.data.calls {
+		call := &a.data.calls[i]
+		if spanContains(call.Span, offset) && narrowerSpan(call.Span, best) {
+			found = call
+			best = call.Span
+		}
+	}
+
+	if found == nil {
+		return Call{}, false
+	}
+
+	return cloneCall(*found), true
+}
+
+// TypeAt returns the narrowest expression type fact containing offset.
+func (a *Analysis) TypeAt(offset int) (TypeFact, bool) {
+	if !a.validOffset(offset) {
+		return TypeFact{}, false
+	}
+
+	best := source.Span{}
+	var found TypeFact
+	ok := false
+
+	for _, fact := range a.data.typeFacts {
+		if spanContains(fact.Span, offset) && narrowerSpan(fact.Span, best) {
+			found = fact
+			best = fact.Span
+			ok = true
+		}
+	}
+
+	return found, ok
+}
+
+// VisibleSymbols returns source-visible symbols active at offset after lexical shadowing.
+func (a *Analysis) VisibleSymbols(offset int) []Symbol {
+	if !a.validOffset(offset) {
+		return nil
+	}
+
+	type candidate struct {
+		symbol Symbol
+		depth  int
+	}
+
+	candidates := make([]candidate, 0)
+	for i, symbol := range a.data.symbols {
+		metadata := a.data.symbolMetadata[i]
+		if offset < metadata.Activation || !a.scopeContains(metadata.Scope, offset) {
+			continue
+		}
+
+		candidates = append(candidates, candidate{symbol: symbol, depth: a.scope(metadata.Scope).Depth})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].depth != candidates[j].depth {
+			return candidates[i].depth > candidates[j].depth
+		}
+
+		return candidates[i].symbol.ID > candidates[j].symbol.ID
+	})
+
+	seen := make(map[string]struct{}, len(candidates))
+	out := make([]Symbol, 0, len(candidates))
+	for _, candidate := range candidates {
+		key := semanticNamespace(candidate.symbol.Kind) + "\x00" + candidate.symbol.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		seen[key] = struct{}{}
+		out = append(out, candidate.symbol)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+
+	return out
+}
+
+func (a *Analysis) validOffset(offset int) bool {
+	return a != nil && offset >= 0 && offset <= a.data.sourceLength
+}
+
+func (a *Analysis) scope(id analysisScopeID) analysisScope {
+	if a == nil || id == 0 || int(id) > len(a.data.scopes) {
+		return analysisScope{}
+	}
+
+	return a.data.scopes[int(id)-1]
+}
+
+func (a *Analysis) scopeContains(id analysisScopeID, offset int) bool {
+	scope := a.scope(id)
+	if scope.ID == 0 {
+		return false
+	}
+
+	if scope.Parent == 0 && offset == a.data.sourceLength {
+		return true
+	}
+
+	return spanContains(scope.Span, offset)
+}

--- a/pkg/compiler/analysis_build.go
+++ b/pkg/compiler/analysis_build.go
@@ -1,0 +1,172 @@
+package compiler
+
+import (
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func buildAnalysis(
+	src *source.Source,
+	snapshot internal.SemanticSnapshot,
+	errors *parserd.ErrorHandler,
+) *Analysis {
+	data := analysisData{sourceLength: sourceLength(src)}
+	data.symbols = make([]Symbol, len(snapshot.Symbols))
+	data.symbolMetadata = make([]analysisSymbolMetadata, len(snapshot.Symbols))
+
+	for i, symbol := range snapshot.Symbols {
+		data.symbols[i] = Symbol{
+			ID:              SymbolID(symbol.ID),
+			Name:            symbol.Name,
+			Kind:            publicSymbolKind(symbol.Kind),
+			Type:            publicValueType(symbol.Type),
+			DeclarationSpan: symbol.Declaration,
+			SelectionSpan:   symbol.Selection,
+			Mutable:         symbol.Mutable,
+			HasDeclaration:  symbol.HasDeclaration,
+		}
+		data.symbolMetadata[i] = analysisSymbolMetadata{
+			Function:   SymbolID(symbol.Function),
+			Scope:      analysisScopeID(symbol.Scope),
+			Activation: symbol.Activation,
+		}
+	}
+
+	data.references = make([]Reference, len(snapshot.References))
+	for i, reference := range snapshot.References {
+		data.references[i] = Reference{Symbol: SymbolID(reference.Symbol), Span: reference.Span}
+	}
+
+	data.calls = make([]Call, len(snapshot.Calls))
+	for i, call := range snapshot.Calls {
+		data.calls[i] = Call{
+			Target:        SymbolID(call.Target),
+			Name:          call.Name,
+			Identity:      call.Identity,
+			Kind:          publicCallKind(call.Kind),
+			ResultType:    publicValueType(call.Type),
+			Span:          call.Span,
+			CalleeSpan:    call.CalleeSpan,
+			ArgumentSpans: append([]source.Span(nil), call.ArgumentSpans...),
+		}
+	}
+
+	data.typeFacts = make([]TypeFact, len(snapshot.TypeFacts))
+	for i, fact := range snapshot.TypeFacts {
+		data.typeFacts[i] = TypeFact{Span: fact.Span, Type: publicValueType(fact.Type)}
+	}
+
+	data.scopes = make([]analysisScope, len(snapshot.Scopes))
+	for i, scope := range snapshot.Scopes {
+		data.scopes[i] = analysisScope{
+			ID:     analysisScopeID(scope.ID),
+			Parent: analysisScopeID(scope.Parent),
+			Span:   scope.Span,
+			Depth:  scope.Depth,
+		}
+	}
+
+	data.diagnostics = diagnosticsFromHandler(src, errors)
+
+	return newAnalysis(data)
+}
+
+func diagnosticsFromHandler(src *source.Source, handler *parserd.ErrorHandler) []*diagnostics.Diagnostic {
+	if handler == nil || handler.Errors() == nil {
+		return nil
+	}
+
+	out := make([]*diagnostics.Diagnostic, 0, handler.Errors().Size())
+	byteOffsets := analysisByteOffsets(src)
+
+	for _, diagnostic := range handler.Errors().Errors() {
+		cloned := cloneDiagnostic(diagnostic)
+		if cloned != nil {
+			for i := range cloned.Spans {
+				cloned.Spans[i].Span = analysisByteSpan(byteOffsets, cloned.Spans[i].Span)
+			}
+		}
+
+		out = append(out, cloned)
+	}
+
+	return out
+}
+
+func sourceLength(src *source.Source) int {
+	if src == nil {
+		return 0
+	}
+
+	return len(src.Content())
+}
+
+func publicSymbolKind(kind internal.SemanticSymbolKind) SymbolKind {
+	switch kind {
+	case internal.SemanticSymbolBinding:
+		return SymbolKindBinding
+	case internal.SemanticSymbolFunctionParameter:
+		return SymbolKindFunctionParameter
+	case internal.SemanticSymbolUserFunction:
+		return SymbolKindUDF
+	case internal.SemanticSymbolBindParameter:
+		return SymbolKindBindParameter
+	case internal.SemanticSymbolLoopBinding:
+		return SymbolKindLoopBinding
+	case internal.SemanticSymbolMatchBinding:
+		return SymbolKindMatchBinding
+	case internal.SemanticSymbolCollectBinding:
+		return SymbolKindCollectBinding
+	case internal.SemanticSymbolNamespaceAlias:
+		return SymbolKindNamespaceAlias
+	default:
+		return 0
+	}
+}
+
+func publicCallKind(kind internal.SemanticCallKind) CallKind {
+	switch kind {
+	case internal.SemanticCallUserFunction:
+		return CallKindUDF
+	case internal.SemanticCallBuiltin:
+		return CallKindBuiltin
+	case internal.SemanticCallHost:
+		return CallKindHost
+	default:
+		return 0
+	}
+}
+
+func publicValueType(typ core.ValueType) ValueType {
+	switch typ {
+	case core.TypeUnknown:
+		return ValueTypeUnknown
+	case core.TypeNone:
+		return ValueTypeNone
+	case core.TypeInt:
+		return ValueTypeInteger
+	case core.TypeFloat:
+		return ValueTypeFloat
+	case core.TypeDuration:
+		return ValueTypeDuration
+	case core.TypeString:
+		return ValueTypeString
+	case core.TypeBool:
+		return ValueTypeBoolean
+	case core.TypeArray:
+		return ValueTypeArray
+	case core.TypeObject:
+		return ValueTypeObject
+	case core.TypeList:
+		return ValueTypeList
+	case core.TypeMap:
+		return ValueTypeMap
+	case core.TypeAny:
+		return ValueTypeAny
+	default:
+		return ValueTypeUnknown
+	}
+}

--- a/pkg/compiler/analysis_helpers.go
+++ b/pkg/compiler/analysis_helpers.go
@@ -1,0 +1,114 @@
+package compiler
+
+import (
+	"errors"
+	"unicode/utf8"
+
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func cloneCall(call Call) Call {
+	call.ArgumentSpans = append([]source.Span(nil), call.ArgumentSpans...)
+
+	return call
+}
+
+func cloneDiagnostics(values []*diagnostics.Diagnostic) []*diagnostics.Diagnostic {
+	out := make([]*diagnostics.Diagnostic, len(values))
+	for i, value := range values {
+		out[i] = cloneDiagnostic(value)
+	}
+
+	return out
+}
+
+func cloneDiagnostic(value *diagnostics.Diagnostic) *diagnostics.Diagnostic {
+	if value == nil {
+		return nil
+	}
+
+	out := *value
+	out.Spans = append([]diagnostics.ErrorSpan(nil), value.Spans...)
+
+	if value.Cause != nil {
+		if diagnostic, ok := value.Cause.(*diagnostics.Diagnostic); ok {
+			out.Cause = cloneDiagnostic(diagnostic)
+		} else {
+			out.Cause = errors.New(value.Cause.Error())
+		}
+	}
+
+	if value.Source != nil {
+		out.Source = source.New(value.Source.Name(), value.Source.Content())
+	}
+
+	return &out
+}
+
+func spanContains(span source.Span, offset int) bool {
+	return span.Start >= 0 && span.End > span.Start && offset >= span.Start && offset < span.End
+}
+
+func narrowerSpan(candidate, current source.Span) bool {
+	if current.End <= current.Start {
+		return true
+	}
+
+	return candidate.End-candidate.Start < current.End-current.Start
+}
+
+func semanticNamespace(kind SymbolKind) string {
+	switch kind {
+	case SymbolKindUDF:
+		return "function"
+	case SymbolKindNamespaceAlias:
+		return "namespace"
+	case SymbolKindBindParameter:
+		return "parameter"
+	default:
+		return "binding"
+	}
+}
+
+func analysisByteSpan(offsets []int, span source.Span) source.Span {
+	if span.Start < 0 || span.End < 0 || span.Start >= len(offsets) || span.End >= len(offsets) {
+		return span
+	}
+
+	return source.Span{Start: offsets[span.Start], End: offsets[span.End]}
+}
+
+func analysisByteOffsets(src *source.Source) []int {
+	if src == nil {
+		return []int{0}
+	}
+
+	text := src.Content()
+	offsets := make([]int, 0, utf8.RuneCountInString(text)+1)
+
+	for offset := range text {
+		offsets = append(offsets, offset)
+	}
+
+	offsets = append(offsets, len(text))
+
+	return offsets
+}
+
+func analysisError(analysis *Analysis) error {
+	if analysis == nil {
+		return nil
+	}
+
+	values := analysis.Diagnostics()
+	if len(values) == 0 {
+		return nil
+	}
+
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	return diagnostics.NewDiagnosticsOf(values)
+}

--- a/pkg/compiler/analysis_test.go
+++ b/pkg/compiler/analysis_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	diagnosticspkg "github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/source"
@@ -103,6 +104,144 @@ RETURN [LENGTH([value]), html::PARSE("<p/>")]`
 	fact, ok := analysis.TypeAt(strings.LastIndex(query, "[value]"))
 	if !ok || fact.Type != ValueTypeArray {
 		t.Fatalf("TypeAt([value]) = %+v, %t", fact, ok)
+	}
+}
+
+func TestAnalysisCallAtUsesNarrowestEnclosingCall(t *testing.T) {
+	query := `LET value = 1
+RETURN OUTER(INNER(value))`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outer := requireAnalysisCall(t, analysis.Calls(), "OUTER")
+	inner := requireAnalysisCall(t, analysis.Calls(), "INNER")
+
+	call, ok := analysis.CallAt(outer.CalleeSpan.Start)
+	if !ok || call.Name != "OUTER" {
+		t.Fatalf("CallAt(OUTER) = %+v, %t", call, ok)
+	}
+
+	call, ok = analysis.CallAt(inner.CalleeSpan.Start)
+	if !ok || call.Name != "INNER" {
+		t.Fatalf("CallAt(INNER) = %+v, %t", call, ok)
+	}
+
+	argumentOffset := strings.LastIndex(query, "value")
+	call, ok = analysis.CallAt(argumentOffset)
+	if !ok || call.Name != "INNER" {
+		t.Fatalf("CallAt(inner argument) = %+v, %t", call, ok)
+	}
+	if spanContains(inner.CalleeSpan, argumentOffset) {
+		t.Fatal("inner argument unexpectedly falls within Call.CalleeSpan")
+	}
+
+	call, ok = analysis.CallAt(inner.Span.End)
+	if !ok || call.Name != "OUTER" {
+		t.Fatalf("CallAt(inner end) = %+v, %t, want enclosing OUTER call", call, ok)
+	}
+
+	if _, ok := analysis.CallAt(outer.Span.End); ok {
+		t.Fatal("CallAt matched the half-open end of the outer call")
+	}
+}
+
+func TestAnalysisReferenceAtBasicAndUTF8ByteOffsets(t *testing.T) {
+	query := `LET prefix = "é"
+LET value = 42
+RETURN value`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	value := requireAnalysisSymbol(t, analysis, "value", SymbolKindBinding)
+	declarationOffset := strings.Index(query, "value")
+	if _, ok := analysis.ReferenceAt(declarationOffset); ok {
+		t.Fatal("ReferenceAt matched a declaration selection")
+	}
+
+	useOffset := strings.LastIndex(query, "value")
+	if useOffset == utf8.RuneCountInString(query[:useOffset]) {
+		t.Fatal("test source does not distinguish byte and rune offsets")
+	}
+
+	reference, ok := analysis.ReferenceAt(useOffset)
+	if !ok || reference.Symbol != value.ID || reference.Span.Start != useOffset {
+		t.Fatalf("ReferenceAt(value) = %+v, %t", reference, ok)
+	}
+
+	if _, ok := analysis.ReferenceAt(reference.Span.End); ok {
+		t.Fatal("ReferenceAt matched the half-open end of a reference")
+	}
+}
+
+func TestAnalysisReferenceAtPreservesLexicalIdentity(t *testing.T) {
+	query := `LET shared = 1
+FUNC outer(param) {
+  LET shared = param
+  FUNC inner() => shared
+  RETURN inner()
+}
+RETURN [outer(shared), shared]`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shared := analysisSymbolsNamed(analysis.Symbols(), "shared", SymbolKindBinding)
+	if len(shared) != 2 {
+		t.Fatalf("shared symbols = %+v, want outer and shadowing declarations", shared)
+	}
+
+	outerShared := shared[0]
+	innerShared := shared[1]
+	param := requireAnalysisSymbol(t, analysis, "param", SymbolKindFunctionParameter)
+	inner := requireAnalysisSymbol(t, analysis, "inner", SymbolKindUDF)
+
+	paramUse := strings.Index(query, "shared = param") + len("shared = ")
+	assertAnalysisReferenceSymbol(t, analysis, paramUse, param.ID)
+
+	capturedUse := strings.Index(query, "=> shared") + len("=> ")
+	assertAnalysisReferenceSymbol(t, analysis, capturedUse, innerShared.ID)
+
+	udfCall := strings.LastIndex(query, "inner()")
+	assertAnalysisReferenceSymbol(t, analysis, udfCall, inner.ID)
+
+	outerUse := strings.Index(query, "outer(shared)") + len("outer(")
+	assertAnalysisReferenceSymbol(t, analysis, outerUse, outerShared.ID)
+}
+
+func TestAnalysisReferenceAtUsesNarrowestValidSpan(t *testing.T) {
+	analysis := newAnalysis(analysisData{
+		references: []Reference{
+			{Symbol: 1, Span: source.Span{Start: 1, End: 8}},
+			{Symbol: 2, Span: source.Span{Start: 3, End: 6}},
+			{Symbol: 3, Span: source.Span{}},
+		},
+		sourceLength: 8,
+	})
+
+	reference, ok := analysis.ReferenceAt(1)
+	if !ok || reference.Symbol != 1 {
+		t.Fatalf("ReferenceAt(first byte) = %+v, %t", reference, ok)
+	}
+
+	reference, ok = analysis.ReferenceAt(3)
+	if !ok || reference.Symbol != 2 {
+		t.Fatalf("ReferenceAt(overlap) = %+v, %t", reference, ok)
+	}
+
+	if _, ok := analysis.ReferenceAt(0); ok {
+		t.Fatal("ReferenceAt matched a zero-length synthetic span")
+	}
+
+	if _, ok := analysis.ReferenceAt(8); ok {
+		t.Fatal("ReferenceAt matched the half-open end of the widest reference")
 	}
 }
 
@@ -448,6 +587,15 @@ func requireAnalysisCall(t *testing.T, calls []Call, name string) Call {
 	t.Fatalf("call %q not found in %+v", name, calls)
 
 	return Call{}
+}
+
+func assertAnalysisReferenceSymbol(t *testing.T, analysis *Analysis, offset int, want SymbolID) {
+	t.Helper()
+
+	reference, ok := analysis.ReferenceAt(offset)
+	if !ok || reference.Symbol != want {
+		t.Fatalf("ReferenceAt(%d) = %+v, %t, want symbol %d", offset, reference, ok, want)
+	}
 }
 
 func assertAnalysisSpanText(t *testing.T, query string, span source.Span, want string) {

--- a/pkg/compiler/analysis_test.go
+++ b/pkg/compiler/analysis_test.go
@@ -1,0 +1,489 @@
+package compiler
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	diagnosticspkg "github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestAnalyzeRecordsPublicSemanticsAndExactSpans(t *testing.T) {
+	query := `USE WEB::HTML AS html
+LET outer = 1
+FUNC add(p) => outer + p
+LET value = add(@input)
+RETURN [LENGTH([value]), html::PARSE("<p/>")]`
+
+	analysis, err := New().Analyze(source.New("analysis.fql", query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outer := requireAnalysisSymbol(t, analysis, "outer", SymbolKindBinding)
+	assertAnalysisSpanText(t, query, outer.DeclarationSpan, "LET outer = 1")
+	assertAnalysisSpanText(t, query, outer.SelectionSpan, "outer")
+	if outer.Type != ValueTypeInteger {
+		t.Fatalf("outer type = %v, want integer", outer.Type)
+	}
+
+	value := requireAnalysisSymbol(t, analysis, "value", SymbolKindBinding)
+	assertAnalysisSpanText(t, query, value.DeclarationSpan, "LET value = add(@input)")
+	assertAnalysisSpanText(t, query, value.SelectionSpan, "value")
+
+	add := requireAnalysisSymbol(t, analysis, "add", SymbolKindUDF)
+	assertAnalysisSpanText(t, query, add.DeclarationSpan, "FUNC add(p) => outer + p")
+	assertAnalysisSpanText(t, query, add.SelectionSpan, "add")
+
+	params := analysis.FunctionParameters(add.ID)
+	if len(params) != 1 || params[0].Name != "p" || params[0].Kind != SymbolKindFunctionParameter {
+		t.Fatalf("parameters = %+v, want p", params)
+	}
+	assertAnalysisSpanText(t, query, params[0].SelectionSpan, "p")
+
+	bind := requireAnalysisSymbol(t, analysis, "input", SymbolKindBindParameter)
+	if bind.HasDeclaration || bind.DeclarationSpan != (source.Span{}) || bind.SelectionSpan != (source.Span{}) {
+		t.Fatalf("bind parameter has fabricated declaration: %+v", bind)
+	}
+	bindRefs := analysis.ReferencesTo(bind.ID)
+	if len(bindRefs) != 1 {
+		t.Fatalf("bind parameter references = %+v", bindRefs)
+	}
+	assertAnalysisSpanText(t, query, bindRefs[0].Span, "@input")
+
+	alias := requireAnalysisSymbol(t, analysis, "html", SymbolKindNamespaceAlias)
+	assertAnalysisSpanText(t, query, alias.SelectionSpan, "html")
+	aliasRefs := analysis.ReferencesTo(alias.ID)
+	if len(aliasRefs) != 1 {
+		t.Fatalf("alias references = %+v", aliasRefs)
+	}
+	assertAnalysisSpanText(t, query, aliasRefs[0].Span, "html")
+
+	calls := analysis.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("calls = %+v, want 3", calls)
+	}
+
+	udfCall := requireAnalysisCall(t, calls, "add")
+	if udfCall.Kind != CallKindUDF || udfCall.Target != add.ID || udfCall.Identity != "" || udfCall.ResultType != ValueTypeAny {
+		t.Fatalf("UDF call = %+v", udfCall)
+	}
+	assertAnalysisSpanText(t, query, udfCall.Span, "add(@input)")
+	assertAnalysisSpanText(t, query, udfCall.CalleeSpan, "add")
+	if len(udfCall.ArgumentSpans) != 1 {
+		t.Fatalf("UDF arguments = %+v", udfCall.ArgumentSpans)
+	}
+	assertAnalysisSpanText(t, query, udfCall.ArgumentSpans[0], "@input")
+
+	builtinCall := requireAnalysisCall(t, calls, "LENGTH")
+	if builtinCall.Kind != CallKindBuiltin || builtinCall.Target != 0 || builtinCall.Identity != "length" {
+		t.Fatalf("builtin call = %+v", builtinCall)
+	}
+	assertAnalysisSpanText(t, query, builtinCall.CalleeSpan, "LENGTH")
+
+	hostCall := requireAnalysisCall(t, calls, "WEB::HTML::PARSE")
+	if hostCall.Kind != CallKindHost || hostCall.Target != 0 || hostCall.Identity != "web::html::parse" || hostCall.ResultType != ValueTypeAny {
+		t.Fatalf("host call = %+v", hostCall)
+	}
+	assertAnalysisSpanText(t, query, hostCall.CalleeSpan, "html::PARSE")
+
+	valueAt, ok := analysis.SymbolAt(strings.LastIndex(query, "value"))
+	if !ok || valueAt.ID != value.ID {
+		t.Fatalf("SymbolAt(value) = %+v, %t", valueAt, ok)
+	}
+
+	callAt, ok := analysis.CallAt(strings.Index(query, "<p/>"))
+	if !ok || callAt.Identity != "web::html::parse" {
+		t.Fatalf("CallAt(<p/>) = %+v, %t", callAt, ok)
+	}
+
+	fact, ok := analysis.TypeAt(strings.LastIndex(query, "[value]"))
+	if !ok || fact.Type != ValueTypeArray {
+		t.Fatalf("TypeAt([value]) = %+v, %t", fact, ok)
+	}
+}
+
+func TestAnalyzeVisibilityShadowingAndBindingKinds(t *testing.T) {
+	query := `VAR x = 0
+LET {left, nested: [right]} = {left: 1, nested: [2]}
+FUNC inspect(x) {
+  RETURN FOR item, index IN [x]
+    COLLECT group = item WITH COUNT INTO count
+    RETURN MATCH group { bound => [x, group, count, bound], _ => [] }
+}
+RETURN inspect(x)`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requireAnalysisSymbol(t, analysis, "left", SymbolKindBinding)
+	requireAnalysisSymbol(t, analysis, "right", SymbolKindBinding)
+	item := requireAnalysisSymbol(t, analysis, "item", SymbolKindLoopBinding)
+	requireAnalysisSymbol(t, analysis, "index", SymbolKindLoopBinding)
+	group := requireAnalysisSymbol(t, analysis, "group", SymbolKindCollectBinding)
+	count := requireAnalysisSymbol(t, analysis, "count", SymbolKindCollectBinding)
+	bound := requireAnalysisSymbol(t, analysis, "bound", SymbolKindMatchBinding)
+
+	sourcePos := strings.Index(query, "[x]") + 1
+	if hasAnalysisSymbol(analysis.VisibleSymbols(sourcePos), item.ID) {
+		t.Fatalf("loop binding visible in its input expression: %+v", analysis.VisibleSymbols(sourcePos))
+	}
+
+	collectExprPos := strings.Index(query, "group = item") + len("group = ")
+	visibleAtCollect := analysis.VisibleSymbols(collectExprPos)
+	if !hasAnalysisSymbol(visibleAtCollect, item.ID) || hasAnalysisSymbol(visibleAtCollect, group.ID) || hasAnalysisSymbol(visibleAtCollect, count.ID) {
+		t.Fatalf("unexpected COLLECT visibility: %+v", visibleAtCollect)
+	}
+	midCollectPos := strings.Index(query, "WITH COUNT")
+	if visible := analysis.VisibleSymbols(midCollectPos); hasAnalysisSymbol(visible, group.ID) || hasAnalysisSymbol(visible, count.ID) {
+		t.Fatalf("COLLECT bindings visible before clause end: %+v", visible)
+	}
+
+	matchPos := strings.Index(query, "MATCH group") + len("MATCH ")
+	visibleAtMatch := analysis.VisibleSymbols(matchPos)
+	if !hasAnalysisSymbol(visibleAtMatch, group.ID) || !hasAnalysisSymbol(visibleAtMatch, count.ID) || hasAnalysisSymbol(visibleAtMatch, bound.ID) {
+		t.Fatalf("unexpected post-COLLECT visibility: %+v", visibleAtMatch)
+	}
+
+	boundResultPos := strings.Index(query, "[x, group, count, bound]")
+	if !hasAnalysisSymbol(analysis.VisibleSymbols(boundResultPos), bound.ID) {
+		t.Fatalf("MATCH binding is not visible in its arm result")
+	}
+
+	outerX := analysisSymbolsNamed(analysis.Symbols(), "x", SymbolKindBinding)
+	parameterX := analysisSymbolsNamed(analysis.Symbols(), "x", SymbolKindFunctionParameter)
+	if len(outerX) != 1 || len(parameterX) != 1 || outerX[0].ID == parameterX[0].ID {
+		t.Fatalf("shadowed x symbols = outer %+v, parameter %+v", outerX, parameterX)
+	}
+	if !outerX[0].Mutable || parameterX[0].Mutable {
+		t.Fatalf("mutability = outer %t, parameter %t", outerX[0].Mutable, parameterX[0].Mutable)
+	}
+
+	innerXPos := strings.Index(query, "[x]") + 1
+	innerX, ok := analysis.SymbolAt(innerXPos)
+	if !ok || innerX.ID != parameterX[0].ID {
+		t.Fatalf("inner x resolved to %+v, want parameter %+v", innerX, parameterX[0])
+	}
+
+	outerXPos := strings.LastIndex(query, "inspect(x)") + len("inspect(")
+	resolvedOuter, ok := analysis.SymbolAt(outerXPos)
+	if !ok || resolvedOuter.ID != outerX[0].ID {
+		t.Fatalf("outer x resolved to %+v, want %+v", resolvedOuter, outerX[0])
+	}
+}
+
+func TestAnalyzeCapturesResolveOriginalSymbolsAndRejectFalseIdentities(t *testing.T) {
+	query := `LET base = 1
+FUNC outer(p) {
+  LET local = p
+  FUNC middle(q) {
+    FUNC inner(r) => base + local + p + q + r
+    RETURN inner(q)
+	  }
+	  RETURN middle(local)
+	}
+RETURN outer(base)`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		kind SymbolKind
+	}{
+		{name: "base", kind: SymbolKindBinding},
+		{name: "local", kind: SymbolKindBinding},
+		{name: "p", kind: SymbolKindFunctionParameter},
+		{name: "q", kind: SymbolKindFunctionParameter},
+		{name: "r", kind: SymbolKindFunctionParameter},
+	} {
+		symbols := analysisSymbolsNamed(analysis.Symbols(), tc.name, tc.kind)
+		if len(symbols) != 1 {
+			t.Fatalf("%s symbols = %+v, want one original declaration", tc.name, symbols)
+		}
+
+		if len(analysis.ReferencesTo(symbols[0].ID)) == 0 {
+			t.Fatalf("%s has no resolved references", tc.name)
+		}
+	}
+
+	invalid := `FUNC f() => later
+LET later = 1
+RETURN [f(), missing]`
+	partial, err := New().Analyze(source.NewAnonymous(invalid))
+	if err == nil || partial == nil || len(partial.Diagnostics()) == 0 {
+		t.Fatalf("Analyze invalid = analysis %v, err %v", partial, err)
+	}
+
+	later := requireAnalysisSymbol(t, partial, "later", SymbolKindBinding)
+	if refs := partial.ReferencesTo(later.ID); len(refs) != 0 {
+		t.Fatalf("use-before-declaration received false identity: %+v", refs)
+	}
+
+	for _, reference := range partial.References() {
+		assertValidAnalysisSymbolID(t, partial, reference.Symbol)
+		if queryTextAt(invalid, reference.Span) == "missing" {
+			t.Fatalf("unresolved reference received identity: %+v", reference)
+		}
+	}
+}
+
+func TestAnalyzeNestedLoopsForwardUDFsAndByteOffsets(t *testing.T) {
+	query := `LET label = "é"
+FUNC first(value) => second(value)
+FUNC second(value) => value
+RETURN FOR outer IN [[1]]
+  RETURN FOR inner IN outer
+    RETURN [label, first(inner)]`
+
+	analysis, err := New().Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	label := requireAnalysisSymbol(t, analysis, "label", SymbolKindBinding)
+	if label.SelectionSpan.Start != strings.Index(query, "label") || label.SelectionSpan.End-label.SelectionSpan.Start != len("label") {
+		t.Fatalf("label byte span = %+v", label.SelectionSpan)
+	}
+	labelReference := analysis.ReferencesTo(label.ID)
+	if len(labelReference) != 1 || labelReference[0].Span.Start != strings.LastIndex(query, "label") {
+		t.Fatalf("label reference byte span = %+v", labelReference)
+	}
+
+	outer := requireAnalysisSymbol(t, analysis, "outer", SymbolKindLoopBinding)
+	inner := requireAnalysisSymbol(t, analysis, "inner", SymbolKindLoopBinding)
+	innerSource := strings.Index(query, "IN outer") + len("IN ")
+	visible := analysis.VisibleSymbols(innerSource)
+	if !hasAnalysisSymbol(visible, outer.ID) || hasAnalysisSymbol(visible, inner.ID) {
+		t.Fatalf("nested loop source visibility = %+v", visible)
+	}
+
+	second := requireAnalysisSymbol(t, analysis, "second", SymbolKindUDF)
+	assertAnalysisSpanText(t, query, second.SelectionSpan, "second")
+	secondParams := analysis.FunctionParameters(second.ID)
+	if len(secondParams) != 1 {
+		t.Fatalf("second parameters = %+v", secondParams)
+	}
+	assertAnalysisSpanText(t, query, secondParams[0].SelectionSpan, "value")
+	forward := requireAnalysisCall(t, analysis.Calls(), "second")
+	if forward.Kind != CallKindUDF || forward.Target != second.ID {
+		t.Fatalf("forward call = %+v, want target %+v", forward, second)
+	}
+}
+
+func TestAnalyzeVisitsEveryMatchArm(t *testing.T) {
+	query := `RETURN MATCH 1 {
+  1 => FIRST(),
+  2 => SECOND(),
+  _ => THIRD(),
+}`
+
+	analysis, err := New(WithOptimizationLevel(O1), WithDebugInfo()).Analyze(source.NewAnonymous(query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	calls := analysis.Calls()
+	for _, name := range []string{"FIRST", "SECOND", "THIRD"} {
+		call := requireAnalysisCall(t, calls, name)
+		if call.Kind != CallKindHost {
+			t.Fatalf("%s call = %+v", name, call)
+		}
+	}
+}
+
+func TestAnalyzePartialResultsEmptySyntaxAndDefensiveCopies(t *testing.T) {
+	compiler := New()
+
+	empty, err := compiler.Analyze(source.NewAnonymous(""))
+	if err == nil || empty == nil || len(empty.Diagnostics()) != 1 || len(empty.Symbols()) != 0 {
+		t.Fatalf("empty analysis = %+v, err %v", empty, err)
+	}
+
+	syntax, err := compiler.Analyze(source.NewAnonymous("LET = RETURN"))
+	if err == nil || syntax == nil || len(syntax.Diagnostics()) == 0 || len(syntax.Symbols()) != 0 {
+		t.Fatalf("syntax analysis = %+v, err %v", syntax, err)
+	}
+
+	query := `LET value = @input RETURN HOST(value, 1)`
+	analysis, err := compiler.Analyze(source.New("copy.fql", query))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symbols := analysis.Symbols()
+	symbols[0].Name = "changed"
+	if analysis.Symbols()[0].Name == "changed" {
+		t.Fatal("Symbols returned mutable backing storage")
+	}
+
+	references := analysis.References()
+	references[0].Span = source.Span{}
+	if analysis.References()[0].Span == (source.Span{}) {
+		t.Fatal("References returned mutable backing storage")
+	}
+
+	calls := analysis.Calls()
+	calls[0].ArgumentSpans[0] = source.Span{}
+	if analysis.Calls()[0].ArgumentSpans[0] == (source.Span{}) {
+		t.Fatal("Calls returned mutable nested storage")
+	}
+
+	facts := analysis.TypeFacts()
+	facts[0].Span = source.Span{}
+	if analysis.TypeFacts()[0].Span == (source.Span{}) {
+		t.Fatal("TypeFacts returned mutable backing storage")
+	}
+
+	diagnosticQuery := "LET text = \"é\"\nRETURN missing"
+	diagnosticAnalysis, err := compiler.Analyze(source.New("diagnostic.fql", diagnosticQuery))
+	if err == nil {
+		t.Fatal("expected diagnostic")
+	}
+
+	diagnostics := diagnosticAnalysis.Diagnostics()
+	assertAnalysisSpanText(t, diagnosticQuery, diagnostics[0].Spans[0].Span, "missing")
+	diagnosticErr, ok := err.(*diagnosticspkg.Diagnostic)
+	if !ok {
+		t.Fatalf("diagnostic error type = %T", err)
+	}
+	assertAnalysisSpanText(t, diagnosticQuery, diagnosticErr.Spans[0].Span, "missing")
+	diagnostics[0].Message = "changed"
+	diagnostics[0].Spans[0].Label = "changed"
+	if diagnosticAnalysis.Diagnostics()[0].Message == "changed" || diagnosticAnalysis.Diagnostics()[0].Spans[0].Label == "changed" {
+		t.Fatal("Diagnostics returned mutable backing storage")
+	}
+}
+
+func TestAnalyzeIsConcurrentSafeAndOptionIndependent(t *testing.T) {
+	query := `LET base = 1
+FUNC add(value) => base + value
+RETURN add(@value)`
+	src := source.NewAnonymous(query)
+	shared := New(WithOptimizationLevel(O1), WithDebugInfo())
+
+	want, err := shared.Analyze(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 24
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			got, analyzeErr := shared.Analyze(src)
+			if analyzeErr != nil {
+				errs <- analyzeErr
+
+				return
+			}
+
+			if !reflect.DeepEqual(got.Symbols(), want.Symbols()) || !reflect.DeepEqual(got.References(), want.References()) || !reflect.DeepEqual(got.Calls(), want.Calls()) || !reflect.DeepEqual(got.TypeFacts(), want.TypeFacts()) {
+				errs <- errors.New("concurrent analysis result mismatch")
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for concurrentErr := range errs {
+		t.Fatal(concurrentErr)
+	}
+
+	o0, err := New(WithOptimizationLevel(O0)).Analyze(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(o0.Symbols(), want.Symbols()) || !reflect.DeepEqual(o0.References(), want.References()) || !reflect.DeepEqual(o0.Calls(), want.Calls()) || !reflect.DeepEqual(o0.TypeFacts(), want.TypeFacts()) {
+		t.Fatal("Analyze depends on compiler optimization or debug options")
+	}
+}
+
+func requireAnalysisSymbol(t *testing.T, analysis *Analysis, name string, kind SymbolKind) Symbol {
+	t.Helper()
+
+	symbols := analysisSymbolsNamed(analysis.Symbols(), name, kind)
+	if len(symbols) != 1 {
+		t.Fatalf("symbols named %q kind %v = %+v, want one", name, kind, symbols)
+	}
+
+	return symbols[0]
+}
+
+func analysisSymbolsNamed(symbols []Symbol, name string, kind SymbolKind) []Symbol {
+	out := make([]Symbol, 0)
+	for _, symbol := range symbols {
+		if symbol.Name == name && symbol.Kind == kind {
+			out = append(out, symbol)
+		}
+	}
+
+	return out
+}
+
+func requireAnalysisCall(t *testing.T, calls []Call, name string) Call {
+	t.Helper()
+
+	for _, call := range calls {
+		if call.Name == name {
+			return call
+		}
+	}
+
+	t.Fatalf("call %q not found in %+v", name, calls)
+
+	return Call{}
+}
+
+func assertAnalysisSpanText(t *testing.T, query string, span source.Span, want string) {
+	t.Helper()
+
+	if got := queryTextAt(query, span); got != want {
+		t.Fatalf("span %+v text = %q, want %q", span, got, want)
+	}
+}
+
+func queryTextAt(query string, span source.Span) string {
+	if span.Start < 0 || span.End < span.Start || span.End > len(query) {
+		return ""
+	}
+
+	return query[span.Start:span.End]
+}
+
+func hasAnalysisSymbol(symbols []Symbol, id SymbolID) bool {
+	for _, symbol := range symbols {
+		if symbol.ID == id {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertValidAnalysisSymbolID(t *testing.T, analysis *Analysis, id SymbolID) {
+	t.Helper()
+
+	for _, symbol := range analysis.Symbols() {
+		if symbol.ID == id {
+			return
+		}
+	}
+
+	t.Fatalf("reference has invalid symbol ID %d", id)
+}

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1,17 +1,11 @@
 package compiler
 
 import (
-	goruntime "runtime"
-
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/optimization"
-	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
 	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/source"
-
-	"github.com/antlr4-go/antlr/v4"
-
-	"github.com/MontFerret/ferret/v2/pkg/parser"
 )
 
 const Version = "2.0.0"
@@ -52,100 +46,62 @@ func (c *Compiler) Compile(src *source.Source) (program *bytecode.Program, err e
 	errorHandler := parserd.NewErrorHandler(src, 10)
 
 	defer func() {
-		if r := recover(); r != nil {
-			var e *diagnostics.Diagnostic
-
-			buf := make([]byte, 1024)
-			n := goruntime.Stack(buf, false)
-			stackTrace := string(buf[:n])
-
-			// Find out exactly what the error was and add the e
-			switch x := r.(type) {
-			case string:
-				e = diagnostics.NewUnexpectedError(src, x+"\n"+stackTrace)
-			case error:
-				e = diagnostics.NewUnexpectedErrorWith(src, "unhandled panic\n"+stackTrace, x)
-			default:
-				e = diagnostics.NewUnexpectedError(src, "unhandled panic\n"+stackTrace)
-			}
-
-			errorHandler.Add(e)
+		if recovered := recover(); recovered != nil {
+			addRecoveredAnalysisDiagnostic(src, errorHandler, recovered)
 
 			program = nil
 			err = errorHandler.Unwrap()
 		}
 	}()
 
-	tokenHistory := parserd.NewTokenHistory(64)
-	p := parser.New(src.Content(), func(stream antlr.TokenStream) antlr.TokenStream {
-		return parserd.NewTrackingTokenStream(stream, tokenHistory)
-	})
-
-	// Remove all default error listeners
-	p.RemoveErrorListeners()
-	// Add custom error listener
-	p.AddErrorListener(parserd.NewErrorListener(src, errorHandler, tokenHistory))
-	p.Program()
-
-	if errorHandler.HasErrors() {
-		return nil, errorHandler.Unwrap()
-	}
-
 	level := c.opts.Level
 	if c.opts.DebugInfo {
 		level = optimization.LevelNone
 	}
 
-	l := NewVisitor(src, errorHandler, level)
-	l.Session.Program.DebugInfo = c.opts.DebugInfo
-	p.Visit(l)
+	visitor := runFrontend(src, errorHandler, level, c.opts.DebugInfo, nil)
 
 	if errorHandler.HasErrors() {
 		return nil, errorHandler.Unwrap()
 	}
 
-	var udfs []bytecode.UDF
+	return buildProgram(visitor, src, level)
+}
 
-	if l.Session.Program.UDFs != nil {
-		udfs = l.Session.Program.UDFs.Metadata()
-	}
+// Analyze parses and semantically analyzes source without constructing a bytecode program.
+// It is safe for concurrent use by multiple goroutines. When source diagnostics
+// exist, Analyze returns both a non-nil partial snapshot and a non-nil error.
+func (c *Compiler) Analyze(src *source.Source) (analysis *Analysis, err error) {
+	errorHandler := parserd.NewErrorHandler(src, 10)
+	recorder := internal.NewSemanticRecorder(src)
 
-	registers := l.Session.Function.Registers.Size()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			addRecoveredAnalysisDiagnostic(src, errorHandler, recovered)
 
-	for _, udf := range udfs {
-		if udf.Registers > registers {
-			registers = udf.Registers
+			recorder.Sort()
+			analysis = buildAnalysis(src, recorder.Snapshot(), errorHandler)
+			err = analysisError(analysis)
 		}
+	}()
+
+	if src.Empty() {
+		errorHandler.Add(parserd.NewEmptyQueryError(src))
+
+		analysis = buildAnalysis(src, recorder.Snapshot(), errorHandler)
+
+		return analysis, analysisError(analysis)
 	}
 
-	program = &bytecode.Program{
-		ISAVersion: bytecode.Version,
-		Functions: bytecode.Functions{
-			Host:        l.Session.Program.HostFunctions.All(),
-			UserDefined: udfs,
-		},
-		Metadata: bytecode.Metadata{
-			CompilerVersion:        Version,
-			OptimizationLevel:      int(level),
-			AggregatePlans:         l.Session.Program.AggregatePlans(),
-			AggregateSelectorSlots: l.Session.Program.Emitter.AggregateSelectorSlots(),
-			CallArgumentSpans:      l.Session.Program.Emitter.CallArgumentSpans(),
-			MatchFailTargets:       l.Session.Program.Emitter.MatchFailTargets(),
-			DebugSpans:             l.Session.Program.Emitter.Spans(),
-			DebugPoints:            l.Session.Program.DebugPoints,
-			Labels:                 l.Session.Program.Emitter.Labels(),
-		},
-		Source:     src,
-		Bytecode:   l.Session.Program.Emitter.Bytecode(),
-		Constants:  l.Session.Function.Symbols.Constants(),
-		CatchTable: l.Session.Program.CatchTable.All(),
-		Registers:  registers,
-		Params:     l.Session.Program.HostParams.Names(),
+	visitor := runFrontend(src, errorHandler, optimization.LevelNone, false, recorder)
+	if visitor != nil {
+		recorder.Sort()
 	}
 
-	if err := optimization.Run(program, level); err != nil {
-		return nil, err
+	analysis = buildAnalysis(src, recorder.Snapshot(), errorHandler)
+	if errorHandler.HasErrors() {
+		return analysis, analysisError(analysis)
 	}
 
-	return program, err
+	return analysis, nil
 }

--- a/pkg/compiler/frontend_driver.go
+++ b/pkg/compiler/frontend_driver.go
@@ -1,0 +1,38 @@
+package compiler
+
+import (
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/optimization"
+	"github.com/MontFerret/ferret/v2/pkg/parser"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func runFrontend(
+	src *source.Source,
+	errors *parserd.ErrorHandler,
+	level optimization.Level,
+	debugInfo bool,
+	recorder *internal.SemanticRecorder,
+) *Visitor {
+	tokenHistory := parserd.NewTokenHistory(64)
+	p := parser.New(src.Content(), func(stream antlr.TokenStream) antlr.TokenStream {
+		return parserd.NewTrackingTokenStream(stream, tokenHistory)
+	})
+
+	p.RemoveErrorListeners()
+	p.AddErrorListener(parserd.NewErrorListener(src, errors, tokenHistory))
+	p.Program()
+
+	if errors.HasErrors() {
+		return nil
+	}
+
+	visitor := newVisitor(src, errors, level, recorder)
+	visitor.Session.Program.DebugInfo = debugInfo
+	p.Visit(visitor)
+
+	return visitor
+}

--- a/pkg/compiler/internal/binding_compiler.go
+++ b/pkg/compiler/internal/binding_compiler.go
@@ -10,6 +10,7 @@ import (
 	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
 type BindingCompiler struct {
@@ -103,11 +104,16 @@ func (c *BindingCompiler) CompileVariableDeclaration(ctx fql.IVariableDeclaratio
 		dest, ok := c.declareBinding(name, srcType, opts)
 		if !ok {
 			c.ctx.Program.Errors.VariableNotUnique(decl, name)
+
 			return bytecode.NoopOperand
 		}
 
 		c.ctx.Program.Emitter.EmitMakeCell(dest, src)
 		c.ctx.Function.Types.Set(dest, core.TypeAny)
+
+		if c.ctx.Program.Semantics != nil {
+			c.recordVariableDeclaration(ctx, opts.ID, name, mutable, srcType)
+		}
 
 		return dest
 	}
@@ -116,11 +122,16 @@ func (c *BindingCompiler) CompileVariableDeclaration(ctx fql.IVariableDeclaratio
 		dest, ok := c.declareBinding(name, srcType, opts)
 		if !ok {
 			c.ctx.Program.Errors.VariableNotUnique(decl, name)
+
 			return bytecode.NoopOperand
 		}
 
 		c.ctx.Program.Emitter.EmitLoadConst(dest, src)
 		c.ctx.Function.Types.Set(dest, srcType)
+
+		if c.ctx.Program.Semantics != nil {
+			c.recordVariableDeclaration(ctx, opts.ID, name, mutable, srcType)
+		}
 
 		return dest
 	}
@@ -131,6 +142,11 @@ func (c *BindingCompiler) CompileVariableDeclaration(ctx fql.IVariableDeclaratio
 	}
 
 	c.ctx.Function.Types.Set(src, srcType)
+
+	if c.ctx.Program.Semantics != nil {
+		c.recordVariableDeclaration(ctx, opts.ID, name, mutable, srcType)
+	}
+
 	return src
 }
 
@@ -144,7 +160,20 @@ func (c *BindingCompiler) compileDestructuringDeclaration(
 	}
 
 	src = ensureOperandRegister(c.ctx, c.facts, src)
-	c.compileDestructuringPattern(pattern, src, c.isMutableDeclaration(ctx))
+	declaration := source.Span{}
+
+	if c.ctx.Program.Semantics != nil {
+		declaration = parserd.SpanFromRuleContext(ctx.(antlr.ParserRuleContext))
+	}
+
+	c.compileDestructuringPattern(
+		pattern,
+		src,
+		c.isMutableDeclaration(ctx),
+		SemanticSymbolBinding,
+		declaration,
+		declaration.End,
+	)
 
 	return src
 }
@@ -153,6 +182,9 @@ func (c *BindingCompiler) compileDestructuringPattern(
 	pattern fql.IStructuredBindingPatternContext,
 	src bytecode.Operand,
 	mutable bool,
+	kind SemanticSymbolKind,
+	declaration source.Span,
+	activation int,
 ) {
 	if pattern == nil {
 		return
@@ -162,7 +194,7 @@ func (c *BindingCompiler) compileDestructuringPattern(
 		c.emitDestructuringAssertion(object.(antlr.ParserRuleContext), src, bytecode.DestructureModeObject)
 
 		for _, entry := range object.AllObjectBindingEntry() {
-			c.compileObjectDestructuringEntry(entry, src, mutable)
+			c.compileObjectDestructuringEntry(entry, src, mutable, kind, declaration, activation)
 		}
 
 		return
@@ -172,7 +204,7 @@ func (c *BindingCompiler) compileDestructuringPattern(
 		c.emitDestructuringAssertion(array.(antlr.ParserRuleContext), src, bytecode.DestructureModeArray)
 
 		for index, child := range array.AllBindingPattern() {
-			c.compileArrayDestructuringEntry(child, src, index, mutable)
+			c.compileArrayDestructuringEntry(child, src, index, mutable, kind, declaration, activation)
 		}
 	}
 }
@@ -181,6 +213,9 @@ func (c *BindingCompiler) compileObjectDestructuringEntry(
 	entry fql.IObjectBindingEntryContext,
 	src bytecode.Operand,
 	mutable bool,
+	kind SemanticSymbolKind,
+	declaration source.Span,
+	activation int,
 ) {
 	if entry == nil || entry.BindingIdentifier() == nil {
 		return
@@ -197,7 +232,7 @@ func (c *BindingCompiler) compileObjectDestructuringEntry(
 
 	if nested == nil {
 		leafCtx := entry.BindingIdentifier().(antlr.ParserRuleContext)
-		c.compileDestructuringLeaf(key, leafCtx, mutable, func(dst bytecode.Operand) {
+		c.compileDestructuringLeaf(key, leafCtx, mutable, kind, declaration, activation, func(dst bytecode.Operand) {
 			c.emitObjectDestructuringLoad(entryCtx, dst, src, keyConst)
 		})
 
@@ -206,7 +241,7 @@ func (c *BindingCompiler) compileObjectDestructuringEntry(
 
 	if id := nested.BindingIdentifier(); id != nil {
 		leafCtx := id.(antlr.ParserRuleContext)
-		c.compileDestructuringLeaf(textOfBindingIdentifier(id), leafCtx, mutable, func(dst bytecode.Operand) {
+		c.compileDestructuringLeaf(textOfBindingIdentifier(id), leafCtx, mutable, kind, declaration, activation, func(dst bytecode.Operand) {
 			c.emitObjectDestructuringLoad(entryCtx, dst, src, keyConst)
 		})
 
@@ -220,7 +255,7 @@ func (c *BindingCompiler) compileObjectDestructuringEntry(
 
 	child := c.ctx.Function.Registers.Allocate()
 	c.emitObjectDestructuringLoad(entryCtx, child, src, keyConst)
-	c.compileDestructuringPattern(structured, child, mutable)
+	c.compileDestructuringPattern(structured, child, mutable, kind, declaration, activation)
 }
 
 func (c *BindingCompiler) compileArrayDestructuringEntry(
@@ -228,6 +263,9 @@ func (c *BindingCompiler) compileArrayDestructuringEntry(
 	src bytecode.Operand,
 	index int,
 	mutable bool,
+	kind SemanticSymbolKind,
+	declaration source.Span,
+	activation int,
 ) {
 	if !bindingPatternHasBindings(pattern) {
 		return
@@ -238,7 +276,7 @@ func (c *BindingCompiler) compileArrayDestructuringEntry(
 
 	if id := pattern.BindingIdentifier(); id != nil {
 		leafCtx := id.(antlr.ParserRuleContext)
-		c.compileDestructuringLeaf(textOfBindingIdentifier(id), leafCtx, mutable, func(dst bytecode.Operand) {
+		c.compileDestructuringLeaf(textOfBindingIdentifier(id), leafCtx, mutable, kind, declaration, activation, func(dst bytecode.Operand) {
 			c.emitArrayDestructuringLoad(patternCtx, dst, src, indexConst)
 		})
 
@@ -252,13 +290,16 @@ func (c *BindingCompiler) compileArrayDestructuringEntry(
 
 	child := c.ctx.Function.Registers.Allocate()
 	c.emitArrayDestructuringLoad(patternCtx, child, src, indexConst)
-	c.compileDestructuringPattern(structured, child, mutable)
+	c.compileDestructuringPattern(structured, child, mutable, kind, declaration, activation)
 }
 
 func (c *BindingCompiler) compileDestructuringLeaf(
 	name string,
 	ctx antlr.ParserRuleContext,
 	mutable bool,
+	kind SemanticSymbolKind,
+	declaration source.Span,
+	activation int,
 	load func(dst bytecode.Operand),
 ) bytecode.Operand {
 	target, ok := c.declareDestructuringLeaf(name, ctx, mutable)
@@ -272,6 +313,22 @@ func (c *BindingCompiler) compileDestructuringLeaf(
 	if target.Storage == core.BindingStorageCell {
 		c.ctx.Program.Emitter.EmitMakeCell(target.Destination, target.Load)
 		c.ctx.Function.Types.Set(target.Destination, core.TypeAny)
+	}
+
+	if c.ctx.Program.Semantics != nil {
+		selection := parserd.SpanFromRuleContext(ctx)
+		c.ctx.Program.Semantics.RecordBinding(
+			bindingIDFromRule(ctx),
+			name,
+			kind,
+			declaration,
+			selection,
+			mutable,
+			core.TypeAny,
+			activation,
+			c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+			0,
+		)
 	}
 
 	return target.Destination
@@ -359,11 +416,13 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 	assignment, ok := newAssignmentTarget(target)
 	if !ok {
 		c.reportInvalidAssignmentTarget(stmt)
+
 		return bytecode.NoopOperand
 	}
 
 	if assignment.Root == "" || assignment.Root == core.IgnorePseudoVariable {
 		c.reportInvalidAssignmentTarget(stmt)
+
 		return bytecode.NoopOperand
 	}
 
@@ -374,7 +433,12 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 		}
 
 		reportVariableNotFound(c.ctx, assignment.RootTok, assignment.Root)
+
 		return bytecode.NoopOperand
+	}
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RecordBindingReference(binding.ID, parserd.SpanFromRuleContext(assignment.RootCtx))
 	}
 
 	if len(assignment.Segments) > 0 {
@@ -386,6 +450,7 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 		err := c.ctx.Program.Errors.Create(parserd.SemanticError, stmt, fmt.Sprintf("Variable '%s' cannot be reassigned", name))
 		err.Hint = "Declare it with VAR if you need to update it."
 		c.ctx.Program.Errors.Add(err)
+
 		return bytecode.NoopOperand
 	}
 
@@ -396,6 +461,7 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 		src = c.exprs.Compile(stmt.Expression())
 	} else if !augmentedAssignmentKnownTypeAllowed(operator, binding.Type) {
 		c.reportInvalidAugmentedAssignment(stmt, operator)
+
 		return bytecode.NoopOperand
 	} else if operator == "+=" && binding.Type == core.TypeString {
 		left := c.snapshotBindingValue(binding)
@@ -420,6 +486,9 @@ func (c *BindingCompiler) CompileAssignmentStatement(ctx fql.IAssignmentStatemen
 	}
 
 	binding.Type = publishedType
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.UpdateBindingType(binding.ID, publishedType)
+	}
 
 	return c.storeBindingValue(binding, src, publishedType)
 }
@@ -487,6 +556,44 @@ func (c *BindingCompiler) isMutableDeclaration(ctx fql.IVariableDeclarationConte
 
 	decl, ok := ctx.(*fql.VariableDeclarationContext)
 	return ok && decl.Var() != nil
+}
+
+func (c *BindingCompiler) recordVariableDeclaration(
+	ctx fql.IVariableDeclarationContext,
+	id core.BindingID,
+	name string,
+	mutable bool,
+	typ core.ValueType,
+) {
+	if c == nil || c.ctx == nil || c.ctx.Program.Semantics == nil || ctx == nil {
+		return
+	}
+
+	declaration := parserd.SpanFromRuleContext(ctx.(antlr.ParserRuleContext))
+	selection := declaration
+
+	if binding := ctx.BindingIdentifier(); binding != nil {
+		selection = parserd.SpanFromRuleContext(binding.(antlr.ParserRuleContext))
+	} else if identifier := ctx.Identifier(); identifier != nil {
+		selection = parserd.SpanFromToken(identifier.GetSymbol())
+	} else if reserved := ctx.SafeReservedWord(); reserved != nil {
+		selection = parserd.SpanFromRuleContext(reserved.(antlr.ParserRuleContext))
+	} else if token := ctx.GetId(); token != nil {
+		selection = parserd.SpanFromToken(token)
+	}
+
+	c.ctx.Program.Semantics.RecordBinding(
+		id,
+		name,
+		SemanticSymbolBinding,
+		declaration,
+		selection,
+		mutable,
+		typ,
+		declaration.End,
+		c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+		0,
+	)
 }
 
 func (c *BindingCompiler) declarationStorage(decl antlr.ParserRuleContext, mutable bool) core.BindingStorage {

--- a/pkg/compiler/internal/binding_delete.go
+++ b/pkg/compiler/internal/binding_delete.go
@@ -20,17 +20,20 @@ func (c *BindingCompiler) CompileDeleteStatement(ctx fql.IDeleteStatementContext
 	target := stmt.AssignmentTarget()
 	if target == nil {
 		c.reportInvalidDeleteTarget(stmt)
+
 		return bytecode.NoopOperand
 	}
 
 	deletion, ok := newAssignmentTarget(target)
 	if !ok {
 		c.reportInvalidDeleteTarget(stmt)
+
 		return bytecode.NoopOperand
 	}
 
 	if deletion.Root == "" || deletion.Root == core.IgnorePseudoVariable || len(deletion.Segments) == 0 {
 		c.reportInvalidDeleteTarget(stmt)
+
 		return bytecode.NoopOperand
 	}
 
@@ -41,7 +44,12 @@ func (c *BindingCompiler) CompileDeleteStatement(ctx fql.IDeleteStatementContext
 		}
 
 		reportVariableNotFound(c.ctx, deletion.RootTok, deletion.Root)
+
 		return bytecode.NoopOperand
+	}
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RecordBindingReference(binding.ID, parserd.SpanFromRuleContext(deletion.RootCtx))
 	}
 
 	return c.compilePathDeleteStatement(stmt, deletion, binding)

--- a/pkg/compiler/internal/binding_pattern.go
+++ b/pkg/compiler/internal/binding_pattern.go
@@ -103,6 +103,7 @@ func appendBindingPatternLeaves(
 
 	if id := pattern.BindingIdentifier(); id != nil {
 		ctx := id.(antlr.ParserRuleContext)
+
 		return append(leaves, bindingPatternLeaf{
 			Context:     ctx,
 			Declaration: ctx,
@@ -139,6 +140,7 @@ func appendStructuredBindingPatternLeaves(
 			entryPath := appendPatternAccess(path, bindingPatternAccess{Kind: bindingPatternObjectAccess, Key: key})
 			if nested := entry.BindingPattern(); nested != nil {
 				leaves = appendBindingPatternLeaves(leaves, nested, entryPath)
+
 				continue
 			}
 

--- a/pkg/compiler/internal/call_resolver.go
+++ b/pkg/compiler/internal/call_resolver.go
@@ -2,15 +2,34 @@ package internal
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
-type CallResolver struct {
-	session *CompilationSession
-}
+type (
+	CallResolver struct {
+		session *CompilationSession
+	}
+
+	resolvedCallKind uint8
+
+	resolvedCall struct {
+		Function *core.UDFInfo
+		Name     string
+		Identity string
+		Kind     resolvedCallKind
+	}
+)
+
+const (
+	resolvedCallUDF resolvedCallKind = iota + 1
+	resolvedCallBuiltin
+	resolvedCallHost
+)
 
 func NewCallResolver(session *CompilationSession) *CallResolver {
 	return &CallResolver{session: session}
@@ -29,6 +48,10 @@ func (r *CallResolver) ResolveFunctionName(ctx fql.IFunctionCallContext) runtime
 		ns := nsText
 
 		if len(r.session.Program.UseAliases) > 0 {
+			if r.session.Program.Semantics != nil {
+				r.recordNamespaceAliasReference(funcNS, nsText)
+			}
+
 			ns = r.applyNamespaceAlias(ns)
 		}
 
@@ -43,6 +66,11 @@ func (r *CallResolver) ResolveFunctionName(ctx fql.IFunctionCallContext) runtime
 	if len(r.session.Program.UseAliases) > 0 {
 		if target, ok := r.session.Program.UseAliases[fn]; ok && target != "" {
 			if strings.Contains(target, runtime.NamespaceSeparator) {
+				if r.session.Program.Semantics != nil && ctx.FunctionName().GetStart() != nil {
+					start := ctx.FunctionName().GetStart().GetStart()
+					r.session.Program.Semantics.RecordNamespaceAliasReference(fn, source.Span{Start: start, End: start + utf8.RuneCountInString(fn)})
+				}
+
 				return runtime.NewString(target)
 			}
 		}
@@ -51,6 +79,26 @@ func (r *CallResolver) ResolveFunctionName(ctx fql.IFunctionCallContext) runtime
 	name += fn
 
 	return runtime.NewString(name)
+}
+
+func (r *CallResolver) recordNamespaceAliasReference(ctx fql.INamespaceContext, namespace string) {
+	if r == nil || r.session == nil || r.session.Program.Semantics == nil || ctx == nil || ctx.GetStart() == nil {
+		return
+	}
+
+	trimmed := strings.TrimSuffix(namespace, runtime.NamespaceSeparator)
+	parts := strings.Split(trimmed, runtime.NamespaceSeparator)
+	if len(parts) == 0 || parts[0] == "" {
+		return
+	}
+
+	alias := parts[0]
+	if _, ok := r.session.Program.UseAliases[alias]; !ok {
+		return
+	}
+
+	start := ctx.GetStart().GetStart()
+	r.session.Program.Semantics.RecordNamespaceAliasReference(alias, source.Span{Start: start, End: start + utf8.RuneCountInString(alias)})
 }
 
 func (r *CallResolver) ResolveLocalFunctionName(ctx fql.IFunctionCallContext) (string, bool) {
@@ -89,6 +137,53 @@ func (r *CallResolver) ResolveUDF(ctx fql.IFunctionCallContext) (*core.UDFInfo, 
 	}
 
 	return r.ResolveUDFInScope(ctx, r.session.Function.UDFScope)
+}
+
+func (r *CallResolver) resolveCall(ctx fql.IFunctionCallContext, name runtime.String) resolvedCall {
+	nameStr := name.String()
+	namespaced := strings.Contains(nameStr, runtime.NamespaceSeparator)
+
+	if ctx != nil {
+		if ns := ctx.Namespace(); ns != nil && ns.GetText() != "" {
+			namespaced = true
+		}
+	}
+
+	if !namespaced {
+		if fn, ok := r.ResolveUDF(ctx); ok {
+			return resolvedCall{
+				Function: fn,
+				Name:     fn.DisplayName,
+				Kind:     resolvedCallUDF,
+			}
+		}
+
+		builtin := strings.ToUpper(nameStr)
+		switch builtin {
+		case runtimeLength, runtimeTypename, runtimeWait:
+			identity := ""
+			if r.session.Program.Semantics != nil {
+				identity = runtime.NormalizeRegisteredName(builtin)
+			}
+
+			return resolvedCall{
+				Name:     builtin,
+				Identity: identity,
+				Kind:     resolvedCallBuiltin,
+			}
+		}
+	}
+
+	identity := ""
+	if r.session.Program.Semantics != nil {
+		identity = runtime.NormalizeRegisteredName(nameStr)
+	}
+
+	return resolvedCall{
+		Name:     nameStr,
+		Identity: identity,
+		Kind:     resolvedCallHost,
+	}
 }
 
 // ResolveUDFInScope resolves an unqualified source call against an explicit lexical UDF scope.

--- a/pkg/compiler/internal/context.go
+++ b/pkg/compiler/internal/context.go
@@ -21,21 +21,23 @@ type (
 	// persist for the whole compilation. The final bytecode.Program reads its
 	// metadata almost entirely from here.
 	ProgramContext struct {
-		Errors              *diagnostics.ErrorHandler
-		aggregatePlanByHash map[uint64][]int
+		Emitter             *core.Emitter
+		UseAliases          map[string]string
 		CatchTable          *core.CatchStack
 		UDFs                *core.UDFTable
 		HostParams          *core.HostParamTable
 		HostFunctions       *core.HostFunctionTable
 		Constants           *core.ConstantPool
 		ForwardBindings     *ForwardBindingIndex
-		Emitter             *core.Emitter
-		UseAliases          map[string]string
+		aggregatePlanByHash map[uint64][]int
 		Source              *source.Source
-		aggregatePlans      []*bytecode.AggregatePlan
+		Errors              *diagnostics.ErrorHandler
+		Semantics           *SemanticRecorder
 		DebugPoints         []bytecode.DebugPoint
+		aggregatePlans      []*bytecode.AggregatePlan
 		OptimizationLevel   optimization.Level
 		DebugInfo           bool
+		DisableMatchFolding bool
 	}
 
 	// FunctionContext holds state that is local to a single function body
@@ -87,10 +89,32 @@ func NewFunctionContext(constants *core.ConstantPool) *FunctionContext {
 
 // NewCompilationSession initializes a new CompilationSession with default values.
 func NewCompilationSession(src *source.Source, errors *diagnostics.ErrorHandler, level optimization.Level) *CompilationSession {
+	return newCompilationSession(src, errors, level, nil)
+}
+
+// NewSemanticCompilationSession initializes a compilation session that records
+// source semantics while lowering.
+func NewSemanticCompilationSession(
+	src *source.Source,
+	errors *diagnostics.ErrorHandler,
+	level optimization.Level,
+	recorder *SemanticRecorder,
+) *CompilationSession {
+	return newCompilationSession(src, errors, level, recorder)
+}
+
+func newCompilationSession(
+	src *source.Source,
+	errors *diagnostics.ErrorHandler,
+	level optimization.Level,
+	recorder *SemanticRecorder,
+) *CompilationSession {
 	program := &ProgramContext{
-		Source:            src,
-		Errors:            errors,
-		OptimizationLevel: level,
+		Source:              src,
+		Errors:              errors,
+		OptimizationLevel:   level,
+		Semantics:           recorder,
+		DisableMatchFolding: recorder != nil,
 
 		Emitter:       core.NewEmitter(),
 		Constants:     core.NewConstantPool(),

--- a/pkg/compiler/internal/core/loop.go
+++ b/pkg/compiler/internal/core/loop.go
@@ -65,8 +65,12 @@ func (l *Loop) BreakLabel() Label {
 }
 
 func (l *Loop) DeclareKeyVar(name string, st *SymbolTable, typ ValueType) bool {
+	return l.DeclareKeyVarWithOptions(name, st, typ, BindingOptions{})
+}
+
+func (l *Loop) DeclareKeyVarWithOptions(name string, st *SymbolTable, typ ValueType, opts BindingOptions) bool {
 	if l.canDeclareVar(name) {
-		reg, ok := st.DeclareLocal(name, typ)
+		reg, ok := st.DeclareLocalWithOptions(name, typ, opts)
 
 		if !ok {
 			return false
@@ -80,8 +84,12 @@ func (l *Loop) DeclareKeyVar(name string, st *SymbolTable, typ ValueType) bool {
 }
 
 func (l *Loop) DeclareValueVar(name string, st *SymbolTable, typ ValueType) bool {
+	return l.DeclareValueVarWithOptions(name, st, typ, BindingOptions{})
+}
+
+func (l *Loop) DeclareValueVarWithOptions(name string, st *SymbolTable, typ ValueType, opts BindingOptions) bool {
 	if l.canDeclareVar(name) {
-		reg, ok := st.DeclareLocal(name, typ)
+		reg, ok := st.DeclareLocalWithOptions(name, typ, opts)
 
 		if !ok {
 			return false

--- a/pkg/compiler/internal/expr.go
+++ b/pkg/compiler/internal/expr.go
@@ -129,9 +129,15 @@ func (c *ExprCompiler) CompileDiscarded(ctx fql.IExpressionContext) bytecode.Ope
 	return c.compileWithResultUse(ctx, resultDiscarded)
 }
 
-func (c *ExprCompiler) compileWithResultUse(ctx fql.IExpressionContext, use resultUse) bytecode.Operand {
+func (c *ExprCompiler) compileWithResultUse(ctx fql.IExpressionContext, use resultUse) (out bytecode.Operand) {
 	if ctx == nil {
 		return bytecode.NoopOperand
+	}
+
+	if c.ctx.Program.Semantics != nil {
+		defer func() {
+			c.ctx.Program.Semantics.RecordExpressionType(ctx.(antlr.ParserRuleContext), c.facts.OperandType(out))
+		}()
 	}
 
 	if uo := ctx.UnaryOperator(); uo != nil {

--- a/pkg/compiler/internal/expr_call_compiler.go
+++ b/pkg/compiler/internal/expr_call_compiler.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
 
@@ -82,6 +81,10 @@ func (c *exprCallCompiler) compileVariable(ctx fql.IVariableContext) bytecode.Op
 		return bytecode.NoopOperand
 	}
 
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RecordBindingReference(binding.ID, diagnostics.SpanFromRuleContext(ctx.(antlr.ParserRuleContext)))
+	}
+
 	op := c.bindings.LoadBindingValue(binding)
 
 	if op.IsRegister() {
@@ -108,6 +111,10 @@ func (c *exprCallCompiler) compileParam(ctx fql.IParamContext) bytecode.Operand 
 		c.ctx.Program.Emitter.EmitLoadParam(reg, c.ctx.Program.HostParams.Bind(name))
 	})
 	c.ctx.Function.Types.Set(reg, core.TypeAny)
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RecordBindParameter(name, span)
+	}
 
 	return reg
 }
@@ -181,16 +188,8 @@ func (c *exprCallCompiler) compileFunctionCallWith(ctx fql.IFunctionCallContext,
 }
 
 func (c *exprCallCompiler) compileFunctionCallByNameWith(ctx fql.IFunctionCallContext, name runtime.String, protected bool, seq core.RegisterSequence) bytecode.Operand {
-	nameStr := name.String()
-	builtinName := strings.ToUpper(nameStr)
 	argSpans := c.argumentSpansFromList(nil)
-
-	namespaced := strings.Contains(nameStr, runtime.NamespaceSeparator)
 	if ctx != nil {
-		if ns := ctx.Namespace(); ns != nil && ns.GetText() != "" {
-			namespaced = true
-		}
-
 		argSpans = c.argumentSpansFromList(ctx.ArgumentList())
 	}
 
@@ -201,46 +200,55 @@ func (c *exprCallCompiler) compileFunctionCallByNameWith(ctx fql.IFunctionCallCo
 		}
 	}
 
-	if !namespaced && c.ctx.Program.UDFs != nil && c.ctx.Function.UDFScope != nil {
-		if fn, ok := c.calls.ResolveUDF(ctx); ok {
-			return c.compileUdfCallWith(fn, protected, seq, callCtx, argSpans)
-		}
-	}
+	resolved := c.calls.resolveCall(ctx, name)
+	var out bytecode.Operand
 
-	if !namespaced {
-		switch builtinName {
+	switch resolved.Kind {
+	case resolvedCallUDF:
+		out = c.compileUdfCallWith(resolved.Function, protected, seq, callCtx, argSpans)
+	case resolvedCallBuiltin:
+		switch resolved.Name {
 		case runtimeLength:
 			dst := c.ctx.Function.Registers.Allocate()
 
 			if len(seq) != 1 {
-				return c.reportFunctionArityError(callCtx, builtinName, 1, len(seq))
+				out = c.reportFunctionArityError(callCtx, resolved.Name, 1, len(seq))
+
+				break
 			}
 
 			c.ctx.Program.Emitter.EmitAB(bytecode.OpLength, dst, seq[0])
-
-			return dst
+			out = dst
 		case runtimeTypename:
 			dst := c.ctx.Function.Registers.Allocate()
 
 			if len(seq) != 1 {
-				return c.reportFunctionArityError(callCtx, builtinName, 1, len(seq))
+				out = c.reportFunctionArityError(callCtx, resolved.Name, 1, len(seq))
+
+				break
 			}
 
 			c.ctx.Program.Emitter.EmitAB(bytecode.OpType, dst, seq[0])
-
-			return dst
+			out = dst
 		case runtimeWait:
 			if len(seq) != 1 {
-				return c.reportFunctionArityError(callCtx, builtinName, 1, len(seq))
+				out = c.reportFunctionArityError(callCtx, resolved.Name, 1, len(seq))
+
+				break
 			}
 
 			c.ctx.Program.Emitter.EmitA(bytecode.OpSleep, seq[0])
-
-			return seq[0]
+			out = seq[0]
 		}
+	case resolvedCallHost:
+		out = c.compileHostFunctionCallWith(runtime.NewString(resolved.Name), protected, seq, argSpans)
 	}
 
-	return c.compileHostFunctionCallWith(name, protected, seq, argSpans)
+	if c.ctx.Program.Semantics != nil {
+		c.recordCall(ctx, resolved, out, argSpans)
+	}
+
+	return out
 }
 
 func (c *exprCallCompiler) reportFunctionArityError(ctx antlr.ParserRuleContext, name string, expected, got int) bytecode.Operand {
@@ -296,6 +304,56 @@ func (c *exprCallCompiler) emitUdfTailCall(fn *core.UDFInfo, seq core.RegisterSe
 	dest := c.ctx.Function.Registers.Allocate()
 	c.ctx.Program.Emitter.EmitLoadConst(dest, c.ctx.Function.Symbols.AddConstant(runtime.NewInt(fn.ID)))
 	c.ctx.Program.Emitter.EmitAsWithCallArgumentSpans(bytecode.OpTailCall, dest, args, argSpans)
+
+	if c.ctx.Program.Semantics != nil {
+		if call, ok := callCtx.(fql.IFunctionCallContext); ok {
+			c.recordCall(call, resolvedCall{Function: fn, Name: fn.DisplayName, Kind: resolvedCallUDF}, bytecode.NoopOperand, argSpans)
+		}
+	}
+}
+
+func (c *exprCallCompiler) recordCall(
+	ctx fql.IFunctionCallContext,
+	resolved resolvedCall,
+	out bytecode.Operand,
+	argumentSpans []source.Span,
+) {
+	if c == nil || c.ctx == nil || c.ctx.Program.Semantics == nil || ctx == nil {
+		return
+	}
+
+	callCtx := ctx.(antlr.ParserRuleContext)
+	calleeSpan := diagnostics.SpanFromRuleContext(callCtx)
+
+	if fn := ctx.FunctionName(); fn != nil {
+		calleeSpan = diagnostics.SpanFromRuleContext(fn.(antlr.ParserRuleContext))
+		if ns := ctx.Namespace(); ns != nil && ns.GetStart() != nil {
+			calleeSpan.Start = ns.GetStart().GetStart()
+		}
+	}
+
+	call := SemanticCall{
+		Name:          resolved.Name,
+		Identity:      resolved.Identity,
+		Span:          diagnostics.SpanFromRuleContext(callCtx),
+		CalleeSpan:    calleeSpan,
+		ArgumentSpans: argumentSpans,
+		Type:          c.facts.OperandType(out),
+	}
+
+	switch resolved.Kind {
+	case resolvedCallUDF:
+		call.Kind = SemanticCallUserFunction
+		call.Target = c.ctx.Program.Semantics.UserFunctionSymbol(resolved.Function)
+		call.Type = core.TypeAny
+		c.ctx.Program.Semantics.RecordUserFunctionReference(resolved.Function, calleeSpan)
+	case resolvedCallBuiltin:
+		call.Kind = SemanticCallBuiltin
+	case resolvedCallHost:
+		call.Kind = SemanticCallHost
+	}
+
+	c.ctx.Program.Semantics.RecordCall(call)
 }
 
 func (c *exprCallCompiler) prepareUdfCallArgs(fn *core.UDFInfo, seq core.RegisterSequence, callCtx antlr.ParserRuleContext) core.RegisterSequence {

--- a/pkg/compiler/internal/expr_match_compiler.go
+++ b/pkg/compiler/internal/expr_match_compiler.go
@@ -55,7 +55,7 @@ func (c *exprMatchCompiler) compileMatchExpression(ctx fql.IMatchExpressionConte
 			return bytecode.NoopOperand
 		}
 
-		if c.tryCompileMatchConstantFold(scrutinee, arms, dst) {
+		if !c.ctx.Program.DisableMatchFolding && c.tryCompileMatchConstantFold(scrutinee, arms, dst) {
 			c.ctx.Function.Types.Set(dst, core.TypeAny)
 
 			return dst
@@ -82,7 +82,13 @@ func (c *exprMatchCompiler) compileMatchPatternArms(scrReg bytecode.Operand, ctx
 	}
 
 	arms := collectMatchPatternArms(ctx)
-	mergeLabels, mergeGroups := collectMatchResultMerges(c.ctx, arms)
+	var mergeLabels map[int]core.Label
+	var mergeGroups []matchResultGroup
+
+	if !c.ctx.Program.DisableMatchFolding {
+		mergeLabels, mergeGroups = collectMatchResultMerges(c.ctx, arms)
+	}
+
 	defaultLabel, hasDefaultLabel := c.matchMergeDefaultLabel(mergeGroups)
 
 	for idx, arm := range arms {
@@ -111,9 +117,19 @@ func (c *exprMatchCompiler) compileMatchPatternArm(scrReg bytecode.Operand, arm 
 
 	next := c.ctx.Program.Emitter.NewLabel("match.next")
 	c.ctx.Function.Symbols.EnterScope()
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.EnterScope(diagnostics.SpanFromRuleContext(arm.(antlr.ParserRuleContext)))
+	}
+
 	c.compileMatchPatternArmConditions(scrReg, arm, next)
 	c.compileMatchPatternArmResult(arm, idx, mergeLabels, dst, end)
 	c.ctx.Function.Symbols.ExitScope()
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.ExitScope()
+	}
+
 	c.ctx.Program.Emitter.MarkLabel(next)
 }
 
@@ -163,10 +179,12 @@ func (c *exprMatchCompiler) compileMatchMergedResults(groups []matchResultGroup,
 	for _, group := range groups {
 		c.ctx.Program.Emitter.MarkLabel(group.label)
 		c.ctx.Function.Symbols.EnterScope()
+
 		out := ensureOperandRegister(c.ctx, c.facts, c.callbacks.compileExpr(group.result))
 		if out != bytecode.NoopOperand && out != dst {
 			c.ctx.Program.Emitter.EmitMove(dst, out)
 		}
+
 		c.ctx.Function.Symbols.ExitScope()
 		c.ctx.Program.Emitter.EmitJump(end)
 	}
@@ -187,6 +205,7 @@ func (c *exprMatchCompiler) compileMatchPatternDefaultArm(def fql.IMatchDefaultA
 			c.ctx.Program.Emitter.EmitMove(dst, out)
 		}
 	}
+
 	c.ctx.Function.Symbols.ExitScope()
 }
 
@@ -227,12 +246,14 @@ func (c *exprMatchCompiler) compileMatchGuardArms(ctx fql.IMatchGuardArmsContext
 
 	if def := ctx.MatchDefaultArm(); def != nil {
 		c.ctx.Function.Symbols.EnterScope()
+
 		if result := def.Expression(); result != nil {
 			out := ensureOperandRegister(c.ctx, c.facts, c.callbacks.compileExpr(result))
 			if out != bytecode.NoopOperand && out != dst {
 				c.ctx.Program.Emitter.EmitMove(dst, out)
 			}
 		}
+
 		c.ctx.Function.Symbols.ExitScope()
 	}
 }
@@ -302,10 +323,12 @@ func (c *exprMatchCompiler) emitMatchConstantFoldExpression(expr fql.IExpression
 	}
 
 	c.ctx.Function.Symbols.EnterScope()
+
 	out := ensureOperandRegister(c.ctx, c.facts, c.callbacks.compileExpr(expr))
 	if out != bytecode.NoopOperand && out != dst {
 		c.ctx.Program.Emitter.EmitMove(dst, out)
 	}
+
 	c.ctx.Function.Symbols.ExitScope()
 
 	return true
@@ -386,10 +409,29 @@ func (c *exprMatchCompiler) emitObjectsKeys(scrReg bytecode.Operand) bytecode.Op
 
 func (c *exprMatchCompiler) declareMatchBinding(ctx antlr.ParserRuleContext, name string, valueReg bytecode.Operand) bytecode.Operand {
 	valueReg = ensureOperandRegister(c.ctx, c.facts, valueReg)
-	reg, ok := c.ctx.Function.Symbols.DeclareLocal(name, core.TypeAny)
+	bindingID := bindingIDFromRule(ctx)
+	reg, ok := c.ctx.Function.Symbols.DeclareLocalWithOptions(name, core.TypeAny, core.BindingOptions{ID: bindingID})
+
 	if ok {
 		c.ctx.Program.Emitter.EmitMove(reg, valueReg)
-		c.ctx.Function.Types.Set(reg, c.facts.OperandType(valueReg))
+		typ := c.facts.OperandType(valueReg)
+		c.ctx.Function.Types.Set(reg, typ)
+
+		if c.ctx.Program.Semantics != nil {
+			span := diagnostics.SpanFromRuleContext(ctx)
+			c.ctx.Program.Semantics.RecordBinding(
+				bindingID,
+				name,
+				SemanticSymbolMatchBinding,
+				span,
+				span,
+				false,
+				typ,
+				span.End,
+				c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+				0,
+			)
+		}
 
 		return reg
 	}

--- a/pkg/compiler/internal/loop.go
+++ b/pkg/compiler/internal/loop.go
@@ -263,6 +263,10 @@ func (c *LoopCompiler) compileInitialization(ctx fql.IForExpressionContext, kind
 	c.ctx.Function.Loops.Push(loop)
 	c.ctx.Function.Symbols.EnterScope()
 
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.EnterScope(parser.SpanFromRuleContext(ctx.(antlr.ParserRuleContext)))
+	}
+
 	valueType, keyType := c.inferLoopVariableTypes(ctx, loop, kind)
 	c.declareLoopVariables(ctx, loop, valueType, keyType)
 	c.emitLoopInitialization(ctx, loop)
@@ -335,7 +339,30 @@ func (c *LoopCompiler) declareLoopValueVariable(ctx fql.IForExpressionContext, l
 	}
 
 	varName := textOfLoopVariable(val)
-	loop.DeclareValueVar(varName, c.ctx.Function.Symbols, valueType)
+	valueCtx := val.(antlr.ParserRuleContext)
+	bindingID := bindingIDFromRule(valueCtx)
+	declared := loop.DeclareValueVarWithOptions(varName, c.ctx.Function.Symbols, valueType, core.BindingOptions{ID: bindingID})
+
+	if declared && c.ctx.Program.Semantics != nil {
+		span := parser.SpanFromRuleContext(valueCtx)
+		activation := span.End
+		if src := ctx.ForExpressionSource(); src != nil {
+			activation = parser.SpanFromRuleContext(src.(antlr.ParserRuleContext)).End
+		}
+
+		c.ctx.Program.Semantics.RecordBinding(
+			bindingID,
+			varName,
+			SemanticSymbolLoopBinding,
+			span,
+			span,
+			false,
+			valueType,
+			activation,
+			c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+			0,
+		)
+	}
 
 	if loop.Value.IsRegister() {
 		c.ctx.Function.Types.Set(loop.Value, valueType)
@@ -348,7 +375,32 @@ func (c *LoopCompiler) declareLoopCounterVariable(ctx fql.IForExpressionContext,
 		return
 	}
 
-	loop.DeclareKeyVar(textOfBindingIdentifier(ctr), c.ctx.Function.Symbols, keyType)
+	counterCtx := ctr.(antlr.ParserRuleContext)
+	bindingID := bindingIDFromRule(counterCtx)
+	name := textOfBindingIdentifier(ctr)
+	declared := loop.DeclareKeyVarWithOptions(name, c.ctx.Function.Symbols, keyType, core.BindingOptions{ID: bindingID})
+
+	if declared && c.ctx.Program.Semantics != nil {
+		span := parser.SpanFromRuleContext(counterCtx)
+		activation := span.End
+
+		if src := ctx.ForExpressionSource(); src != nil {
+			activation = parser.SpanFromRuleContext(src.(antlr.ParserRuleContext)).End
+		}
+
+		c.ctx.Program.Semantics.RecordBinding(
+			bindingID,
+			name,
+			SemanticSymbolLoopBinding,
+			span,
+			span,
+			false,
+			keyType,
+			activation,
+			c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+			0,
+		)
+	}
 	if loop.Key.IsRegister() {
 		c.ctx.Function.Types.Set(loop.Key, keyType)
 	}
@@ -370,7 +422,27 @@ func (c *LoopCompiler) emitLoopInitialization(ctx fql.IForExpressionContext, loo
 	})
 
 	if loop.Destructured {
-		c.bindings.compileDestructuringPattern(ctx.GetValuePattern(), loop.Value, false)
+		pattern := ctx.GetValuePattern()
+		declaration := source.Span{}
+		activation := 0
+
+		if c.ctx.Program.Semantics != nil {
+			declaration = parser.SpanFromRuleContext(pattern.(antlr.ParserRuleContext))
+			activation = declaration.End
+
+			if src := ctx.ForExpressionSource(); src != nil {
+				activation = parser.SpanFromRuleContext(src.(antlr.ParserRuleContext)).End
+			}
+		}
+
+		c.bindings.compileDestructuringPattern(
+			pattern,
+			loop.Value,
+			false,
+			SemanticSymbolLoopBinding,
+			declaration,
+			activation,
+		)
 	}
 }
 
@@ -415,6 +487,7 @@ func (c *LoopCompiler) compileFinalization(ctx antlr.RuleContext) bytecode.Opera
 		// results are appended to the loop destination.
 		re := ctx.(*fql.ReturnExpressionContext)
 		returnUse := resultDiscarded
+
 		if loop.CollectResult {
 			returnUse = resultRequired
 		}
@@ -472,6 +545,11 @@ func (c *LoopCompiler) compileFinalization(ctx antlr.RuleContext) bytecode.Opera
 
 	// Clean up the symbol scope and pop the loop from the stack
 	c.ctx.Function.Symbols.ExitScope()
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.ExitScope()
+	}
+
 	c.ctx.Function.Loops.Pop()
 
 	return loop.Dst

--- a/pkg/compiler/internal/loop_collect_locals.go
+++ b/pkg/compiler/internal/loop_collect_locals.go
@@ -8,11 +8,19 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
 	parser "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 )
 
 func (c *CollectCompiler) declareLocalOrReport(ctx antlr.ParserRuleContext, name string, typ core.ValueType) bytecode.Operand {
-	reg, ok := c.ctx.Function.Symbols.DeclareLocal(name, typ)
+	bindingCtx := c.collectBindingContext(ctx)
+	id := bindingIDFromRule(bindingCtx)
+	reg, ok := c.ctx.Function.Symbols.DeclareLocalWithOptions(name, typ, core.BindingOptions{ID: id})
+
 	if ok {
+		if c.ctx.Program.Semantics != nil {
+			c.recordCollectBinding(ctx, bindingCtx, id, name, typ)
+		}
+
 		return reg
 	}
 
@@ -27,12 +35,84 @@ func (c *CollectCompiler) declareLocalOrReport(ctx antlr.ParserRuleContext, name
 }
 
 func (c *CollectCompiler) assignLocalOrReport(ctx antlr.ParserRuleContext, name string, typ core.ValueType, op bytecode.Operand) bool {
-	if c.ctx.Function.Symbols.AssignLocal(name, typ, op) {
+	bindingCtx := c.collectBindingContext(ctx)
+	id := bindingIDFromRule(bindingCtx)
+
+	if c.ctx.Function.Symbols.AssignLocalWithOptions(name, typ, op, core.BindingOptions{ID: id}) {
+		if c.ctx.Program.Semantics != nil {
+			c.recordCollectBinding(ctx, bindingCtx, id, name, typ)
+		}
+
 		return true
 	}
 
 	c.reportDuplicateLocal(ctx, name)
 	return false
+}
+
+func (c *CollectCompiler) recordCollectBinding(
+	declaration antlr.ParserRuleContext,
+	selection antlr.ParserRuleContext,
+	id core.BindingID,
+	name string,
+	typ core.ValueType,
+) {
+	if c == nil || c.ctx == nil || c.ctx.Program.Semantics == nil || declaration == nil || selection == nil {
+		return
+	}
+
+	declarationSpan := parser.SpanFromRuleContext(declaration)
+	c.ctx.Program.Semantics.RecordBinding(
+		id,
+		name,
+		SemanticSymbolCollectBinding,
+		declarationSpan,
+		parser.SpanFromRuleContext(selection),
+		false,
+		typ,
+		c.collectClauseActivation(declaration, declarationSpan.End),
+		c.ctx.Program.Semantics.CurrentFunctionSymbol(),
+		0,
+	)
+}
+
+func (c *CollectCompiler) collectClauseActivation(ctx antlr.ParserRuleContext, fallback int) int {
+	for node := antlr.Tree(ctx); node != nil; node = node.GetParent() {
+		if clause, ok := node.(fql.ICollectClauseContext); ok {
+			return parser.SpanFromRuleContext(clause.(antlr.ParserRuleContext)).End
+		}
+	}
+
+	return fallback
+}
+
+func (c *CollectCompiler) collectBindingContext(ctx antlr.ParserRuleContext) antlr.ParserRuleContext {
+	switch typed := ctx.(type) {
+	case fql.ICollectSelectorContext:
+		return c.bindingIdentifierRule(typed.BindingIdentifier())
+	case fql.ICollectAggregateSelectorContext:
+		return c.bindingIdentifierRule(typed.BindingIdentifier())
+	case fql.ICollectGroupProjectionContext:
+		if id := typed.BindingIdentifier(); id != nil {
+			return c.bindingIdentifierRule(id)
+		}
+
+		if selector := typed.CollectSelector(); selector != nil {
+			return c.bindingIdentifierRule(selector.BindingIdentifier())
+		}
+	case fql.ICollectCounterContext:
+		return c.bindingIdentifierRule(typed.BindingIdentifier())
+	}
+
+	return ctx
+}
+
+func (c *CollectCompiler) bindingIdentifierRule(ctx fql.IBindingIdentifierContext) antlr.ParserRuleContext {
+	if ctx == nil {
+		return nil
+	}
+
+	return ctx.(antlr.ParserRuleContext)
 }
 
 func (c *CollectCompiler) reportDuplicateLocal(ctx antlr.ParserRuleContext, name string) {

--- a/pkg/compiler/internal/loop_collect_prj.go
+++ b/pkg/compiler/internal/loop_collect_prj.go
@@ -18,6 +18,7 @@ func (c *CollectCompiler) initializeProjection(kv *core.KV, projection fql.IColl
 	if projection != nil {
 		// Compile the group variable projection and get the variable name
 		varName := c.compileGroupVariableProjection(kv, projection)
+
 		// Create a group projection with the variable name
 		return core.NewCollectorGroupProjection(varName, projection)
 	}
@@ -30,6 +31,7 @@ func (c *CollectCompiler) initializeProjection(kv *core.KV, projection fql.IColl
 			err := c.ctx.Program.Errors.Create(parser.SemanticError, counter, "Missing counter projection variable")
 			err.Hint = "Use WITH COUNT INTO <variable>."
 			c.ctx.Program.Errors.Add(err)
+
 			return nil
 		}
 
@@ -52,6 +54,7 @@ func (c *CollectCompiler) finalizeProjection(spec *core.Collector, aggregator by
 		// For cases with grouping or without aggregation:
 		// Now we need to expand group variables from the dataset
 		loop.ValueName = varName
+
 		// Assign the aggregator value to the local variable with the projection name
 		if !c.assignLocalOrReport(spec.Projection().Context(), loop.ValueName, core.TypeUnknown, aggregator) {
 			if existing, found := c.ctx.Function.Symbols.ResolveBinding(loop.ValueName); found {
@@ -124,7 +127,12 @@ func (c *CollectCompiler) compileDefaultGroupProjection(kv *core.KV, identifier 
 				c.ctx.Program.Emitter.EmitA(bytecode.OpLoadNone, noneReg)
 				c.ctx.Function.Types.Set(noneReg, core.TypeNone)
 				resolved[i] = noneReg
+
 				continue
+			}
+
+			if c.ctx.Program.Semantics != nil {
+				c.ctx.Program.Semantics.RecordBindingReference(binding.ID, parser.SpanFromToken(variable.GetSymbol()))
 			}
 
 			resolved[i] = c.bindings.LoadBindingValue(binding)

--- a/pkg/compiler/internal/semantic_recorder.go
+++ b/pkg/compiler/internal/semantic_recorder.go
@@ -1,0 +1,592 @@
+package internal
+
+import (
+	"sort"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+type (
+	SemanticSymbolID uint32
+
+	SemanticScopeID uint32
+
+	SemanticSymbolKind uint8
+
+	SemanticCallKind uint8
+
+	SemanticSymbol struct {
+		Name           string
+		Declaration    source.Span
+		Selection      source.Span
+		Type           core.ValueType
+		Activation     int
+		ID             SemanticSymbolID
+		Function       SemanticSymbolID
+		Scope          SemanticScopeID
+		Kind           SemanticSymbolKind
+		Mutable        bool
+		HasDeclaration bool
+	}
+
+	SemanticReference struct {
+		Symbol SemanticSymbolID
+		Span   source.Span
+	}
+
+	SemanticCall struct {
+		Name          string
+		Identity      string
+		ArgumentSpans []source.Span
+		Span          source.Span
+		CalleeSpan    source.Span
+		Type          core.ValueType
+		Target        SemanticSymbolID
+		Kind          SemanticCallKind
+	}
+
+	SemanticTypeFact struct {
+		Span source.Span
+		Type core.ValueType
+	}
+
+	SemanticScope struct {
+		ID     SemanticScopeID
+		Parent SemanticScopeID
+		Span   source.Span
+		Depth  int
+	}
+
+	SemanticSnapshot struct {
+		Symbols    []SemanticSymbol
+		References []SemanticReference
+		Calls      []SemanticCall
+		TypeFacts  []SemanticTypeFact
+		Scopes     []SemanticScope
+	}
+
+	// SemanticRecorder captures immutable-source semantic decisions while the
+	// normal compiler frontend resolves and lowers the program.
+	SemanticRecorder struct {
+		symbols          []SemanticSymbol
+		references       []SemanticReference
+		calls            []SemanticCall
+		typeFacts        []SemanticTypeFact
+		scopes           []SemanticScope
+		scopeStack       []SemanticScopeID
+		symbolByBinding  map[core.BindingID]SemanticSymbolID
+		symbolByFunction map[*core.UDFInfo]SemanticSymbolID
+		scopeByUDF       map[*core.UDFScope]SemanticScopeID
+		functionByScope  map[SemanticScopeID]SemanticSymbolID
+		bindParameters   map[string]SemanticSymbolID
+		aliases          map[string]SemanticSymbolID
+		referenceKeys    map[SemanticReference]struct{}
+		callBySpan       map[source.Span]int
+		typeFactBySpan   map[source.Span]int
+		byteOffsets      []int
+	}
+)
+
+const (
+	SemanticSymbolBinding SemanticSymbolKind = iota + 1
+	SemanticSymbolFunctionParameter
+	SemanticSymbolUserFunction
+	SemanticSymbolBindParameter
+	SemanticSymbolLoopBinding
+	SemanticSymbolMatchBinding
+	SemanticSymbolCollectBinding
+	SemanticSymbolNamespaceAlias
+)
+
+const (
+	SemanticCallUserFunction SemanticCallKind = iota + 1
+	SemanticCallBuiltin
+	SemanticCallHost
+)
+
+func NewSemanticRecorder(src *source.Source) *SemanticRecorder {
+	end := 0
+	if src != nil {
+		end = len(src.Content())
+	}
+
+	r := &SemanticRecorder{
+		symbolByBinding:  make(map[core.BindingID]SemanticSymbolID),
+		symbolByFunction: make(map[*core.UDFInfo]SemanticSymbolID),
+		scopeByUDF:       make(map[*core.UDFScope]SemanticScopeID),
+		functionByScope:  make(map[SemanticScopeID]SemanticSymbolID),
+		bindParameters:   make(map[string]SemanticSymbolID),
+		aliases:          make(map[string]SemanticSymbolID),
+		referenceKeys:    make(map[SemanticReference]struct{}),
+		callBySpan:       make(map[source.Span]int),
+		typeFactBySpan:   make(map[source.Span]int),
+		byteOffsets:      semanticByteOffsets(src),
+	}
+
+	root := r.newScope(source.Span{Start: 0, End: end}, 0)
+	r.scopeStack = append(r.scopeStack, root)
+
+	return r
+}
+
+func (r *SemanticRecorder) Snapshot() SemanticSnapshot {
+	if r == nil {
+		return SemanticSnapshot{}
+	}
+
+	calls := make([]SemanticCall, len(r.calls))
+	for i := range r.calls {
+		calls[i] = r.calls[i]
+		calls[i].ArgumentSpans = append([]source.Span(nil), r.calls[i].ArgumentSpans...)
+	}
+
+	return SemanticSnapshot{
+		Symbols:    append([]SemanticSymbol(nil), r.symbols...),
+		References: append([]SemanticReference(nil), r.references...),
+		Calls:      calls,
+		TypeFacts:  append([]SemanticTypeFact(nil), r.typeFacts...),
+		Scopes:     append([]SemanticScope(nil), r.scopes...),
+	}
+}
+
+func (r *SemanticRecorder) RegisterGlobalUDFScope(scope *core.UDFScope) {
+	if r == nil || scope == nil || len(r.scopeStack) == 0 {
+		return
+	}
+
+	r.scopeByUDF[scope] = r.scopeStack[0]
+}
+
+func (r *SemanticRecorder) RecordUserFunction(fn *core.UDFInfo) SemanticSymbolID {
+	if r == nil || fn == nil || fn.Decl == nil || fn.Scope == nil || fn.BodyScope == nil {
+		return 0
+	}
+
+	if id, ok := r.symbolByFunction[fn]; ok {
+		return id
+	}
+
+	ownerScope, ok := r.scopeByUDF[fn.Scope]
+	if !ok {
+		return 0
+	}
+
+	decl := r.normalizeSpan(ruleSpan(fn.Decl))
+	selection := decl
+
+	if name := fn.Decl.FunctionName(); name != nil {
+		selection = r.normalizeSpan(ruleSpan(name))
+	}
+
+	id := r.addSymbol(SemanticSymbol{
+		Name:           fn.DisplayName,
+		Kind:           SemanticSymbolUserFunction,
+		Type:           core.TypeAny,
+		Declaration:    decl,
+		Selection:      selection,
+		Scope:          ownerScope,
+		Activation:     r.scope(ownerScope).Span.Start,
+		HasDeclaration: true,
+	})
+	r.symbolByFunction[fn] = id
+
+	bodyRuleSpan := ruleSpan(fn.Decl)
+
+	if body := fn.Decl.FunctionBody(); body != nil {
+		bodyRuleSpan = ruleSpan(body)
+	}
+
+	bodySpan := r.normalizeSpan(bodyRuleSpan)
+
+	functionScope := r.newScope(bodySpan, ownerScope)
+	r.scopeByUDF[fn.BodyScope] = functionScope
+	r.functionByScope[functionScope] = id
+
+	for _, param := range fn.Params {
+		paramCtx := functionParameterByID(fn.Decl, param.ID)
+		if paramCtx == nil {
+			continue
+		}
+
+		span := ruleSpan(paramCtx)
+		r.RecordBinding(param.ID, param.Name, SemanticSymbolFunctionParameter, span, span, false, core.TypeAny, bodyRuleSpan.Start, id, functionScope)
+	}
+
+	return id
+}
+
+func (r *SemanticRecorder) PushUDFScope(fn *core.UDFInfo) bool {
+	if r == nil || fn == nil {
+		return false
+	}
+
+	scope, ok := r.scopeByUDF[fn.BodyScope]
+	if !ok {
+		return false
+	}
+
+	r.scopeStack = append(r.scopeStack, scope)
+
+	return true
+}
+
+func (r *SemanticRecorder) EnterScope(span source.Span) SemanticScopeID {
+	if r == nil {
+		return 0
+	}
+
+	id := r.newScope(r.normalizeSpan(span), r.CurrentScope())
+	r.scopeStack = append(r.scopeStack, id)
+
+	return id
+}
+
+func (r *SemanticRecorder) ExitScope() {
+	if r == nil || len(r.scopeStack) <= 1 {
+		return
+	}
+
+	r.scopeStack = r.scopeStack[:len(r.scopeStack)-1]
+}
+
+func (r *SemanticRecorder) CurrentScope() SemanticScopeID {
+	if r == nil || len(r.scopeStack) == 0 {
+		return 0
+	}
+
+	return r.scopeStack[len(r.scopeStack)-1]
+}
+
+func (r *SemanticRecorder) RecordBinding(
+	id core.BindingID,
+	name string,
+	kind SemanticSymbolKind,
+	declaration source.Span,
+	selection source.Span,
+	mutable bool,
+	typ core.ValueType,
+	activation int,
+	function SemanticSymbolID,
+	scope SemanticScopeID,
+) SemanticSymbolID {
+	if r == nil || id == core.InvalidBindingID || name == "" || name == core.IgnorePseudoVariable || name == core.PseudoVariable {
+		return 0
+	}
+
+	if existing, ok := r.symbolByBinding[id]; ok {
+		r.updateSymbolType(existing, typ)
+
+		return existing
+	}
+
+	if scope == 0 {
+		scope = r.CurrentScope()
+	}
+
+	declaration = r.normalizeSpan(declaration)
+	selection = r.normalizeSpan(selection)
+	activation = r.normalizeOffset(activation)
+
+	symbol := SemanticSymbol{
+		Function:       function,
+		Name:           name,
+		Kind:           kind,
+		Type:           typ,
+		Declaration:    declaration,
+		Selection:      selection,
+		Scope:          scope,
+		Activation:     activation,
+		Mutable:        mutable,
+		HasDeclaration: true,
+	}
+
+	symbolID := r.addSymbol(symbol)
+	r.symbolByBinding[id] = symbolID
+
+	return symbolID
+}
+
+func (r *SemanticRecorder) UpdateBindingType(id core.BindingID, typ core.ValueType) {
+	if r == nil {
+		return
+	}
+
+	symbolID, ok := r.symbolByBinding[id]
+	if !ok {
+		return
+	}
+
+	r.updateSymbolType(symbolID, typ)
+}
+
+func (r *SemanticRecorder) RecordBindingReference(id core.BindingID, span source.Span) {
+	if r == nil || id == core.InvalidBindingID {
+		return
+	}
+
+	span = r.normalizeSpan(span)
+	if !validSpan(span) {
+		return
+	}
+
+	symbol, ok := r.symbolByBinding[id]
+	if !ok {
+		return
+	}
+
+	r.recordReference(symbol, span)
+}
+
+func (r *SemanticRecorder) RecordUserFunctionReference(fn *core.UDFInfo, span source.Span) {
+	if r == nil || fn == nil {
+		return
+	}
+
+	span = r.normalizeSpan(span)
+	if !validSpan(span) {
+		return
+	}
+
+	symbol, ok := r.symbolByFunction[fn]
+	if !ok {
+		return
+	}
+
+	r.recordReference(symbol, span)
+}
+
+func (r *SemanticRecorder) RecordBindParameter(name string, span source.Span) {
+	if r == nil || name == "" {
+		return
+	}
+
+	span = r.normalizeSpan(span)
+	if !validSpan(span) {
+		return
+	}
+
+	symbol, ok := r.bindParameters[name]
+	if !ok {
+		symbol = r.addSymbol(SemanticSymbol{
+			Name:       name,
+			Kind:       SemanticSymbolBindParameter,
+			Type:       core.TypeAny,
+			Scope:      r.scopeStack[0],
+			Activation: r.scope(r.scopeStack[0]).Span.Start,
+		})
+		r.bindParameters[name] = symbol
+	}
+
+	r.recordReference(symbol, span)
+}
+
+func (r *SemanticRecorder) RecordNamespaceAlias(name string, declaration, selection source.Span) {
+	if r == nil || name == "" {
+		return
+	}
+
+	declaration = r.normalizeSpan(declaration)
+	selection = r.normalizeSpan(selection)
+	if !validSpan(selection) {
+		return
+	}
+
+	symbol := r.addSymbol(SemanticSymbol{
+		Name:           name,
+		Kind:           SemanticSymbolNamespaceAlias,
+		Type:           core.TypeAny,
+		Declaration:    declaration,
+		Selection:      selection,
+		Scope:          r.scopeStack[0],
+		Activation:     r.scope(r.scopeStack[0]).Span.Start,
+		HasDeclaration: true,
+	})
+	r.aliases[name] = symbol
+}
+
+func (r *SemanticRecorder) RecordNamespaceAliasReference(name string, span source.Span) {
+	if r == nil || name == "" {
+		return
+	}
+
+	span = r.normalizeSpan(span)
+	if !validSpan(span) {
+		return
+	}
+
+	symbol, ok := r.aliases[name]
+	if !ok {
+		return
+	}
+
+	r.recordReference(symbol, span)
+}
+
+func (r *SemanticRecorder) RecordCall(call SemanticCall) {
+	if r == nil {
+		return
+	}
+
+	call.Span = r.normalizeSpan(call.Span)
+	call.CalleeSpan = r.normalizeSpan(call.CalleeSpan)
+	call.ArgumentSpans = append([]source.Span(nil), call.ArgumentSpans...)
+
+	for i := range call.ArgumentSpans {
+		call.ArgumentSpans[i] = r.normalizeSpan(call.ArgumentSpans[i])
+	}
+
+	if !validSpan(call.Span) || !validSpan(call.CalleeSpan) {
+		return
+	}
+
+	if idx, ok := r.callBySpan[call.Span]; ok {
+		r.calls[idx] = call
+
+		return
+	}
+
+	r.callBySpan[call.Span] = len(r.calls)
+	r.calls = append(r.calls, call)
+}
+
+func (r *SemanticRecorder) RecordExpressionType(ctx antlr.ParserRuleContext, typ core.ValueType) {
+	if r == nil || ctx == nil {
+		return
+	}
+
+	span := r.normalizeSpan(ruleSpan(ctx))
+	if !validSpan(span) {
+		return
+	}
+
+	if idx, ok := r.typeFactBySpan[span]; ok {
+		r.typeFacts[idx].Type = core.JoinValueTypes(r.typeFacts[idx].Type, typ)
+
+		return
+	}
+
+	r.typeFactBySpan[span] = len(r.typeFacts)
+	r.typeFacts = append(r.typeFacts, SemanticTypeFact{Span: span, Type: typ})
+}
+
+func (r *SemanticRecorder) UserFunctionSymbol(fn *core.UDFInfo) SemanticSymbolID {
+	if r == nil || fn == nil {
+		return 0
+	}
+
+	return r.symbolByFunction[fn]
+}
+
+func (r *SemanticRecorder) CurrentFunctionSymbol() SemanticSymbolID {
+	if r == nil {
+		return 0
+	}
+
+	current := r.CurrentScope()
+	for current != 0 {
+		if function := r.functionByScope[current]; function != 0 {
+			return function
+		}
+
+		current = r.scope(current).Parent
+	}
+
+	return 0
+}
+
+func (r *SemanticRecorder) Sort() {
+	if r == nil {
+		return
+	}
+
+	sort.SliceStable(r.references, func(i, j int) bool {
+		if r.references[i].Span.Start != r.references[j].Span.Start {
+			return r.references[i].Span.Start < r.references[j].Span.Start
+		}
+
+		return r.references[i].Span.End < r.references[j].Span.End
+	})
+	sort.SliceStable(r.calls, func(i, j int) bool {
+		if r.calls[i].Span.Start != r.calls[j].Span.Start {
+			return r.calls[i].Span.Start < r.calls[j].Span.Start
+		}
+
+		return r.calls[i].Span.End < r.calls[j].Span.End
+	})
+	sort.SliceStable(r.typeFacts, func(i, j int) bool {
+		if r.typeFacts[i].Span.Start != r.typeFacts[j].Span.Start {
+			return r.typeFacts[i].Span.Start < r.typeFacts[j].Span.Start
+		}
+
+		return r.typeFacts[i].Span.End < r.typeFacts[j].Span.End
+	})
+}
+
+func (r *SemanticRecorder) addSymbol(symbol SemanticSymbol) SemanticSymbolID {
+	symbol.ID = SemanticSymbolID(len(r.symbols) + 1)
+	r.symbols = append(r.symbols, symbol)
+
+	return symbol.ID
+}
+
+func (r *SemanticRecorder) recordReference(symbol SemanticSymbolID, span source.Span) {
+	reference := SemanticReference{Symbol: symbol, Span: span}
+	if _, exists := r.referenceKeys[reference]; exists {
+		return
+	}
+
+	r.referenceKeys[reference] = struct{}{}
+	r.references = append(r.references, reference)
+}
+
+func (r *SemanticRecorder) updateSymbolType(id SemanticSymbolID, typ core.ValueType) {
+	idx := int(id) - 1
+	if idx < 0 || idx >= len(r.symbols) {
+		return
+	}
+
+	r.symbols[idx].Type = core.JoinValueTypes(r.symbols[idx].Type, typ)
+}
+
+func (r *SemanticRecorder) newScope(span source.Span, parent SemanticScopeID) SemanticScopeID {
+	depth := 0
+	if parent != 0 {
+		depth = r.scope(parent).Depth + 1
+	}
+
+	id := SemanticScopeID(len(r.scopes) + 1)
+	r.scopes = append(r.scopes, SemanticScope{ID: id, Parent: parent, Span: span, Depth: depth})
+
+	return id
+}
+
+func (r *SemanticRecorder) scope(id SemanticScopeID) SemanticScope {
+	idx := int(id) - 1
+	if idx < 0 || idx >= len(r.scopes) {
+		return SemanticScope{}
+	}
+
+	return r.scopes[idx]
+}
+
+func (r *SemanticRecorder) normalizeOffset(offset int) int {
+	if r == nil || offset < 0 || offset >= len(r.byteOffsets) {
+		return offset
+	}
+
+	return r.byteOffsets[offset]
+}
+
+func (r *SemanticRecorder) normalizeSpan(span source.Span) source.Span {
+	if r == nil || span.Start < 0 {
+		return span
+	}
+
+	return source.Span{
+		Start: r.normalizeOffset(span.Start),
+		End:   r.normalizeOffset(span.End),
+	}
+}

--- a/pkg/compiler/internal/semantic_recorder_helpers.go
+++ b/pkg/compiler/internal/semantic_recorder_helpers.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"unicode/utf8"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func functionParameterByID(decl fql.IFunctionDeclarationContext, id core.BindingID) antlr.ParserRuleContext {
+	if decl == nil || decl.FunctionParameterList() == nil {
+		return nil
+	}
+
+	for _, param := range decl.FunctionParameterList().AllFunctionParameter() {
+		ctx, ok := param.(antlr.ParserRuleContext)
+		if ok && bindingIDFromRule(ctx) == id {
+			return ctx
+		}
+	}
+
+	return nil
+}
+
+func ruleSpan(ctx antlr.ParserRuleContext) source.Span {
+	if ctx == nil {
+		return source.Span{}
+	}
+
+	return parserd.SpanFromRuleContext(ctx)
+}
+
+func validSpan(span source.Span) bool {
+	return span.Start >= 0 && span.End > span.Start
+}
+
+func semanticByteOffsets(src *source.Source) []int {
+	if src == nil {
+		return []int{0}
+	}
+
+	text := src.Content()
+	offsets := make([]int, 0, utf8.RuneCountInString(text)+1)
+
+	for offset := range text {
+		offsets = append(offsets, offset)
+	}
+
+	offsets = append(offsets, len(text))
+
+	return offsets
+}

--- a/pkg/compiler/internal/udf_collect.go
+++ b/pkg/compiler/internal/udf_collect.go
@@ -39,6 +39,10 @@ func (c *UDFCatalogBuilder) BuildCatalog(program *fql.ProgramContext) {
 	c.ctx.Program.UDFs = table
 	c.ctx.Function.UDFScope = table.GlobalScope
 
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RegisterGlobalUDFScope(table.GlobalScope)
+	}
+
 	if program == nil || program.Body() == nil {
 		return
 	}
@@ -126,6 +130,7 @@ func (c *UDFCatalogBuilder) validateBindingConflicts(body *fql.BodyContext, scop
 
 		if decl := stmt.VariableDeclaration(); decl != nil {
 			c.validateVariableDeclarationConflict(decl, scope)
+
 			continue
 		}
 
@@ -160,6 +165,7 @@ func (c *UDFCatalogBuilder) validateFunctionBindingConflicts(fn *core.UDFInfo) {
 
 		if decl := stmt.VariableDeclaration(); decl != nil {
 			c.validateVariableDeclarationConflict(decl, fn.BodyScope)
+
 			continue
 		}
 
@@ -219,6 +225,7 @@ func (c *UDFCatalogBuilder) registerFunction(scope *core.UDFScope, decl *fql.Fun
 
 	if _, exists := scope.Declared[name]; exists {
 		c.ctx.Program.Errors.Add(c.ctx.Program.Errors.Create(parserd.NameError, decl, fmt.Sprintf("Function '%s' is already defined", displayName)))
+
 		return nil
 	}
 
@@ -235,6 +242,10 @@ func (c *UDFCatalogBuilder) registerFunction(scope *core.UDFScope, decl *fql.Fun
 	scope.Functions[name] = fn
 	scope.Declared[name] = fn
 	c.ctx.Program.UDFs.Functions = append(c.ctx.Program.UDFs.Functions, fn)
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.RecordUserFunction(fn)
+	}
 
 	return fn
 }
@@ -299,6 +310,7 @@ func (c *UDFCatalogBuilder) pruneUnusedFunctions(body *fql.BodyContext) {
 
 		if _, ok := reachable[fn]; ok {
 			filtered = append(filtered, fn)
+
 			continue
 		}
 

--- a/pkg/compiler/internal/udf_compile.go
+++ b/pkg/compiler/internal/udf_compile.go
@@ -119,8 +119,17 @@ func (c *UDFCompiler) withFunctionCompileState(fn *core.UDFInfo, compile func())
 	localFunction := NewFunctionContext(c.ctx.Program.Constants)
 	localFunction.UDFScope = fn.BodyScope
 	c.ctx.Function = localFunction
+	semanticScope := false
+
+	if c.ctx.Program.Semantics != nil {
+		semanticScope = c.ctx.Program.Semantics.PushUDFScope(fn)
+	}
 
 	defer func() {
+		if semanticScope {
+			c.ctx.Program.Semantics.ExitScope()
+		}
+
 		c.ctx.Function = outerFunction
 	}()
 

--- a/pkg/compiler/internal/wait_event.go
+++ b/pkg/compiler/internal/wait_event.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"github.com/antlr4-go/antlr/v4"
+
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
@@ -234,6 +237,11 @@ func (c *WaitCompiler) compileWaitForTriggerClause(ctx fql.IWaitForTriggerClause
 	c.ctx.Function.Symbols.EnterScope()
 	defer c.ctx.Function.Symbols.ExitScope()
 
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.EnterScope(parserd.SpanFromRuleContext(ctx.(antlr.ParserRuleContext)))
+		defer c.ctx.Program.Semantics.ExitScope()
+	}
+
 	if inline := ctx.WaitForTriggerInlineStatement(); inline != nil {
 		c.compileWaitForTriggerInlineStatement(inline)
 		return
@@ -344,6 +352,7 @@ func (c *WaitCompiler) emitWaitEventCleanup(state waitEventCompileState, streamR
 func (c *WaitCompiler) emitWaitEventCleanupIfReady(state waitEventCompileState, streamReg, streamReadyReg bytecode.Operand) {
 	if streamReadyReg == bytecode.NoopOperand {
 		c.emitWaitEventCleanup(state, streamReg)
+
 		return
 	}
 

--- a/pkg/compiler/internal/wait_recovery.go
+++ b/pkg/compiler/internal/wait_recovery.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"github.com/antlr4-go/antlr/v4"
+
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/core"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
 	"github.com/MontFerret/ferret/v2/pkg/parser/fql"
 )
 
@@ -52,6 +55,11 @@ func (c *WaitCompiler) CompileWithOuterRecoveryPlan(ctx fql.IWaitForExpressionCo
 
 	c.ctx.Function.Symbols.EnterScope()
 	defer c.ctx.Function.Symbols.ExitScope()
+
+	if c.ctx.Program.Semantics != nil {
+		c.ctx.Program.Semantics.EnterScope(parserd.SpanFromRuleContext(ctx.(antlr.ParserRuleContext)))
+		defer c.ctx.Program.Semantics.ExitScope()
+	}
 
 	return c.recovery.CompileOperation(c.newWaitOperationRecoverySpec(ctx, outerPlan))
 }
@@ -256,6 +264,7 @@ func (c *WaitCompiler) buildProtectedEventRecovery(
 	if hasTimeout {
 		c.ctx.Program.Emitter.EmitBoolean(timeoutStateReg, false)
 	}
+
 	c.ctx.Program.Emitter.EmitJump(recoveryLabel)
 
 	return ProtectedRecoveryRegion{
@@ -284,6 +293,7 @@ func (c *WaitCompiler) buildProtectedPredicateRecovery(
 	start := c.ctx.Program.Emitter.NewLabel()
 	success := c.ctx.Program.Emitter.NewLabel()
 	protectedTimeout := core.Label{}
+
 	if hasTimeout {
 		protectedTimeout = c.ctx.Program.Emitter.NewLabel()
 	}

--- a/pkg/compiler/panic_recovery.go
+++ b/pkg/compiler/panic_recovery.go
@@ -1,0 +1,28 @@
+package compiler
+
+import (
+	goruntime "runtime"
+
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	parserd "github.com/MontFerret/ferret/v2/pkg/parser/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func addRecoveredAnalysisDiagnostic(src *source.Source, errors *parserd.ErrorHandler, recovered any) {
+	var diagnostic *diagnostics.Diagnostic
+
+	buf := make([]byte, 1024)
+	n := goruntime.Stack(buf, false)
+	stackTrace := string(buf[:n])
+
+	switch value := recovered.(type) {
+	case string:
+		diagnostic = diagnostics.NewUnexpectedError(src, value+"\n"+stackTrace)
+	case error:
+		diagnostic = diagnostics.NewUnexpectedErrorWith(src, "unhandled panic\n"+stackTrace, value)
+	default:
+		diagnostic = diagnostics.NewUnexpectedError(src, "unhandled panic\n"+stackTrace)
+	}
+
+	errors.Add(diagnostic)
+}

--- a/pkg/compiler/program_build.go
+++ b/pkg/compiler/program_build.go
@@ -1,0 +1,54 @@
+package compiler
+
+import (
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/compiler/internal/optimization"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func buildProgram(visitor *Visitor, src *source.Source, level optimization.Level) (*bytecode.Program, error) {
+	var udfs []bytecode.UDF
+
+	if visitor.Session.Program.UDFs != nil {
+		udfs = visitor.Session.Program.UDFs.Metadata()
+	}
+
+	registers := visitor.Session.Function.Registers.Size()
+
+	for _, udf := range udfs {
+		if udf.Registers > registers {
+			registers = udf.Registers
+		}
+	}
+
+	program := &bytecode.Program{
+		ISAVersion: bytecode.Version,
+		Functions: bytecode.Functions{
+			Host:        visitor.Session.Program.HostFunctions.All(),
+			UserDefined: udfs,
+		},
+		Metadata: bytecode.Metadata{
+			CompilerVersion:        Version,
+			OptimizationLevel:      int(level),
+			AggregatePlans:         visitor.Session.Program.AggregatePlans(),
+			AggregateSelectorSlots: visitor.Session.Program.Emitter.AggregateSelectorSlots(),
+			CallArgumentSpans:      visitor.Session.Program.Emitter.CallArgumentSpans(),
+			MatchFailTargets:       visitor.Session.Program.Emitter.MatchFailTargets(),
+			DebugSpans:             visitor.Session.Program.Emitter.Spans(),
+			DebugPoints:            visitor.Session.Program.DebugPoints,
+			Labels:                 visitor.Session.Program.Emitter.Labels(),
+		},
+		Source:     src,
+		Bytecode:   visitor.Session.Program.Emitter.Bytecode(),
+		Constants:  visitor.Session.Function.Symbols.Constants(),
+		CatchTable: visitor.Session.Program.CatchTable.All(),
+		Registers:  registers,
+		Params:     visitor.Session.Program.HostParams.Names(),
+	}
+
+	if err := optimization.Run(program, level); err != nil {
+		return nil, err
+	}
+
+	return program, nil
+}

--- a/pkg/compiler/semantic.go
+++ b/pkg/compiler/semantic.go
@@ -1,0 +1,120 @@
+package compiler
+
+import (
+	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+type (
+	// SymbolID identifies a semantic symbol within one Analysis result.
+	// Zero is reserved as an invalid ID. IDs are not stable across analyses.
+	SymbolID uint32
+
+	// SymbolKind classifies a source-visible semantic symbol.
+	SymbolKind uint8
+
+	// CallKind classifies a resolved function call.
+	CallKind uint8
+
+	// ValueType is a type fact established by the existing compiler pipeline.
+	// Unknown means the compiler has not established a type; Any is a known
+	// dynamic value.
+	ValueType uint8
+
+	// Symbol describes a source-visible declaration or analysis-local bind parameter.
+	Symbol struct {
+		Name            string
+		DeclarationSpan source.Span
+		SelectionSpan   source.Span
+		ID              SymbolID
+		Kind            SymbolKind
+		Type            ValueType
+		Mutable         bool
+		HasDeclaration  bool
+	}
+
+	// Reference is a resolved source reference to a symbol.
+	Reference struct {
+		Symbol SymbolID
+		Span   source.Span
+	}
+
+	// Call describes a compiler-resolved call site.
+	Call struct {
+		Name          string
+		Identity      string
+		ArgumentSpans []source.Span
+		Span          source.Span
+		CalleeSpan    source.Span
+		Target        SymbolID
+		Kind          CallKind
+		ResultType    ValueType
+	}
+
+	// TypeFact describes the compiler-established type for an expression span.
+	TypeFact struct {
+		Span source.Span
+		Type ValueType
+	}
+
+	analysisScopeID uint32
+
+	analysisScope struct {
+		ID     analysisScopeID
+		Parent analysisScopeID
+		Span   source.Span
+		Depth  int
+	}
+
+	analysisSymbolMetadata struct {
+		Function   SymbolID
+		Scope      analysisScopeID
+		Activation int
+	}
+
+	analysisData struct {
+		symbols        []Symbol
+		references     []Reference
+		calls          []Call
+		diagnostics    []*diagnostics.Diagnostic
+		typeFacts      []TypeFact
+		scopes         []analysisScope
+		symbolMetadata []analysisSymbolMetadata
+		sourceLength   int
+	}
+)
+
+// InvalidSymbolID represents the absence of a semantic symbol target.
+const InvalidSymbolID SymbolID = 0
+
+const (
+	SymbolKindBinding SymbolKind = iota + 1
+	SymbolKindFunctionParameter
+	SymbolKindUDF
+	SymbolKindBindParameter
+	SymbolKindLoopBinding
+	SymbolKindMatchBinding
+	SymbolKindCollectBinding
+	SymbolKindNamespaceAlias
+)
+
+const (
+	CallKindUDF CallKind = iota + 1
+	CallKindBuiltin
+	CallKindHost
+)
+
+const (
+	ValueTypeUnknown ValueType = iota
+	ValueTypeAny
+	ValueTypeNone
+	ValueTypeInteger
+	ValueTypeFloat
+	ValueTypeDuration
+	ValueTypeBoolean
+	ValueTypeString
+	ValueTypeArray
+	ValueTypeObject
+	ValueTypeList
+	ValueTypeMap
+)

--- a/pkg/compiler/visitor.go
+++ b/pkg/compiler/visitor.go
@@ -19,9 +19,24 @@ type Visitor struct {
 }
 
 func NewVisitor(src *source.Source, errors *parser.ErrorHandler, level optimization.Level) *Visitor {
+	return newVisitor(src, errors, level, nil)
+}
+
+func newVisitor(
+	src *source.Source,
+	errors *parser.ErrorHandler,
+	level optimization.Level,
+	recorder *internal.SemanticRecorder,
+) *Visitor {
 	v := new(Visitor)
 	v.BaseFqlParserVisitor = new(fql.BaseFqlParserVisitor)
-	v.Session = internal.NewCompilationSession(src, errors, level)
+
+	if recorder == nil {
+		v.Session = internal.NewCompilationSession(src, errors, level)
+	} else {
+		v.Session = internal.NewSemanticCompilationSession(src, errors, level, recorder)
+	}
+
 	v.Frontend = internal.NewCompilationFrontend(v.Session)
 
 	return v
@@ -35,11 +50,13 @@ func (v *Visitor) VisitProgram(ctx *fql.ProgramContext) interface{} {
 	v.Frontend.UDFCatalog.BuildCatalog(ctx)
 	v.Frontend.ForwardBindings.BuildProgram(ctx)
 	v.Frontend.NameCollisions.ValidateProgram(ctx)
+
 	if ctx != nil {
 		if body, ok := ctx.Body().(*fql.BodyContext); ok {
 			v.Frontend.CaptureAnalyzer.AnalyzeProgram(body)
 		}
 	}
+
 	v.Frontend.Statements.Compile(ctx.Body())
 	v.Frontend.UDFs.CompileAll()
 
@@ -88,6 +105,9 @@ func (v *Visitor) VisitHead(ctx *fql.HeadContext) interface{} {
 	}
 
 	v.Session.Program.UseAliases[alias] = namespace
+	if recorder := v.Session.Program.Semantics; recorder != nil {
+		recorder.RecordNamespaceAlias(alias, parser.SpanFromRuleContext(ctx), parser.SpanFromToken(aliasTok))
+	}
 
 	return nil
 }

--- a/test/benchmarks/bench_compiler_analysis_test.go
+++ b/test/benchmarks/bench_compiler_analysis_test.go
@@ -1,0 +1,41 @@
+package benchmarks_test
+
+import (
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+const compilerAnalysisQuery = `
+USE WEB::HTML AS html
+LET base = @base
+
+FUNC outer(value) {
+  LET carried = base + value
+
+  FUNC middle(extra) {
+    RETURN FOR item, index IN [carried, extra]
+      FILTER item > 0
+      RETURN html::PARSE(TO_STRING(item + index))
+  }
+
+  RETURN middle(value)
+}
+
+RETURN outer(1)
+`
+
+func BenchmarkCompilerAnalyzeSemanticSnapshot(b *testing.B) {
+	compilerInstance := compiler.New(compiler.WithOptimizationLevel(compiler.O1), compiler.WithDebugInfo())
+	src := source.New("analysis_benchmark", compilerAnalysisQuery)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := compilerInstance.Analyze(src); err != nil {
+			b.Fatalf("analyze failed: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new semantic analysis API to the `compiler` package, enabling advanced semantic inspection of Ferret source code. The main addition is the new `Analysis` type, which provides immutable, queryable access to semantic information such as symbols, references, calls, diagnostics, and type facts. The changes also refactor parts of the compiler to support this new API, including the addition of a public `Analyze` method, helpers for semantic data extraction, and improved error handling and frontend orchestration.

The most important changes are:

**Semantic Analysis API:**

* Added a new `Analysis` type in `analysis.go` that provides immutable, queryable semantic information about Ferret source code, including methods to access symbols, references, calls, diagnostics, type facts, and source-visible symbol queries.
* Added `analysis_build.go` to build the `Analysis` object from internal semantic snapshots, including conversion functions for symbol kinds, call kinds, and value types.
* Added `analysis_helpers.go` with utility functions for cloning diagnostics, span calculations, and error aggregation for the new semantic API.

**Compiler API and Refactoring:**

* Added a public `Analyze` method to the `Compiler` type, which parses and semantically analyzes source code, returning an `Analysis` and any diagnostics. Refactored error handling and moved frontend orchestration into a new helper.
* Added `frontend_driver.go` to encapsulate the parsing and visiting logic for both compilation and analysis, improving code reuse and maintainability.

**Internal Semantic Data Tracking:**

* Updated `internal/binding_compiler.go` to record variable declarations and destructuring patterns into the semantic recorder, enabling richer semantic data for analysis. [[1]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01R107-R135) [[2]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01R145-R149) [[3]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01L147-R176) [[4]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01R185-R187) [[5]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01L165-R197) [[6]](diffhunk://#diff-3e343c45f37650c4936b2ea8936196e23f382797adff201f4d86ed02975f8d01L175-R207)

These changes collectively provide a foundation for advanced tooling, such as language servers, by exposing detailed semantic information about Ferret scripts.