### PR TITLE
feat(debugger): inspect caller frame bindings

### DIFF
--- a/debug_session_benchmark_test.go
+++ b/debug_session_benchmark_test.go
@@ -49,3 +49,55 @@ RETURN FOR i IN 1..100
 		}
 	}
 }
+
+func BenchmarkDebugSessionPausedCallerFrameInspection(b *testing.B) {
+	engine, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer engine.Close()
+
+	plan, err := engine.CompileDebug(context.Background(), source.New("caller.fql", `LET base = 1
+FUNC outer(p) {
+  LET carried = base + p
+  FUNC inner(q) {
+    RETURN carried + q
+  }
+  LET result = inner(3)
+  RETURN result
+}
+RETURN outer(2)`))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer plan.Close()
+
+	session, err := plan.NewDebugSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer session.Close()
+
+	if _, err := session.SetBreakpoint("caller.fql", 5); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := session.Start(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := session.Continue(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		locals, localsErr := session.FrameLocals(2)
+		if localsErr != nil {
+			b.Fatal(localsErr)
+		}
+		if len(locals) == 0 {
+			b.Fatal("caller frame has no locals")
+		}
+	}
+}

--- a/debug_session_udf_resolution_test.go
+++ b/debug_session_udf_resolution_test.go
@@ -2,10 +2,13 @@ package ferret
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/MontFerret/ferret/v2/pkg/debugger"
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
@@ -302,5 +305,141 @@ RETURN y`
 	formatted := diagnostics.Format(event.Error)
 	if !strings.Contains(formatted, "udf-error.fql:4") || !strings.Contains(formatted, "RETURN b / 0") {
 		t.Fatalf("expected UDF error location, got:\n%s", formatted)
+	}
+	assertFrameValues(t, session, 1, map[string]string{"x": "1"})
+	value, err := session.EvaluateFrame(context.Background(), 1, "x + 1")
+	if err != nil || value.Display != "2" {
+		t.Fatalf("unexpected runtime-error caller evaluation: %#v, %v", value, err)
+	}
+}
+
+func TestDebugSessionCallerFramesExposeBindingsCellsAndParameters(t *testing.T) {
+	engine, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer engine.Close()
+
+	query := `VAR shared = 1
+FUNC outer(p) {
+  VAR x = p + shared - shared
+  FUNC inner(q) {
+    shared = shared + q
+    LET x = shared + q
+    RETURN x
+  }
+  LET result = inner(3)
+  RETURN result
+}
+LET box = {value: 10}
+LET x = 10
+RETURN outer(2) + x + @input + box.value - 10`
+	plan, err := engine.CompileDebug(context.Background(), source.New("caller-frames.fql", query))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plan.Close()
+
+	session, err := plan.NewDebugSession(context.Background(), WithSessionParam("input", 5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	breakpoint, err := session.SetBreakpoint("caller-frames.fql", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !breakpoint.Bound || breakpoint.Line != 5 {
+		t.Fatalf("unexpected inner breakpoint: %#v", breakpoint)
+	}
+
+	if _, err := session.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	event, err := session.Continue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Reason != DebugReasonBreakpoint || event.Location.Line != 5 || event.Depth != 2 {
+		t.Fatalf("unexpected nested stop: %#v", event)
+	}
+
+	frames, err := session.Frames()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) != 3 || frames[0].Name != "inner" || frames[1].Name != "outer" || frames[2].Name != "<main>" {
+		t.Fatalf("unexpected nested frames: %#v", frames)
+	}
+
+	assertFrameValues(t, session, 0, map[string]string{"q": "3", "shared": "1", "@input": "5"})
+	assertFrameValues(t, session, 1, map[string]string{"p": "2", "x": "2", "shared": "1", "@input": "5"})
+	assertFrameValues(t, session, 2, map[string]string{"x": "10", "shared": "1", "@input": "5"})
+
+	callerLocals, err := session.FrameLocals(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var callerReference debugger.ValueReference
+	for _, local := range callerLocals {
+		if local.Name == "box" {
+			callerReference = local.Value.Reference
+		}
+	}
+	if !callerReference.Valid() {
+		t.Fatalf("expected expandable caller value: %#v", callerLocals)
+	}
+
+	value, err := session.EvaluateFrame(context.Background(), 2, "x + shared + @input")
+	if err != nil || value.Display != "16" {
+		t.Fatalf("unexpected caller evaluation: %#v, %v", value, err)
+	}
+	if _, err := session.FrameLocals(-1); !errors.Is(err, runtime.ErrInvalidArgument) {
+		t.Fatalf("expected negative frame rejection, got %v", err)
+	}
+	if _, err := session.FrameLocals(len(frames)); !errors.Is(err, runtime.ErrNotFound) {
+		t.Fatalf("expected missing frame rejection, got %v", err)
+	}
+
+	event, err = session.Step(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Location.Line != 6 {
+		t.Fatalf("unexpected mutable-cell step: %#v", event)
+	}
+	if _, err := session.Variables(callerReference); !errors.Is(err, runtime.ErrNotFound) {
+		t.Fatalf("expected caller reference to become stale on resume, got %v", err)
+	}
+	assertFrameValues(t, session, 0, map[string]string{"shared": "4", "@input": "5"})
+	assertFrameValues(t, session, 1, map[string]string{"x": "2", "shared": "4", "@input": "5"})
+	assertFrameValues(t, session, 2, map[string]string{"x": "10", "shared": "4", "@input": "5"})
+
+	value, err = session.EvaluateFrame(context.Background(), 1, "x + shared + @input")
+	if err != nil || value.Display != "11" {
+		t.Fatalf("unexpected mutable caller evaluation: %#v, %v", value, err)
+	}
+}
+
+func assertFrameValues(t *testing.T, session interface {
+	FrameLocals(int) ([]debugger.Variable, error)
+}, frame int, expected map[string]string) {
+	t.Helper()
+
+	locals, err := session.FrameLocals(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := make(map[string]string, len(locals))
+	for _, local := range locals {
+		actual[local.Name] = local.Value.Display
+	}
+
+	for name, value := range expected {
+		if actual[name] != value {
+			t.Fatalf("frame %d binding %q: expected %q, got %q in %#v", frame, name, value, actual[name], locals)
+		}
 	}
 }

--- a/pkg/debugger/session.go
+++ b/pkg/debugger/session.go
@@ -316,6 +316,12 @@ func (s *Session) Frames() ([]Frame, error) {
 
 // Locals returns the visible top-frame locals followed by bound parameters.
 func (s *Session) Locals() ([]Variable, error) {
+	return s.FrameLocals(0)
+}
+
+// FrameLocals returns the visible locals and bound parameters for one paused
+// frame. Frame indexes follow Frames: zero is the current frame.
+func (s *Session) FrameLocals(frame int) ([]Variable, error) {
 	if err := s.lockCommand(); err != nil {
 		return nil, err
 	}
@@ -324,7 +330,7 @@ func (s *Session) Locals() ([]Variable, error) {
 	if err := s.ensureOpen(); err != nil {
 		return nil, err
 	}
-	locals, err := s.execution.Locals()
+	locals, err := s.frameLocals(frame)
 
 	if err != nil {
 		return nil, err
@@ -347,6 +353,18 @@ func (s *Session) Locals() ([]Variable, error) {
 	}
 
 	return out, nil
+}
+
+func (s *Session) frameLocals(frame int) ([]vm.DebugLocal, error) {
+	if inspector, ok := s.execution.(vm.DebugFrameInspector); ok {
+		return inspector.FrameLocals(frame)
+	}
+
+	if frame != 0 {
+		return nil, runtime.Error(runtime.ErrInvalidOperation, "debug execution does not support caller frame inspection")
+	}
+
+	return s.execution.Locals()
 }
 
 // Variables returns the child variables for one expandable debugger value from
@@ -408,6 +426,11 @@ func (s *Session) Variables(reference ValueReference) ([]Variable, error) {
 // rejects calls, queries, mutation, async/event behavior, and full collection
 // execution.
 func (s *Session) Evaluate(ctx context.Context, expression string) (Value, error) {
+	return s.EvaluateFrame(ctx, 0, expression)
+}
+
+// EvaluateFrame evaluates an expression against one paused frame.
+func (s *Session) EvaluateFrame(ctx context.Context, frame int, expression string) (Value, error) {
 	if err := s.lockCommand(); err != nil {
 		return Value{}, err
 	}
@@ -416,7 +439,7 @@ func (s *Session) Evaluate(ctx context.Context, expression string) (Value, error
 	if err := s.ensureOpen(); err != nil {
 		return Value{}, err
 	}
-	locals, err := s.execution.Locals()
+	locals, err := s.frameLocals(frame)
 
 	if err != nil {
 		return Value{}, err

--- a/pkg/debugger/session_concurrency_test.go
+++ b/pkg/debugger/session_concurrency_test.go
@@ -161,7 +161,7 @@ func TestSessionCloseClearsReferencesCreatedByActiveInspection(t *testing.T) {
 
 	localsDone := make(chan error, 1)
 	go func() {
-		_, err := session.Locals()
+		_, err := session.FrameLocals(0)
 		localsDone <- err
 	}()
 	waitForSignal(t, inspectStarted, "value inspection")

--- a/pkg/debugger/session_test.go
+++ b/pkg/debugger/session_test.go
@@ -66,6 +66,13 @@ func TestSessionUsesInterfacesForBreakpointsEvaluationAndLifecycle(t *testing.T)
 	if value.Display != "2" || values.typeCalls == 0 || values.debugInfoCalls == 0 {
 		t.Fatalf("unexpected evaluated value: %#v", value)
 	}
+	if _, err := session.FrameLocals(1); !errors.Is(err, runtime.ErrInvalidOperation) {
+		t.Fatalf("expected legacy execution to reject caller inspection, got %v", err)
+	}
+	value, err = session.EvaluateFrame(context.Background(), 0, "x + 2")
+	if err != nil || value.Display != "3" {
+		t.Fatalf("unexpected legacy top-frame evaluation: %#v, %v", value, err)
+	}
 	if err := session.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/vm/debug.go
+++ b/pkg/vm/debug.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/internal/debugpoint"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/mem"
 )
 
 type (
@@ -54,6 +55,13 @@ type (
 		Params() runtime.Params
 		Frames() ([]DebugFrame, error)
 		Close() error
+	}
+
+	// DebugFrameInspector optionally exposes bindings for retained caller frames.
+	// Frame indexes follow DebugExecution.Frames: zero is the current frame and
+	// larger indexes walk callers from nearest to farthest.
+	DebugFrameInspector interface {
+		FrameLocals(frame int) ([]DebugLocal, error)
 	}
 
 	debugExecution struct {
@@ -225,19 +233,50 @@ func (d *debugExecution) Status() DebugExecutionStatus {
 
 // Locals returns values for bindings visible at the current stop.
 func (d *debugExecution) Locals() ([]DebugLocal, error) {
+	return d.FrameLocals(0)
+}
+
+// FrameLocals returns values for bindings visible in one paused frame.
+func (d *debugExecution) FrameLocals(frame int) ([]DebugLocal, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if d.status != DebugExecutionPaused || d.current == nil {
+	if d.status != DebugExecutionPaused {
 		return nil, runtime.Error(runtime.ErrInvalidOperation, "debug execution is not paused at a source location")
 	}
 
-	out := make([]DebugLocal, 0, len(d.current.Bindings))
-	for _, binding := range d.current.Bindings {
-		value := d.vm.state.valueOf(d.vm.program.Constants, binding.Register)
+	if frame < 0 {
+		return nil, runtime.Error(runtime.ErrInvalidArgument, "debug frame index must not be negative")
+	}
+
+	point := d.current
+	registers := []runtime.Value(d.vm.state.registers)
+
+	if frame > 0 {
+		callers := d.vm.state.frames.DebugTraceEntries()
+		index := frame - 1
+		if index >= len(callers) {
+			return nil, runtime.Errorf(runtime.ErrNotFound, "debug frame %d", frame)
+		}
+
+		caller := callers[index]
+		point = d.points.NearestBeforeOrAtInFunction(caller.FunctionID, caller.PC)
+		registers = caller.Registers
+	}
+
+	if point == nil {
+		return nil, runtime.Errorf(runtime.ErrNotFound, "debug frame %d has no source location", frame)
+	}
+
+	out := make([]DebugLocal, 0, len(point.Bindings))
+	for _, binding := range point.Bindings {
+		value, err := d.debugBindingValue(registers, binding.Register)
+		if err != nil {
+			return nil, err
+		}
 
 		if binding.Cell {
-			if handle, ok := d.vm.state.cellHandleOf(binding.Register); ok {
+			if handle, ok := value.(mem.CellHandle); ok {
 				if cellValue, exists := d.vm.state.cells.Get(handle); exists {
 					value = cellValue
 				}
@@ -248,6 +287,30 @@ func (d *debugExecution) Locals() ([]DebugLocal, error) {
 	}
 
 	return out, nil
+}
+
+func (d *debugExecution) debugBindingValue(
+	registers []runtime.Value,
+	operand bytecode.Operand,
+) (runtime.Value, error) {
+	switch {
+	case operand.IsRegister():
+		index := int(operand)
+		if index < 0 || index >= len(registers) {
+			return nil, runtime.Errorf(runtime.ErrUnexpected, "debug binding register %d is unavailable", index)
+		}
+
+		return normalizeValue(registers[index]), nil
+	case operand.IsConstant():
+		index := operand.Constant()
+		if index < 0 || index >= len(d.vm.program.Constants) {
+			return nil, runtime.Errorf(runtime.ErrUnexpected, "debug binding constant %d is unavailable", index)
+		}
+
+		return normalizeValue(d.vm.program.Constants[index]), nil
+	default:
+		return runtime.None, nil
+	}
 }
 
 // Params returns the bound host parameters for the current execution.

--- a/pkg/vm/debug_frame_inspection_test.go
+++ b/pkg/vm/debug_frame_inspection_test.go
@@ -1,0 +1,83 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/bytecode"
+	"github.com/MontFerret/ferret/v2/pkg/internal/debugpoint"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm/internal/frame"
+)
+
+func TestDebugExecutionFrameLocalsUseCallerRegistersAndCells(t *testing.T) {
+	callerPoint := bytecode.DebugPoint{
+		ID:         1,
+		PC:         10,
+		FunctionID: -1,
+		Bindings: []bytecode.DebugBinding{
+			{Name: "caller", Register: bytecode.NewRegister(0)},
+			{Name: "captured", Register: bytecode.NewRegister(1), Mutable: true, Cell: true},
+		},
+	}
+	currentPoint := bytecode.DebugPoint{
+		ID:         2,
+		PC:         20,
+		FunctionID: 0,
+		Bindings: []bytecode.DebugBinding{
+			{Name: "current", Register: bytecode.NewRegister(0)},
+		},
+	}
+	points, err := debugpoint.New([]bytecode.DebugPoint{callerPoint, currentPoint})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &VM{program: &bytecode.Program{}}
+	handle := instance.state.cells.New(runtime.NewInt(42))
+	instance.state.registers = []runtime.Value{runtime.NewInt(7)}
+	instance.state.frames.Push(frame.CallFrame{
+		FnID:            0,
+		ReturnPC:        12,
+		HasCallSite:     true,
+		CallerRegisters: []runtime.Value{runtime.NewInt(3), handle},
+	})
+	execution := &debugExecution{
+		vm:      instance,
+		points:  points,
+		current: &currentPoint,
+		status:  DebugExecutionPaused,
+	}
+
+	locals, err := execution.FrameLocals(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locals) != 2 || locals[0].Name != "caller" || locals[0].Value != runtime.NewInt(3) ||
+		locals[1].Name != "captured" || !locals[1].Mutable || locals[1].Value != runtime.NewInt(42) {
+		t.Fatalf("unexpected caller locals: %#v", locals)
+	}
+
+	if !instance.state.cells.Set(handle, runtime.NewInt(43)) {
+		t.Fatal("failed to update captured cell")
+	}
+	locals, err = execution.FrameLocals(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if locals[1].Value != runtime.NewInt(43) {
+		t.Fatalf("caller frame did not observe cell update: %#v", locals)
+	}
+
+	if _, err := execution.FrameLocals(-1); !errors.Is(err, runtime.ErrInvalidArgument) {
+		t.Fatalf("expected negative frame rejection, got %v", err)
+	}
+	if _, err := execution.FrameLocals(2); !errors.Is(err, runtime.ErrNotFound) {
+		t.Fatalf("expected missing frame rejection, got %v", err)
+	}
+
+	execution.status = DebugExecutionRunning
+	if _, err := execution.FrameLocals(0); !errors.Is(err, runtime.ErrInvalidOperation) {
+		t.Fatalf("expected running execution rejection, got %v", err)
+	}
+}

--- a/pkg/vm/internal/frame/stack.go
+++ b/pkg/vm/internal/frame/stack.go
@@ -1,5 +1,7 @@
 package frame
 
+import "github.com/MontFerret/ferret/v2/pkg/runtime"
+
 // CallStack manages structural call frames for UDF execution.
 type (
 	CallStack struct {
@@ -13,6 +15,7 @@ type (
 	}
 
 	DebugTraceEntry struct {
+		Registers  []runtime.Value
 		FunctionID int
 		PC         int
 	}
@@ -150,6 +153,7 @@ func (s *CallStack) DebugTraceEntries() []DebugTraceEntry {
 		traces = append(traces, DebugTraceEntry{
 			FunctionID: functionID,
 			PC:         frame.structuralCallSitePC(),
+			Registers:  frame.CallerRegisters,
 		})
 	}
 

--- a/pkg/vm/internal/frame/stack_test.go
+++ b/pkg/vm/internal/frame/stack_test.go
@@ -178,6 +178,9 @@ func TestCallStackSetTopMetadata(t *testing.T) {
 	if len(traces) != 1 || traces[0].FunctionID != -1 || traces[0].PC != 10 {
 		t.Fatalf("unexpected structural debug trace: %#v", traces)
 	}
+	if len(traces[0].Registers) != 1 || &traces[0].Registers[0] != &top.CallerRegisters[0] {
+		t.Fatalf("debug trace did not retain caller registers: %#v", traces)
+	}
 }
 
 func TestCallStackTraceEntriesOrderAndMetadata(t *testing.T) {


### PR DESCRIPTION
## Summary
- add optional VM caller-frame inspection without breaking existing DebugExecution implementations
- expose frame-indexed locals and evaluation with top-frame compatibility shims
- retain caller register windows and cell-backed values across paused frames
- cover nested calls, shadowing, parameters, runtime errors, stale references, and concurrent close
- add a paused caller-frame inspection benchmark

## Validation
- make test
- make lint
- make generate
- go test -race ./pkg/debugger . ./pkg/vm ./pkg/vm/internal/frame -count=1