### PR TITLE
api: add `WithSessionFSRoot` to support session-specific filesystem overrides

### DIFF
--- a/counting_close_filesystem_test.go
+++ b/counting_close_filesystem_test.go
@@ -1,0 +1,20 @@
+package ferret
+
+import (
+	"errors"
+	"sync/atomic"
+
+	ferretfs "github.com/MontFerret/ferret/v2/pkg/fs"
+)
+
+type countingCloseFileSystem struct {
+	ferretfs.FileSystem
+	closeErr   error
+	closeCalls atomic.Int32
+}
+
+func (f *countingCloseFileSystem) Close() error {
+	f.closeCalls.Add(1)
+
+	return errors.Join(f.closeErr, f.FileSystem.Close())
+}

--- a/debug_session_services.go
+++ b/debug_session_services.go
@@ -2,6 +2,7 @@ package ferret
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/MontFerret/ferret/v2/pkg/encoding"
@@ -19,6 +20,7 @@ type debugSessionServices struct {
 	network           ferretnet.Network
 	releasePermit     sessionPermitRelease
 	outputContentType string
+	ownsFileSystem    bool
 }
 
 func (s *debugSessionServices) BeforeRun(ctx context.Context) (context.Context, error) {
@@ -48,6 +50,12 @@ func (s *debugSessionServices) Close() error {
 		if hookErr := s.hooks.runCloseHooks(); hookErr != nil {
 			err = fmt.Errorf("close hooks: %w", hookErr)
 		}
+	}
+
+	if s.ownsFileSystem {
+		err = errors.Join(err, closeFileSystem(s.fs))
+		s.fs = nil
+		s.ownsFileSystem = false
 	}
 
 	if s.releasePermit != nil {

--- a/docs/development/runtime.md
+++ b/docs/development/runtime.md
@@ -89,7 +89,10 @@ The root embedding lifecycle is hierarchical:
   unbounded pool of VMs for that program.
 * `Session` borrows a VM, constructs an execution environment, injects logging,
   encoding, filesystem, and network services into the context, and materializes
-  output.
+  output. By default it borrows the engine filesystem.
+  `ferret.WithSessionFSRoot` replaces only that session's root while retaining
+  the engine's read-only policy; the session owns and closes the replacement
+  filesystem.
 
 `Engine.Run` is a convenience path that owns and closes its temporary plan and
 session. A caller that creates a plan or session directly owns its `Close` call.

--- a/host.go
+++ b/host.go
@@ -13,21 +13,23 @@ import (
 
 type (
 	host struct {
-		functions *runtime.Functions
-		params    runtime.Params
-		encoding  *encoding.Registry
-		logger    logging.Logger
-		fs        fs.FileSystem
-		network   ferretnet.Network
+		functions  *runtime.Functions
+		params     runtime.Params
+		encoding   *encoding.Registry
+		logger     logging.Logger
+		fs         fs.FileSystem
+		network    ferretnet.Network
+		fsReadOnly bool
 	}
 
 	hostContext struct {
-		library  runtime.Library
-		params   runtime.Params
-		encoding *encoding.Registry
-		logger   logging.Logger
-		fs       fs.FileSystem
-		network  ferretnet.Network
+		library    runtime.Library
+		params     runtime.Params
+		encoding   *encoding.Registry
+		logger     logging.Logger
+		fs         fs.FileSystem
+		network    ferretnet.Network
+		fsReadOnly bool
 	}
 )
 
@@ -53,12 +55,13 @@ func newHostContext(opts *config) (*hostContext, error) {
 	}
 
 	return &hostContext{
-		library:  opts.library,
-		params:   opts.params,
-		encoding: opts.encoding,
-		logger:   logger,
-		fs:       rootFs,
-		network:  network,
+		library:    opts.library,
+		params:     opts.params,
+		encoding:   opts.encoding,
+		logger:     logger,
+		fs:         rootFs,
+		network:    network,
+		fsReadOnly: opts.fsReadOnly,
 	}, nil
 }
 
@@ -94,11 +97,12 @@ func (h *hostContext) Build() (*host, error) {
 	}
 
 	return &host{
-		functions: funcs,
-		params:    h.params.Clone(),
-		encoding:  h.encoding.Clone(),
-		logger:    h.logger,
-		fs:        h.fs,
-		network:   h.network,
+		functions:  funcs,
+		params:     h.params.Clone(),
+		encoding:   h.encoding.Clone(),
+		logger:     h.logger,
+		fs:         h.fs,
+		network:    h.network,
+		fsReadOnly: h.fsReadOnly,
 	}, nil
 }

--- a/options_public_test.go
+++ b/options_public_test.go
@@ -122,6 +122,7 @@ func TestPublicOptionTypesRemainUsable(t *testing.T) {
 
 	sessionOptions := []ferret.SessionOption{
 		ferret.WithOutputContentType("application/json"),
+		ferret.WithSessionFSRoot(t.TempDir()),
 		ferret.WithSessionLogLevel(ferret.LogDebug),
 		ferret.WithSessionRuntimeParams(sessionParams),
 		ferret.WithSessionRuntimeParam("sessionValue", sessionValue),

--- a/plan_benchmark_test.go
+++ b/plan_benchmark_test.go
@@ -38,6 +38,33 @@ func BenchmarkPlanNewSession(b *testing.B) {
 	}
 }
 
+func BenchmarkPlanNewSessionWithSessionFSRoot(b *testing.B) {
+	root := b.TempDir()
+	engine, err := New(WithMaxIdleVMsPerPlan(1), WithMaxVMsPerPlan(1))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	plan, err := engine.Compile(context.Background(), source.NewAnonymous("RETURN 1"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = plan.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		session, sessionErr := plan.NewSession(context.Background(), WithSessionFSRoot(root))
+		if sessionErr != nil {
+			b.Fatal(sessionErr)
+		}
+		if closeErr := session.Close(); closeErr != nil {
+			b.Fatal(closeErr)
+		}
+	}
+}
+
 func BenchmarkPlanNewDebugSession(b *testing.B) {
 	engine, err := New()
 	if err != nil {
@@ -60,6 +87,33 @@ func BenchmarkPlanNewDebugSession(b *testing.B) {
 
 	for b.Loop() {
 		session, sessionErr := plan.NewDebugSession(context.Background())
+		if sessionErr != nil {
+			b.Fatal(sessionErr)
+		}
+		if closeErr := session.Close(); closeErr != nil {
+			b.Fatal(closeErr)
+		}
+	}
+}
+
+func BenchmarkPlanNewDebugSessionWithSessionFSRoot(b *testing.B) {
+	root := b.TempDir()
+	engine, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	plan, err := engine.CompileDebug(context.Background(), source.NewAnonymous("RETURN 1"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = plan.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		session, sessionErr := plan.NewDebugSession(context.Background(), WithSessionFSRoot(root))
 		if sessionErr != nil {
 			b.Fatal(sessionErr)
 		}

--- a/plan_session.go
+++ b/plan_session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MontFerret/ferret/v2/pkg/bytecode"
 	"github.com/MontFerret/ferret/v2/pkg/debugger"
+	"github.com/MontFerret/ferret/v2/pkg/fs"
 	"github.com/MontFerret/ferret/v2/pkg/logging"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/vm"
@@ -18,13 +19,15 @@ type (
 	}
 
 	planSessionDependencies struct {
-		logger  logging.Logger
-		hooks   sessionHooks
-		program *bytecode.Program
-		host    *host
-		limiter *sessionLimiter
-		pool    *vm.Pool
-		options sessionOptions
+		logger         logging.Logger
+		hooks          sessionHooks
+		program        *bytecode.Program
+		host           *host
+		limiter        *sessionLimiter
+		pool           *vm.Pool
+		filesystem     fs.FileSystem
+		options        sessionOptions
+		ownsFileSystem bool
 	}
 )
 
@@ -66,6 +69,25 @@ func newPlanSession[T any](
 		return session, err
 	}
 
+	filesystem := h.fs
+	ownsFileSystem := false
+	if options.fsRoot != "" {
+		filesystem, err = fs.New(fs.WithRoot(options.fsRoot), fs.WithReadOnly(h.fsReadOnly))
+		if err != nil {
+			return session, fmt.Errorf("filesystem: %w", err)
+		}
+
+		ownsFileSystem = true
+	}
+
+	fileSystemTransferred := false
+
+	defer func() {
+		if ownsFileSystem && !fileSystemTransferred {
+			err = errors.Join(err, closeFileSystem(filesystem))
+		}
+	}()
+
 	logger, err := logging.NewFrom(h.logger, options.logger...)
 	if err != nil {
 		return session, fmt.Errorf("logger: %w", err)
@@ -85,17 +107,20 @@ func newPlanSession[T any](
 	}()
 
 	session, err = build(planSessionDependencies{
-		program: program,
-		host:    h,
-		hooks:   hooks,
-		limiter: limiter,
-		pool:    pool,
-		options: options,
-		logger:  logger,
+		program:        program,
+		host:           h,
+		hooks:          hooks,
+		limiter:        limiter,
+		pool:           pool,
+		filesystem:     filesystem,
+		options:        options,
+		logger:         logger,
+		ownsFileSystem: ownsFileSystem,
 	})
 
 	if err == nil {
 		releaseOnReturn = false
+		fileSystemTransferred = true
 	}
 
 	return session, err
@@ -120,12 +145,13 @@ func buildSession(dependencies planSessionDependencies) (*Session, error) {
 		vm:                instance,
 		env:               environment,
 		logger:            dependencies.logger,
-		fs:                dependencies.host.fs,
+		fs:                dependencies.filesystem,
 		network:           dependencies.host.network,
 		encoding:          dependencies.host.encoding,
 		outputContentType: dependencies.options.outputContentType,
 		hooks:             dependencies.hooks,
 		release:           newSessionPermitRelease(dependencies.limiter, dependencies.pool),
+		ownsFileSystem:    dependencies.ownsFileSystem,
 	}, nil
 }
 
@@ -155,8 +181,9 @@ func buildDebugSession(dependencies planSessionDependencies) (*DebugSession, err
 			encoding:          dependencies.host.encoding,
 			outputContentType: dependencies.options.outputContentType,
 			logger:            dependencies.logger,
-			fs:                dependencies.host.fs,
+			fs:                dependencies.filesystem,
 			network:           dependencies.host.network,
+			ownsFileSystem:    dependencies.ownsFileSystem,
 		},
 		Source:      dependencies.program.Source,
 		DebugPoints: dependencies.program.Metadata.DebugPoints,

--- a/plan_session.go
+++ b/plan_session.go
@@ -69,6 +69,24 @@ func newPlanSession[T any](
 		return session, err
 	}
 
+	logger, err := logging.NewFrom(h.logger, options.logger...)
+	if err != nil {
+		return session, fmt.Errorf("logger: %w", err)
+	}
+
+	if err = limiter.Acquire(ctx); err != nil {
+		return session, err
+	}
+
+	releaseOnReturn := true
+	defer func() {
+		// Construction errors and panics retain ownership here. Successful
+		// construction transfers the permit release to the returned session.
+		if releaseOnReturn {
+			limiter.Release()
+		}
+	}()
+
 	filesystem := h.fs
 	ownsFileSystem := false
 	if options.fsRoot != "" {
@@ -85,24 +103,6 @@ func newPlanSession[T any](
 	defer func() {
 		if ownsFileSystem && !fileSystemTransferred {
 			err = errors.Join(err, closeFileSystem(filesystem))
-		}
-	}()
-
-	logger, err := logging.NewFrom(h.logger, options.logger...)
-	if err != nil {
-		return session, fmt.Errorf("logger: %w", err)
-	}
-
-	if err = limiter.Acquire(ctx); err != nil {
-		return session, err
-	}
-
-	releaseOnReturn := true
-	defer func() {
-		// Construction errors and panics retain ownership here. Successful
-		// construction transfers the permit release to the returned session.
-		if releaseOnReturn {
-			limiter.Release()
 		}
 	}()
 

--- a/session.go
+++ b/session.go
@@ -40,6 +40,7 @@ type (
 		network           ferretnet.Network
 		release           sessionPermitRelease
 		outputContentType string
+		ownsFileSystem    bool
 		closeOnce         sync.Once
 		closed            atomic.Bool
 	}
@@ -91,7 +92,8 @@ func (s *Session) extendContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-// Close releases the session's borrowed VM and runs close hooks.
+// Close releases the session's borrowed VM, runs close hooks, and closes any
+// filesystem created specifically for the session.
 // It is idempotent and safe to call multiple times, including concurrently.
 func (s *Session) Close() error {
 	if s == nil {
@@ -103,12 +105,20 @@ func (s *Session) Close() error {
 
 		instance := s.vm
 		release := s.release
+		filesystem := s.fs
+		ownsFileSystem := s.ownsFileSystem
 
 		s.vm = nil
 		s.release = nil
+		s.fs = nil
+		s.ownsFileSystem = false
 
 		if hookErr := s.hooks.runCloseHooks(); hookErr != nil {
 			s.closeErr = fmt.Errorf("close hooks: %w", hookErr)
+		}
+
+		if ownsFileSystem {
+			s.closeErr = errors.Join(s.closeErr, closeFileSystem(filesystem))
 		}
 
 		if release != nil && instance != nil {

--- a/session_filesystem_test.go
+++ b/session_filesystem_test.go
@@ -1,0 +1,322 @@
+package ferret
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	ferretfs "github.com/MontFerret/ferret/v2/pkg/fs"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestSessionFSRootOverridesEngineFSRoot(t *testing.T) {
+	t.Parallel()
+
+	engineRoot := t.TempDir()
+	sessionRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(engineRoot, "value.txt"), []byte("engine"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionRoot, "value.txt"), []byte("session"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := mustNewEngine(t, WithFSRoot(engineRoot))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, `RETURN TO_STRING(IO::FS::READ("value.txt"))`)
+	defer func() { _ = plan.Close() }()
+
+	inherited := mustNewSession(t, plan)
+	inheritedOutput, err := inherited.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run inherited filesystem session: %v", err)
+	}
+	if err := inherited.Close(); err != nil {
+		t.Fatalf("close inherited filesystem session: %v", err)
+	}
+	if got := string(inheritedOutput.Content); got != `"engine"` {
+		t.Fatalf("inherited filesystem output = %s, want %q", got, "engine")
+	}
+
+	overridden := mustNewSession(t, plan, WithSessionFSRoot(sessionRoot))
+	overriddenOutput, err := overridden.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run overridden filesystem session: %v", err)
+	}
+	if err := overridden.Close(); err != nil {
+		t.Fatalf("close overridden filesystem session: %v", err)
+	}
+	if got := string(overriddenOutput.Content); got != `"session"` {
+		t.Fatalf("overridden filesystem output = %s, want %q", got, "session")
+	}
+}
+
+func TestSessionFSRootWritesOutsideEngineFSRoot(t *testing.T) {
+	t.Parallel()
+
+	engineRoot := t.TempDir()
+	sessionRoot := t.TempDir()
+	engine := mustNewEngine(t, WithFSRoot(engineRoot))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, `RETURN IO::FS::WRITE("created.txt", TO_BINARY("session"))`)
+	defer func() { _ = plan.Close() }()
+
+	session := mustNewSession(t, plan, WithSessionFSRoot(sessionRoot))
+	if _, err := session.Run(context.Background()); err != nil {
+		t.Fatalf("run session with overridden filesystem: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close session with overridden filesystem: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(sessionRoot, "created.txt"))
+	if err != nil {
+		t.Fatalf("read session-root output: %v", err)
+	}
+	if string(content) != "session" {
+		t.Fatalf("session-root output = %q, want %q", content, "session")
+	}
+	if _, err := os.Stat(filepath.Join(engineRoot, "created.txt")); !os.IsNotExist(err) {
+		t.Fatalf("session write escaped to the engine root: %v", err)
+	}
+}
+
+func TestSessionFSRootPreservesEngineReadOnlyPolicy(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t, WithFSRoot(t.TempDir()), WithFSReadOnly())
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, `RETURN IO::FS::WRITE("created.txt", TO_BINARY("value"))`)
+	defer func() { _ = plan.Close() }()
+
+	sessionRoot := t.TempDir()
+	session := mustNewSession(t, plan, WithSessionFSRoot(sessionRoot))
+	defer func() { _ = session.Close() }()
+
+	if _, err := session.Run(context.Background()); !errors.Is(err, ferretfs.ErrReadOnly) {
+		t.Fatalf("run error = %v, want %v", err, ferretfs.ErrReadOnly)
+	}
+	if _, err := os.Stat(filepath.Join(sessionRoot, "created.txt")); !os.IsNotExist(err) {
+		t.Fatalf("read-only session created a file: %v", err)
+	}
+}
+
+func TestConcurrentSessionsUseIndependentFSRoots(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t, WithFSRoot(t.TempDir()))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, `RETURN TO_STRING(IO::FS::READ("value.txt"))`)
+	defer func() { _ = plan.Close() }()
+
+	roots := []string{t.TempDir(), t.TempDir()}
+	for i, value := range []string{"first", "second"} {
+		if err := os.WriteFile(filepath.Join(roots[i], "value.txt"), []byte(value), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sessions := []*Session{
+		mustNewSession(t, plan, WithSessionFSRoot(roots[0])),
+		mustNewSession(t, plan, WithSessionFSRoot(roots[1])),
+	}
+	defer func() {
+		for _, session := range sessions {
+			_ = session.Close()
+		}
+	}()
+
+	outputs := make([]string, len(sessions))
+	errs := make([]error, len(sessions))
+	var wait sync.WaitGroup
+	for i, session := range sessions {
+		wait.Add(1)
+		go func(index int, current *Session) {
+			defer wait.Done()
+			output, err := current.Run(context.Background())
+			errs[index] = err
+			if output != nil {
+				outputs[index] = string(output.Content)
+			}
+		}(i, session)
+	}
+	wait.Wait()
+
+	for i, want := range []string{`"first"`, `"second"`} {
+		if errs[i] != nil {
+			t.Fatalf("session %d error = %v", i, errs[i])
+		}
+		if outputs[i] != want {
+			t.Fatalf("session %d output = %s, want %s", i, outputs[i], want)
+		}
+	}
+}
+
+func TestSessionClosesOwnedFSRootWithoutClosingBorrowedRoot(t *testing.T) {
+	t.Parallel()
+
+	engineRoot := t.TempDir()
+	engine := mustNewEngine(t, WithFSRoot(engineRoot))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+
+	borrowed := mustNewSession(t, plan)
+	if err := borrowed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := engine.host.fs.Stat("."); err != nil {
+		t.Fatalf("closing a default session closed the engine filesystem: %v", err)
+	}
+
+	owned := mustNewSession(t, plan, WithSessionFSRoot(t.TempDir()))
+	ownedFS := owned.fs
+	if err := owned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ownedFS.Stat("."); err == nil {
+		t.Fatal("closing a session did not close its owned filesystem")
+	}
+}
+
+func TestSessionCloseJoinsOwnedFileSystemErrorExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	hookErr := errors.New("session hook close failed")
+	fileSystemErr := errors.New("session filesystem close failed")
+	engine := mustNewEngine(t, WithSessionCloseHook(func() error { return hookErr }))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+	session := mustNewSession(t, plan, WithSessionFSRoot(t.TempDir()))
+
+	filesystem := &countingCloseFileSystem{FileSystem: session.fs, closeErr: fileSystemErr}
+	session.fs = filesystem
+	firstErr := session.Close()
+	secondErr := session.Close()
+
+	if !errors.Is(firstErr, hookErr) || !errors.Is(firstErr, fileSystemErr) {
+		t.Fatalf("first close error = %v, want hook and filesystem failures", firstErr)
+	}
+	if firstErr != secondErr {
+		t.Fatalf("repeated close returned different errors: %v and %v", firstErr, secondErr)
+	}
+	if calls := filesystem.closeCalls.Load(); calls != 1 {
+		t.Fatalf("filesystem close calls = %d, want 1", calls)
+	}
+}
+
+func TestDebugSessionUsesAndClosesOwnedFSRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fileSystemErr := errors.New("debug session filesystem close failed")
+	if err := os.WriteFile(filepath.Join(root, "value.txt"), []byte("debug"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := mustNewEngine(t, WithFSRoot(t.TempDir()))
+	defer func() { _ = engine.Close() }()
+	plan, err := engine.CompileDebug(
+		context.Background(),
+		source.NewAnonymous(`RETURN TO_STRING(IO::FS::READ("value.txt"))`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = plan.Close() }()
+
+	var filesystem *countingCloseFileSystem
+	session, err := newPlanSession(
+		plan,
+		context.Background(),
+		[]SessionOption{WithSessionFSRoot(root)},
+		planSessionSetup{requiresDebugInfo: true},
+		func(dependencies planSessionDependencies) (*DebugSession, error) {
+			filesystem = &countingCloseFileSystem{
+				FileSystem: dependencies.filesystem,
+				closeErr:   fileSystemErr,
+			}
+			dependencies.filesystem = filesystem
+
+			return buildDebugSession(dependencies)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := session.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	event, err := session.Continue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Output == nil || string(event.Output.Content) != `"debug"` {
+		t.Fatalf("debug output = %#v, want %q", event.Output, "debug")
+	}
+	firstErr := session.Close()
+	secondErr := session.Close()
+	if !errors.Is(firstErr, fileSystemErr) {
+		t.Fatalf("first debug close error = %v, want %v", firstErr, fileSystemErr)
+	}
+	if firstErr != secondErr {
+		t.Fatalf("repeated debug close returned different errors: %v and %v", firstErr, secondErr)
+	}
+	if calls := filesystem.closeCalls.Load(); calls != 1 {
+		t.Fatalf("debug filesystem close calls = %d, want 1", calls)
+	}
+}
+
+func TestNewPlanSessionClosesOwnedFSRootOnBuildFailure(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t)
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+
+	buildErr := errors.New("session build failed")
+	var filesystem ferretfs.FileSystem
+	_, err := newPlanSession(
+		plan,
+		context.Background(),
+		[]SessionOption{WithSessionFSRoot(t.TempDir())},
+		planSessionSetup{},
+		func(dependencies planSessionDependencies) (struct{}, error) {
+			filesystem = dependencies.filesystem
+
+			return struct{}{}, buildErr
+		},
+	)
+	if !errors.Is(err, buildErr) {
+		t.Fatalf("session construction error = %v, want %v", err, buildErr)
+	}
+	if _, err := filesystem.Stat("."); err == nil {
+		t.Fatal("session construction failure did not close its owned filesystem")
+	}
+}
+
+func TestSessionFSRootRejectsUnusablePaths(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t)
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+
+	file := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(file, []byte("value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, root := range []string{filepath.Join(t.TempDir(), "missing"), file} {
+		if session, err := plan.NewSession(context.Background(), WithSessionFSRoot(root)); err == nil {
+			_ = session.Close()
+			t.Fatalf("NewSession(%q) unexpectedly succeeded", root)
+		}
+	}
+}

--- a/session_filesystem_test.go
+++ b/session_filesystem_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	ferretfs "github.com/MontFerret/ferret/v2/pkg/fs"
 	"github.com/MontFerret/ferret/v2/pkg/source"
@@ -298,6 +299,55 @@ func TestNewPlanSessionClosesOwnedFSRootOnBuildFailure(t *testing.T) {
 	}
 	if _, err := filesystem.Stat("."); err == nil {
 		t.Fatal("session construction failure did not close its owned filesystem")
+	}
+}
+
+func TestSessionFSRootWaitsForPermitBeforeOpening(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t, WithMaxActiveSessions(1))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+
+	active := mustNewSession(t, plan)
+	defer func() { _ = active.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	session, err := plan.NewSession(ctx, WithSessionFSRoot(missingRoot))
+	if session != nil {
+		_ = session.Close()
+		t.Fatal("canceled session creation returned a session")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("session creation error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestSessionFSRootCreationFailureReleasesPermit(t *testing.T) {
+	t.Parallel()
+
+	engine := mustNewEngine(t, WithMaxActiveSessions(1))
+	defer func() { _ = engine.Close() }()
+	plan := mustCompilePlan(t, engine, coverageValidQuery)
+	defer func() { _ = plan.Close() }()
+
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	if session, err := plan.NewSession(context.Background(), WithSessionFSRoot(missingRoot)); err == nil {
+		_ = session.Close()
+		t.Fatal("session creation with a missing filesystem root unexpectedly succeeded")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	session, err := plan.NewSession(ctx)
+	if err != nil {
+		t.Fatalf("session creation after filesystem failure: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close session after filesystem failure: %v", err)
 	}
 }
 

--- a/session_options.go
+++ b/session_options.go
@@ -18,6 +18,7 @@ type (
 	sessionOptions struct {
 		logger            []logging.Option
 		outputContentType string
+		fsRoot            string
 		env               []vm.EnvironmentOption
 		debugFormat       debugger.FormatOptions
 	}
@@ -95,6 +96,19 @@ func WithOutputContentType(contentType string) SessionOption {
 	}).
 		Value(contentType).
 		Named("output content type").
+		Validators(gooptions.NotBlank[string]()).
+		Build()
+}
+
+// WithSessionFSRoot selects the rooted filesystem used by one execution
+// session. The session owns the replacement filesystem and inherits the
+// engine's read-only policy.
+func WithSessionFSRoot(root string) SessionOption {
+	return gooptions.New(func(session *sessionOptions, root string) {
+		session.fsRoot = strings.TrimSpace(root)
+	}).
+		Value(root).
+		Named("fs root").
 		Validators(gooptions.NotBlank[string]()).
 		Build()
 }

--- a/session_options_test.go
+++ b/session_options_test.go
@@ -43,6 +43,7 @@ func TestSessionSimpleOptionsApplyValidValues(t *testing.T) {
 		t,
 		WithDebugFormat(format),
 		WithOutputContentType("  application/custom \n"),
+		WithSessionFSRoot("  /runtime \n"),
 	)
 
 	if opts.debugFormat != format {
@@ -51,6 +52,10 @@ func TestSessionSimpleOptionsApplyValidValues(t *testing.T) {
 
 	if opts.outputContentType != "application/custom" {
 		t.Fatalf("output content type = %q", opts.outputContentType)
+	}
+
+	if opts.fsRoot != "/runtime" {
+		t.Fatalf("filesystem root = %q", opts.fsRoot)
 	}
 }
 
@@ -81,6 +86,13 @@ func TestSessionSimpleOptionsReturnStructuredValidationErrors(t *testing.T) {
 			value:  `" \t\n "`,
 			reason: "must not be blank",
 			option: WithOutputContentType(" \t\n "),
+		},
+		{
+			name:   "filesystem root",
+			field:  "fs root",
+			value:  `" \t\n "`,
+			reason: "must not be blank",
+			option: WithSessionFSRoot(" \t\n "),
 		},
 	}
 
@@ -119,10 +131,12 @@ func TestInvalidSessionBuilderOptionDoesNotMutateConfig(t *testing.T) {
 	config := defaultSessionOptions()
 	format := config.debugFormat
 	config.outputContentType = "existing"
+	config.fsRoot = "existing"
 
 	for _, option := range []SessionOption{
 		WithDebugFormat(DebugFormatOptions{MaxDepth: 0, MaxItems: 8, MaxBytes: 1024}),
 		WithOutputContentType(" \t "),
+		WithSessionFSRoot(" \t "),
 	} {
 		if err := option(&config); err == nil {
 			t.Fatal("expected invalid option to fail")
@@ -135,6 +149,10 @@ func TestInvalidSessionBuilderOptionDoesNotMutateConfig(t *testing.T) {
 
 	if config.outputContentType != "existing" {
 		t.Fatalf("invalid output content type mutated the config to %q", config.outputContentType)
+	}
+
+	if config.fsRoot != "existing" {
+		t.Fatalf("invalid filesystem root mutated the config to %q", config.fsRoot)
 	}
 }
 
@@ -326,6 +344,10 @@ func TestNewSessionOptionsKeepDefaultOutputContentTypeWithNoopOptions(t *testing
 
 	if opts.debugFormat != debugger.DefaultFormatOptions() {
 		t.Fatalf("expected default debug format, got %+v", opts.debugFormat)
+	}
+
+	if opts.fsRoot != "" {
+		t.Fatalf("expected no filesystem root override, got %q", opts.fsRoot)
 	}
 
 	if len(opts.env) != 0 {


### PR DESCRIPTION
This pull request introduces and thoroughly tests the ability for a session to override the engine's filesystem root using the new `WithSessionFSRoot` option. Sessions can now have their own filesystem root, which is closed when the session is closed, while preserving the engine's read-only policy and ensuring proper resource management. Extensive tests verify correct behavior, isolation, error handling, and cleanup.

**Session Filesystem Root Override and Ownership**

* Added support for per-session filesystem roots via the `WithSessionFSRoot` option; when set, sessions use their own filesystem root and are responsible for closing it, while default sessions continue to borrow the engine's filesystem. Ownership and cleanup logic were added to both regular and debug sessions. [[1]](diffhunk://#diff-1432dfc3d0ca4a0ef3ce6ecf598b507e686e72472c6638850b8239021bbf95b3R28-R30) [[2]](diffhunk://#diff-1432dfc3d0ca4a0ef3ce6ecf598b507e686e72472c6638850b8239021bbf95b3R72-R90) [[3]](diffhunk://#diff-1432dfc3d0ca4a0ef3ce6ecf598b507e686e72472c6638850b8239021bbf95b3R115-R123) [[4]](diffhunk://#diff-1432dfc3d0ca4a0ef3ce6ecf598b507e686e72472c6638850b8239021bbf95b3L123-R154) [[5]](diffhunk://#diff-1432dfc3d0ca4a0ef3ce6ecf598b507e686e72472c6638850b8239021bbf95b3L158-R186) [[6]](diffhunk://#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccacR43) [[7]](diffhunk://#diff-7e0b96c2717c449fc160fd78d7c086734c5255695719420b889327e6a033f3afR23) [[8]](diffhunk://#diff-7e0b96c2717c449fc160fd78d7c086734c5255695719420b889327e6a033f3afR55-R60) [[9]](diffhunk://#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccacL94-R96) [[10]](diffhunk://#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccacR108-R123)
* Updated host and session construction to propagate and respect the engine's read-only policy when creating per-session filesystems, ensuring session roots cannot be written to if the engine is read-only. [[1]](diffhunk://#diff-7717c52956f97079739dd32cd1d2c7a9ff80173a3895ac11d9e845d1b6c5ca41R22) [[2]](diffhunk://#diff-7717c52956f97079739dd32cd1d2c7a9ff80173a3895ac11d9e845d1b6c5ca41R32) [[3]](diffhunk://#diff-7717c52956f97079739dd32cd1d2c7a9ff80173a3895ac11d9e845d1b6c5ca41R64) [[4]](diffhunk://#diff-7717c52956f97079739dd32cd1d2c7a9ff80173a3895ac11d9e845d1b6c5ca41R106)

**Documentation and Public API**

* Documented the new session filesystem root override behavior and its lifecycle in `runtime.md`.
* Ensured `WithSessionFSRoot` is included in public API tests to maintain usability.

**Testing and Benchmarks**

* Added comprehensive tests in `session_filesystem_test.go` to verify: session root override, isolation between sessions, preservation of engine read-only policy, correct error handling and resource cleanup, and concurrency safety.
* Added a helper test implementation of a counting-close filesystem to verify correct close semantics.
* Introduced benchmarks for session creation with per-session filesystem roots to assess performance impact. [[1]](diffhunk://#diff-a15f5b65b7dbb8d28afdc1fadad7d3e616c3550d59754d58f7a93ce3903cfb76R41-R67) [[2]](diffhunk://#diff-a15f5b65b7dbb8d28afdc1fadad7d3e616c3550d59754d58f7a93ce3903cfb76R98-R124)

These changes collectively enhance session flexibility, robustness, and correctness regarding filesystem usage and lifecycle management.