### PR TITLE
debugger: rename stepping commands for clarity and consistency

### DIFF
--- a/debug_session_benchmark_test.go
+++ b/debug_session_benchmark_test.go
@@ -38,7 +38,7 @@ RETURN FOR i IN 1..100
 		}
 
 		for event.Reason != DebugReasonCompleted {
-			event, startErr = session.Step(context.Background())
+			event, startErr = session.StepIn(context.Background())
 			if startErr != nil {
 				b.Fatal(startErr)
 			}

--- a/debug_session_test.go
+++ b/debug_session_test.go
@@ -71,12 +71,12 @@ func TestDebugSessionBreakpointsLocalsEvaluateAndComplete(t *testing.T) {
 		t.Fatalf("unexpected locals: %#v", locals)
 	}
 
-	event, err = session.Step(context.Background())
+	event, err = session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.Location.Line != 4 {
-		t.Fatalf("unexpected step location: %#v", event)
+		t.Fatalf("unexpected StepIn location: %#v", event)
 	}
 	value, err := session.Evaluate(context.Background(), "x + y")
 	if err != nil {
@@ -443,75 +443,98 @@ func TestPlanNewDebugSessionRequiresDebugCompilation(t *testing.T) {
 	}
 }
 
-func TestDebugSessionStepIntoAndOut(t *testing.T) {
+func TestDebugSessionStepInAndStepOut(t *testing.T) {
 	engine, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer engine.Close()
+
 	query := `FUNC add(a) {
   LET b = a + 1
   RETURN b
 }
-LET x = add(2)
+FUNC outer(a) {
+  LET b = add(a)
+  RETURN b
+}
+LET x = outer(2)
 RETURN x`
 	plan, err := engine.CompileDebug(context.Background(), source.New("udf.fql", query))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer plan.Close()
+
 	session, err := plan.NewDebugSession(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer session.Close()
 
-	event, err := session.Start(context.Background())
-	if err != nil {
-		t.Fatal(err)
+	commands := []struct {
+		resume func(context.Context) (*DebugEvent, error)
+		name   string
+		reason DebugReason
+		frames []string
+		line   int
+	}{
+		{session.Start, "Start", DebugReasonEntry, []string{"<main>"}, 9},
+		{session.StepIn, "StepIn to outer", DebugReasonStep, []string{"outer", "<main>"}, 6},
+		{session.StepIn, "StepIn to add", DebugReasonStep, []string{"add", "outer", "<main>"}, 2},
+		{session.StepOut, "StepOut to outer", DebugReasonStep, []string{"outer", "<main>"}, 7},
+		{session.StepOut, "StepOut to main", DebugReasonStep, []string{"<main>"}, 10},
 	}
-	if event.Location.Line != 5 {
-		t.Fatalf("unexpected entry: %#v", event)
-	}
-	event, err = session.Step(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if event.Location.Line != 2 || event.Depth != 1 {
-		t.Fatalf("expected step into UDF, got %#v", event)
-	}
-	frames, err := session.Frames()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(frames) != 2 || frames[0].Name != "add" || frames[1].Name != "<main>" {
-		t.Fatalf("unexpected frames: %#v", frames)
-	}
-	event, err = session.Out(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if event.Location.Line != 6 || event.Depth != 0 {
-		t.Fatalf("expected step out to main, got %#v", event)
+
+	for _, command := range commands {
+		event, err := command.resume(context.Background())
+		if err != nil {
+			t.Fatalf("%s: %v", command.name, err)
+		}
+
+		if event.Reason != command.reason || event.Location.Line != command.line || event.Depth != len(command.frames)-1 {
+			t.Fatalf("%s: unexpected stop: %#v", command.name, event)
+		}
+
+		frames, err := session.Frames()
+		if err != nil {
+			t.Fatalf("%s: %v", command.name, err)
+		}
+
+		if len(frames) != len(command.frames) {
+			t.Fatalf("%s: unexpected frames: %#v", command.name, frames)
+		}
+
+		for i, name := range command.frames {
+			if frames[i].Name != name {
+				t.Fatalf("%s: frame %d: got %q, want %q", command.name, i, frames[i].Name, name)
+			}
+		}
+
+		if frames[0].Location.Line != command.line {
+			t.Fatalf("%s: unexpected current frame location: %#v", command.name, frames[0])
+		}
 	}
 }
 
-func TestDebugSessionNextStepsOverCallAndOutFromMainCompletes(t *testing.T) {
+func TestDebugSessionStepOverCallAndStepOutFromMainCompletes(t *testing.T) {
 	engine, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer engine.Close()
+
 	query := `FUNC add(a) {
   RETURN a + 1
 }
 LET x = add(2)
 RETURN x`
-	plan, err := engine.CompileDebug(context.Background(), source.New("next.fql", query))
+	plan, err := engine.CompileDebug(context.Background(), source.New("step-over.fql", query))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer plan.Close()
+
 	session, err := plan.NewDebugSession(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -522,22 +545,36 @@ RETURN x`
 	if err != nil {
 		t.Fatal(err)
 	}
-	if event.Location.Line != 4 {
+
+	if event.Reason != DebugReasonEntry || event.Location.Line != 4 || event.Depth != 0 {
 		t.Fatalf("unexpected entry: %#v", event)
 	}
-	event, err = session.Next(context.Background())
+
+	event, err = session.StepOver(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if event.Location.Line != 5 || event.Depth != 0 {
-		t.Fatalf("expected next to step over UDF, got %#v", event)
+
+	if event.Reason != DebugReasonStep || event.Location.Line != 5 || event.Depth != 0 {
+		t.Fatalf("expected StepOver to skip UDF, got %#v", event)
 	}
-	event, err = session.Out(context.Background())
+
+	frames, err := session.Frames()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if len(frames) != 1 || frames[0].Name != "<main>" || frames[0].Location.Line != 5 {
+		t.Fatalf("unexpected frames after StepOver: %#v", frames)
+	}
+
+	event, err = session.StepOut(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if event.Reason != DebugReasonCompleted || event.Output == nil || string(event.Output.Content) != "3" {
-		t.Fatalf("expected out from main to complete, got %#v", event)
+		t.Fatalf("expected StepOut from main to complete, got %#v", event)
 	}
 }
 
@@ -561,11 +598,11 @@ func TestDebugSessionStopsOnRepeatedLoopLocation(t *testing.T) {
 	if _, err := session.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	first, err := session.Step(context.Background())
+	first, err := session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := session.Step(context.Background())
+	second, err := session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/debug_session_udf_resolution_test.go
+++ b/debug_session_udf_resolution_test.go
@@ -245,14 +245,14 @@ RETURN y`
 	if event.Location.Line != 1 {
 		t.Fatalf("unexpected entry: %#v", event)
 	}
-	event, err = session.Step(context.Background())
+	event, err = session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.Location.Line != 9 {
-		t.Fatalf("unexpected caller step: %#v", event)
+		t.Fatalf("unexpected caller StepIn: %#v", event)
 	}
-	event, err = session.Step(context.Background())
+	event, err = session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,12 +277,12 @@ RETURN y`
 		t.Fatalf("unexpected UDF entry locals: %#v", locals)
 	}
 
-	event, err = session.Step(context.Background())
+	event, err = session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.Location.Line != 4 {
-		t.Fatalf("unexpected UDF return step: %#v", event)
+		t.Fatalf("unexpected UDF return StepIn: %#v", event)
 	}
 	locals, err = session.Locals()
 	if err != nil {
@@ -403,12 +403,12 @@ RETURN outer(2) + x + @input + box.value - 10`
 		t.Fatalf("expected missing frame rejection, got %v", err)
 	}
 
-	event, err = session.Step(context.Background())
+	event, err = session.StepIn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.Location.Line != 6 {
-		t.Fatalf("unexpected mutable-cell step: %#v", event)
+		t.Fatalf("unexpected mutable-cell StepIn: %#v", event)
 	}
 	if _, err := session.Variables(callerReference); !errors.Is(err, runtime.ErrNotFound) {
 		t.Fatalf("expected caller reference to become stale on resume, got %v", err)

--- a/docs/development/debugger.md
+++ b/docs/development/debugger.md
@@ -21,9 +21,10 @@ loaded or compiled without debug information cannot create a debug session.
 ## Layer boundaries
 
 `pkg/vm` owns retained execution and paused-state access. Its debug execution
-surface starts or resumes the VM in continue, step, next, and out modes, reports
-stops, accepts pause or termination requests, and exposes frames and runtime
-values without moving source-level policy into the dispatch loop.
+surface starts or resumes the VM in `DebugResumeContinue`, `DebugResumeStepIn`,
+`DebugResumeStepOver`, and `DebugResumeStepOut` modes, reports stops, accepts pause
+or termination requests, and exposes frames and runtime values without moving
+source-level policy into the dispatch loop.
 
 `pkg/debugger` owns source-level policy:
 
@@ -41,9 +42,16 @@ package.
 ## Session state and concurrency
 
 A debug session retains one execution across commands. `Start` stops at entry;
-`Continue`, `Step`, `Next`, and `Out` resume according to the selected VM mode.
-Commands are serialized. `Pause` can safely request a stop while a command is
-running.
+`Continue`, `StepIn`, `StepOver`, and `StepOut` resume according to the selected
+VM mode. `StepIn` stops at the next debuggable source location and may enter
+called functions. `StepOver` stops at the next debuggable location at the same
+or shallower call depth. `StepOut` stops at the next debuggable location in a
+caller after the current frame exits; at main it runs to completion.
+
+Breakpoints and pause requests take precedence over stepping, including inside
+deeper calls. All three stepping operations report the shared `ReasonStep` stop
+reason when their stepping condition is reached. Commands are serialized.
+`Pause` can safely request a stop while a command is running.
 
 Resume calls use the retained execution context unless a caller supplies an
 additional context, in which case both lifetimes are observed. Starting or

--- a/pkg/debugger/session.go
+++ b/pkg/debugger/session.go
@@ -140,34 +140,39 @@ func (s *Session) Continue(ctx context.Context) (*Event, error) {
 	return s.resume(ctx, vm.DebugResumeContinue)
 }
 
-// Step stops at the next logical source location, including inside calls.
-func (s *Session) Step(ctx context.Context) (*Event, error) {
+// StepIn resumes execution until the next debuggable source location and may
+// enter called functions.
+func (s *Session) StepIn(ctx context.Context) (*Event, error) {
 	if err := s.lockCommand(); err != nil {
 		return nil, err
 	}
 	defer s.commandMu.Unlock()
 
-	return s.resume(ctx, vm.DebugResumeStep)
+	return s.resume(ctx, vm.DebugResumeStepIn)
 }
 
-// Next stops at the next logical source location at the same or shallower call depth.
-func (s *Session) Next(ctx context.Context) (*Event, error) {
+// StepOver resumes execution until the next debuggable source location at the
+// same or shallower call depth. Breakpoints and pause requests may interrupt it
+// inside deeper calls.
+func (s *Session) StepOver(ctx context.Context) (*Event, error) {
 	if err := s.lockCommand(); err != nil {
 		return nil, err
 	}
 	defer s.commandMu.Unlock()
 
-	return s.resume(ctx, vm.DebugResumeNext)
+	return s.resume(ctx, vm.DebugResumeStepOver)
 }
 
-// Out stops at the next logical source location in a caller. At main it runs to completion.
-func (s *Session) Out(ctx context.Context) (*Event, error) {
+// StepOut resumes execution until the current frame exits, then stops at the
+// next debuggable source location in a caller. At main it runs to completion.
+// Breakpoints and pause requests may interrupt it before the frame exits.
+func (s *Session) StepOut(ctx context.Context) (*Event, error) {
 	if err := s.lockCommand(); err != nil {
 		return nil, err
 	}
 	defer s.commandMu.Unlock()
 
-	return s.resume(ctx, vm.DebugResumeOut)
+	return s.resume(ctx, vm.DebugResumeStepOut)
 }
 
 // Pause requests a stop at the next logical source location.

--- a/pkg/debugger/session_close_test.go
+++ b/pkg/debugger/session_close_test.go
@@ -82,7 +82,7 @@ func TestSessionCloseLifecycleStates(t *testing.T) {
 			if !execution.closed || !services.closed {
 				t.Fatal("expected execution and services to close")
 			}
-			if _, err := session.Step(context.Background()); err == nil || !errors.Is(err, &StateError{}) {
+			if _, err := session.StepIn(context.Background()); err == nil || !errors.Is(err, &StateError{}) {
 				t.Fatalf("expected command rejection after close, got %v", err)
 			}
 		})

--- a/pkg/debugger/session_concurrency_test.go
+++ b/pkg/debugger/session_concurrency_test.go
@@ -25,10 +25,10 @@ func TestSessionSerializesConcurrentCommands(t *testing.T) {
 	}()
 	waitForSignal(t, execution.resumeStarted, "first resume")
 
-	stepDone := make(chan error, 1)
+	stepInDone := make(chan error, 1)
 	go func() {
-		_, err := session.Step(context.Background())
-		stepDone <- err
+		_, err := session.StepIn(context.Background())
+		stepInDone <- err
 	}()
 	breakpointDone := make(chan error, 1)
 	go func() {
@@ -36,7 +36,7 @@ func TestSessionSerializesConcurrentCommands(t *testing.T) {
 		breakpointDone <- err
 	}()
 
-	assertBlocked(t, stepDone, "step")
+	assertBlocked(t, stepInDone, "StepIn")
 	assertBlocked(t, breakpointDone, "set breakpoint")
 	if calls, maxActive, _ := execution.stats(); calls != 1 || maxActive != 1 {
 		t.Fatalf("commands entered execution concurrently: calls=%d max=%d", calls, maxActive)
@@ -44,7 +44,7 @@ func TestSessionSerializesConcurrentCommands(t *testing.T) {
 
 	execution.release()
 	waitForError(t, continueDone, "continue")
-	waitForError(t, stepDone, "step")
+	waitForError(t, stepInDone, "StepIn")
 	waitForError(t, breakpointDone, "set breakpoint")
 
 	if calls, maxActive, _ := execution.stats(); calls != 2 || maxActive != 1 {

--- a/pkg/vm/debug.go
+++ b/pkg/vm/debug.go
@@ -90,9 +90,9 @@ const (
 
 const (
 	DebugResumeContinue DebugResumeMode = iota
-	DebugResumeStep
-	DebugResumeNext
-	DebugResumeOut
+	DebugResumeStepIn
+	DebugResumeStepOver
+	DebugResumeStepOut
 )
 
 const (

--- a/pkg/vm/debug_control.go
+++ b/pkg/vm/debug_control.go
@@ -66,17 +66,17 @@ func (c *debugControl) shouldStop(pc, depth int) bool {
 	}
 
 	switch c.mode {
-	case DebugResumeStep:
+	case DebugResumeStepIn:
 		c.reason = DebugStopStep
 
 		return true
-	case DebugResumeNext:
+	case DebugResumeStepOver:
 		if depth <= c.startDepth {
 			c.reason = DebugStopStep
 
 			return true
 		}
-	case DebugResumeOut:
+	case DebugResumeStepOut:
 		if depth < c.startDepth {
 			c.reason = DebugStopStep
 

--- a/pkg/vm/source_point_test.go
+++ b/pkg/vm/source_point_test.go
@@ -132,12 +132,12 @@ func TestNewDebugExecutionObservesSourcePointsWithoutMutatingPlan(t *testing.T) 
 		t.Fatalf("unexpected entry event: %#v", event)
 	}
 
-	event, err = execution.Resume(context.Background(), DebugResumeStep, nil)
+	event, err = execution.Resume(context.Background(), DebugResumeStepIn, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.Reason != DebugStopStep || event.Point == nil || event.Point.PC != 2 {
-		t.Fatalf("unexpected step event: %#v", event)
+		t.Fatalf("unexpected StepIn event: %#v", event)
 	}
 
 	event, err = execution.Resume(context.Background(), DebugResumeContinue, nil)


### PR DESCRIPTION
Adjusted stepping command names (`Step`, `Next`, `Out`) to `StepIn`, `StepOver`, and `StepOut`. Updated associated comments, tests, and documentation to reflect these changes, ensuring consistent usage and improved readability.