### PR TITLE
Preserve legacy global object functions as deprecated compatibility aliases

### DIFF
--- a/docs/development/modules.md
+++ b/docs/development/modules.md
@@ -112,8 +112,10 @@ mutation under `arrays::mut::`, and frozen global migration aliases.
 Vocabulary, mutation results, set ordering, copy ownership, and
 legacy signatures are described in [Array library contracts](array-library.md).
 
-The Objects group registers immutable functions under `object::` and explicit
-mutation under `object::mut::`. Shared map
+The Objects group registers immutable functions under `object::`, explicit
+mutation under `object::mut::`, and seven temporary deprecated global aliases.
+The globals delegate to canonical implementations and advertise replacements
+through structured API metadata, without compiler or runtime warnings. Shared map
 transformations, copy ownership, iterable entry construction, and migration
 behavior are described in [Object library contracts](object-library.md).
 

--- a/docs/development/object-library.md
+++ b/docs/development/object-library.md
@@ -3,8 +3,9 @@
 The Objects capability group registers ten immutable functions under
 `object::`: `keys`, `values`, `entries`, `has_key`, `keep_keys`,
 `omit_keys`, `merge`, `merge_deep`, `zip`, and `from_entries`.
-Old global names are removed. Host-function lookup remains case-insensitive;
-registration and generated API metadata use lowercase names. It also registers
+Seven legacy global names remain temporarily as deprecated compatibility aliases.
+Host-function lookup remains case-insensitive; registration and generated API
+metadata use lowercase names. The group also registers
 `object::mut::{merge,merge_deep,keep_keys,omit_keys}`. The stdlib convention is
 immutable by default, with explicit mutation through a `::mut::` subnamespace.
 
@@ -39,7 +40,28 @@ validated before the first mutation.
 `from_entries` consumes any runtime iterable once. Each entry must implement
 `runtime.Measurable` and `runtime.IndexReadable`, have length two, and contain
 a String key at index zero. Both constructors use last-key-wins; this deliberately
-changes the former global ZIP's first-key-wins behavior.
+changes v1 ZIP's first-key-wins behavior. The deprecated global `zip` delegates
+to `object::zip` and also uses last-key-wins.
+
+## Global compatibility
+
+The deprecated globals `keys`, `values`, `keep_keys`, `merge`, and `zip` map to
+the same names under `object::`. The renamed globals `has` and
+`merge_recursive` map to `object::has_key` and `object::merge_deep` respectively.
+They use canonical signatures and semantics, including unary `keys`; the old
+sorting argument is not restored.
+
+Compatibility registration and private forwarding functions live together in
+`pkg/stdlib/objects/legacy.go`. Each forwarder calls the canonical Go function
+without changing arguments, context, results, or errors. Its structured
+`@deprecated` comment names the replacement in generated Core API metadata,
+using the existing array compatibility mechanism. This does not add compiler
+or runtime deprecation warnings. Canonical signatures remain nondeprecated.
+
+No globals are provided for `entries`, `from_entries`, `omit_keys`, or any
+mutable operation. New code and examples should use canonical namespaces.
+The compatibility file and its tests can be removed when the compatibility
+window ends; no removal release is specified.
 
 ## Ownership and shared operations
 
@@ -100,5 +122,5 @@ optimization. Object benchmarks cover transformation time and allocations.
 CLI source migration is owned by the sibling CLI repository. It rewrites
 unqualified legacy calls and composes literal sorted KEYS calls with `sorted`.
 Unsafe sorting expressions produce the established manual action, leaving the
-file untouched. ZIP's duplicate-key change is documented rather than hidden
-behind an alias.
+file untouched. Compatibility aliases do not replace CLI migration support or
+preserve v1 ZIP's duplicate-key behavior.

--- a/pkg/stdlib/object_surface_test.go
+++ b/pkg/stdlib/object_surface_test.go
@@ -2,22 +2,23 @@ package stdlib_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/stdlib"
 )
 
 func TestObjectSurface(t *testing.T) {
-	want := []string{"object::entries", "object::from_entries", "object::has_key", "object::keep_keys", "object::keys", "object::merge", "object::merge_deep", "object::mut::keep_keys", "object::mut::merge", "object::mut::merge_deep", "object::mut::omit_keys", "object::omit_keys", "object::values", "object::zip"}
+	want := []string{"has", "keep_keys", "keys", "merge", "merge_recursive", "object::entries", "object::from_entries", "object::has_key", "object::keep_keys", "object::keys", "object::merge", "object::merge_deep", "object::mut::keep_keys", "object::mut::merge", "object::mut::merge_deep", "object::mut::omit_keys", "object::omit_keys", "object::values", "object::zip", "values", "zip"}
 	got := functionNames(buildFunctions(t, stdlib.Only(stdlib.Objects)))
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("object surface = %v, want %v", got, want)
 	}
 
-	for _, set := range []stdlib.Set{stdlib.Full(), stdlib.Safe()} {
+	for _, set := range []stdlib.Set{stdlib.Only(stdlib.Objects), stdlib.Full(), stdlib.Safe()} {
 		functions := buildFunctions(t, set)
 		without := buildFunctions(t, set.Without(stdlib.Objects))
-		for _, name := range []string{"object::keys", "object::values", "object::entries", "object::from_entries"} {
+		for _, name := range []string{"keys", "values", "object::keys", "object::values", "object::entries", "object::from_entries"} {
 			for arity := 0; arity <= 4; arity++ {
 				if hasFixedArity(functions, name, arity) != (arity == 1) || functions.Var().Has(name) {
 					t.Fatalf("%s must have exactly one unary registration", name)
@@ -25,7 +26,7 @@ func TestObjectSurface(t *testing.T) {
 			}
 		}
 
-		for _, name := range []string{"object::has_key", "object::zip"} {
+		for _, name := range []string{"has", "zip", "object::has_key", "object::zip"} {
 			for arity := 0; arity <= 4; arity++ {
 				if hasFixedArity(functions, name, arity) != (arity == 2) || functions.Var().Has(name) {
 					t.Fatalf("%s must have exactly one binary registration", name)
@@ -33,7 +34,7 @@ func TestObjectSurface(t *testing.T) {
 			}
 		}
 
-		for _, name := range []string{"object::mut::merge", "object::mut::merge_deep", "object::mut::keep_keys", "object::mut::omit_keys"} {
+		for _, name := range []string{"keep_keys", "merge", "merge_recursive", "object::keep_keys", "object::omit_keys", "object::merge", "object::merge_deep", "object::mut::merge", "object::mut::merge_deep", "object::mut::keep_keys", "object::mut::omit_keys"} {
 			if !functions.Var().Has(name) {
 				t.Fatalf("%s must have a variadic registration", name)
 			}
@@ -46,14 +47,24 @@ func TestObjectSurface(t *testing.T) {
 		}
 
 		for _, name := range want {
-			if !functions.Has(name) || without.Has(name) {
-				t.Fatalf("capability mismatch: %s", name)
+			for _, spelling := range []string{name, strings.ToUpper(name)} {
+				if !functions.Has(spelling) || without.Has(spelling) {
+					t.Fatalf("capability mismatch: %s", spelling)
+				}
 			}
 		}
 
-		for _, name := range []string{"keys", "values", "has", "keep_keys", "merge", "merge_recursive", "zip", "object::has", "object::merge_recursive", "object::from_keys_values", "object::mut_merge", "object::merge_mut", "object::merge_in_place", "object::mut::keys", "object::mut::set", "object::mut::delete"} {
+		for _, name := range []string{"entries", "from_entries", "omit_keys", "has_key", "merge_deep", "object::has", "object::merge_recursive", "object::from_keys_values", "mut_merge", "merge_mut", "merge_in_place", "object::mut_merge", "object::merge_mut", "object::merge_in_place", "object::mut::keys", "object::mut::set", "object::mut::delete"} {
 			if functions.Has(name) {
 				t.Fatalf("unexpected alias: %s", name)
+			}
+		}
+
+		for _, name := range []string{"merge", "merge_deep", "keep_keys", "omit_keys"} {
+			for _, alias := range []string{"mut::" + name, "mut_" + name, name + "_mut", name + "_in_place"} {
+				if functions.Has(alias) {
+					t.Fatalf("unexpected mutable alias: %s", alias)
+				}
 			}
 		}
 	}

--- a/pkg/stdlib/objects/legacy.go
+++ b/pkg/stdlib/objects/legacy.go
@@ -1,0 +1,84 @@
+package objects
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+// These temporary globals share canonical semantics. Separate forwarding
+// declarations attach deprecation metadata without deprecating object:: functions.
+func registerLegacy(ns runtime.Namespace) {
+	ns.Function().A1().
+		Add("keys", legacyKeys).
+		Add("values", legacyValues)
+	ns.Function().A2().
+		Add("has", legacyHas).
+		Add("zip", legacyZip)
+	ns.Function().Var().
+		Add("keep_keys", legacyKeepKeys).
+		Add("merge", legacyMerge).
+		Add("merge_recursive", legacyMergeRecursive)
+}
+
+// keys returns an independent list of map keys in unspecified order.
+// @param value {Map} Map whose keys are returned.
+// @return {String[]} Independent list of keys in unspecified order.
+// @deprecated Use object::keys instead.
+func legacyKeys(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
+	return Keys(ctx, arg)
+}
+
+// values returns cloned or copied map values in unspecified order.
+// @param value {Map} Map whose values are returned.
+// @return {Any[]} Independent list of values, following each value's clone or copy contract.
+// @deprecated Use object::values instead.
+func legacyValues(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
+	return Values(ctx, arg)
+}
+
+// has checks key existence, including keys whose value is none.
+// @param object {Map} Object or map to inspect.
+// @param key {String} The key name string.
+// @return {Boolean} True if the key exists else false.
+// @deprecated Use object::has_key instead.
+func legacyHas(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return HasKey(ctx, arg1, arg2)
+}
+
+// keep_keys clones the source and retains only the requested keys.
+// Missing and repeated keys are ignored.
+// @param value {Map} Source map.
+// @param keys {String|String[], repeated} Variadic keys, or one list of keys; an empty list keeps nothing.
+// @return {Map} Independent map containing only selected keys.
+// @deprecated Use object::keep_keys instead.
+func legacyKeepKeys(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
+	return KeepKeys(ctx, args...)
+}
+
+// merge copies maps into an independent destination; later values replace earlier values.
+// @param values {Map|Map[], repeated} Variadic maps, or one list of maps.
+// @return {Map} Shallow merge with cloned or copied values.
+// @deprecated Use object::merge instead.
+func legacyMerge(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
+	return Merge(ctx, args...)
+}
+
+// merge_recursive copies maps into an independent destination, merging nested maps recursively.
+// Arrays, scalars, and none are replaced by later values.
+// @param values {Map|Map[], repeated} Variadic maps, or one list of maps.
+// @return {Map} Deep merge with cloned or copied values.
+// @deprecated Use object::merge_deep instead.
+func legacyMergeRecursive(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
+	return MergeDeep(ctx, args...)
+}
+
+// zip constructs an object from parallel key and value lists of equal length.
+// Keys must be strings. Duplicate keys use the last value in the input.
+// @param keys {String[]} List of object keys.
+// @param values {Any[]} Parallel list of values.
+// @return {Map} Independent object containing cloned or copied values.
+// @deprecated Use object::zip instead.
+func legacyZip(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	return Zip(ctx, arg1, arg2)
+}

--- a/pkg/stdlib/objects/lib.go
+++ b/pkg/stdlib/objects/lib.go
@@ -2,28 +2,30 @@ package objects
 
 import "github.com/MontFerret/ferret/v2/pkg/runtime"
 
-// RegisterLib registers object functions and explicit mutation under object::mut.
+// RegisterLib registers object functions, explicit object::mut operations, and deprecated globals.
 // @namespace object
 func RegisterLib(ns runtime.Namespace) {
-	ns = ns.Namespace("object")
+	canonical := ns.Namespace("object")
 
-	ns.Function().A1().
+	canonical.Function().A1().
 		Add("keys", Keys).
 		Add("values", Values).
 		Add("entries", Entries).
 		Add("from_entries", FromEntries)
-	ns.Function().A2().
+	canonical.Function().A2().
 		Add("has_key", HasKey).
 		Add("zip", Zip)
-	ns.Function().Var().
+	canonical.Function().Var().
 		Add("keep_keys", KeepKeys).
 		Add("omit_keys", OmitKeys).
 		Add("merge", Merge).
 		Add("merge_deep", MergeDeep)
 
-	ns.Namespace("mut").Function().Var().
+	canonical.Namespace("mut").Function().Var().
 		Add("keep_keys", KeepKeysMutable).
 		Add("omit_keys", OmitKeysMutable).
 		Add("merge", MergeMutable).
 		Add("merge_deep", MergeDeepMutable)
+
+	registerLegacy(ns)
 }

--- a/test/integration/vm/vm_object_legacy_test.go
+++ b/test/integration/vm/vm_object_legacy_test.go
@@ -1,0 +1,76 @@
+package vm_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/test/spec"
+	. "github.com/MontFerret/ferret/v2/test/spec/exec"
+)
+
+func TestObjectLegacyAliases(t *testing.T) {
+	var specs []spec.Spec
+	for _, test := range []struct {
+		legacy    string
+		canonical string
+		args      string
+		sort      bool
+	}{
+		{"keys", "object::keys", `{b: 2, a: 1}`, true},
+		{"values", "object::values", `{b: 2, a: 1}`, true},
+		{"has", "object::has_key", `{a: none}, "a"`, false},
+		{"has", "object::has_key", `{}, "missing"`, false},
+		{"keep_keys", "object::keep_keys", `{a: 1, b: {x: 2}}, "b", "missing", "b"`, false},
+		{"keep_keys", "object::keep_keys", `{a: 1, b: 2}, ["b"]`, false},
+		{"keep_keys", "object::keep_keys", `{a: 1}, []`, false},
+		{"merge", "object::merge", `{a: {x: 1}}, {a: {y: 2}}`, false},
+		{"merge", "object::merge", `[{a: 1}, {a: 2}]`, false},
+		{"merge", "object::merge", `[]`, false},
+		{"merge_recursive", "object::merge_deep", `{a: {x: 1}}, {a: {y: 2}}`, false},
+		{"merge_recursive", "object::merge_deep", `[{a: {x: 1}}, {a: {y: 2}}]`, false},
+		{"merge_recursive", "object::merge_deep", `[]`, false},
+		{"zip", "object::zip", `["a", "b", "a"], [1, 2, 3]`, false},
+		{"zip", "object::zip", `[], []`, false},
+	} {
+		for _, name := range []string{test.legacy, strings.ToUpper(test.legacy)} {
+			legacy := fmt.Sprintf("%s(%s)", name, test.args)
+			canonical := fmt.Sprintf("%s(%s)", test.canonical, test.args)
+			if test.sort {
+				legacy = "arrays::sorted(" + legacy + ")"
+				canonical = "arrays::sorted(" + canonical + ")"
+			}
+
+			specs = append(specs, S("return "+legacy+" == "+canonical, true))
+		}
+	}
+
+	specs = append(specs,
+		S(`return zip(["a", "b", "a"], [1, 2, 3]) == {a: 3, b: 2}`, true),
+		S(`let value = {a: {x: 1}, b: 2} let result = keep_keys(value, "a") return value == {a: {x: 1}, b: 2} and result == {a: {x: 1}}`, true),
+		S(`let value = {a: {x: 1}} let result = merge(value, {a: {y: 2}}) return value == {a: {x: 1}} and result == {a: {y: 2}}`, true),
+		S(`let value = {a: {x: 1}} let result = merge_recursive(value, {a: {y: 2}}) return value == {a: {x: 1}} and result == {a: {x: 1, y: 2}}`, true),
+		S(`let value = {x: 1} let result = zip(["a"], [value]) let changed = object::mut::merge(result.a, {y: 2}) return value == {x: 1} and changed == {x: 1, y: 2}`, true),
+	)
+
+	for _, call := range []string{
+		`keys(1)`, `values(1)`, `has({}, 1)`, `keep_keys({}, 1)`,
+		`merge([{}, 1])`, `merge_recursive([{}, 1])`, `zip(["a"], [])`,
+	} {
+		specs = append(specs, S("return "+call+` on error return "caught"`, "caught"))
+	}
+
+	for _, call := range []string{"keys()", "keys({}, true)", "values({}, false)", "has({})", "keep_keys({})", "merge()", "merge_recursive()", "zip([])"} {
+		specs = append(specs, spec.NewSpec("return "+call, call).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "invalid number of arguments"}))
+	}
+
+	for _, level := range []compiler.OptimizationLevel{compiler.None, compiler.Basic, compiler.Full} {
+		c, err := compiler.New(compiler.WithOptimizationLevel(level))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		RunSpecsWith(t, level.String(), c, specs)
+	}
+}

--- a/tools/apiref/internal/analyzer/objects_test.go
+++ b/tools/apiref/internal/analyzer/objects_test.go
@@ -1,0 +1,64 @@
+package analyzer_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MontFerret/specs/pkg/api"
+	apicatalog "github.com/MontFerret/specs/pkg/api/catalog"
+)
+
+func assertObjectCompatibilityMetadata(t *testing.T, reference *api.Reference, catalog *apicatalog.Catalog) {
+	t.Helper()
+
+	signatures := make(map[apicatalog.FunctionRef][]api.Signature)
+	for _, namespace := range reference.Namespaces {
+		for _, function := range namespace.Functions {
+			signatures[apicatalog.FunctionRef{Namespace: namespace.Name, Name: function.Name}] = function.Signatures
+			if namespace.Name != "object" && namespace.Name != "object::mut" {
+				continue
+			}
+
+			for _, signature := range function.Signatures {
+				if signature.Deprecated != "" {
+					t.Fatalf("canonical function %s::%s is deprecated", namespace.Name, function.Name)
+				}
+			}
+		}
+	}
+
+	categories := make(map[apicatalog.FunctionRef]string)
+	for _, category := range catalog.Categories {
+		for _, function := range category.Functions {
+			categories[function] = category.ID
+		}
+	}
+
+	for legacy, canonical := range map[string]string{
+		"keys": "keys", "values": "values", "has": "has_key", "keep_keys": "keep_keys",
+		"merge": "merge", "merge_recursive": "merge_deep", "zip": "zip",
+	} {
+		global := apicatalog.FunctionRef{Name: legacy}
+		target := apicatalog.FunctionRef{Namespace: "object", Name: canonical}
+		old, current := signatures[global], signatures[target]
+		if len(old) != 1 || len(current) != 1 {
+			t.Fatalf("%s and object::%s must each have exactly one signature", legacy, canonical)
+		}
+
+		want := "Use object::" + canonical + " instead."
+		if old[0].Deprecated != want {
+			t.Fatalf("%s deprecation = %q, want %q", legacy, old[0].Deprecated, want)
+		}
+
+		comparable := old[0]
+		comparable.Deprecated = ""
+		comparable.Description = current[0].Description
+		if !reflect.DeepEqual(comparable, current[0]) {
+			t.Fatalf("%s signature differs from object::%s: %+v != %+v", legacy, canonical, comparable, current[0])
+		}
+
+		if categories[global] != "objects" || categories[target] != "objects" {
+			t.Fatalf("%s and object::%s must belong to the Objects catalog", legacy, canonical)
+		}
+	}
+}

--- a/tools/apiref/internal/analyzer/real_test.go
+++ b/tools/apiref/internal/analyzer/real_test.go
@@ -67,6 +67,7 @@ func TestGenerateMatchesFullRuntimeRegistryAndIsDeterministic(t *testing.T) {
 	assertPathNamespace(t, first.Reference, first.Catalog)
 	assertTestingAssertionMetadata(t, first.Reference)
 	assertMutableObjectMetadata(t, first.Reference, first.Catalog)
+	assertObjectCompatibilityMetadata(t, first.Reference, first.Catalog)
 	assertArrayMetadata(t, first.Reference, first.Catalog)
 }
 


### PR DESCRIPTION
Ferret v2 has moved the object standard library to the lowercase `object::` namespace.

To make migration from v1 less disruptive, preserve the legacy global object functions temporarily as deprecated aliases.

This should match the compatibility approach being used for arrays.