### PR TITLE
test(msgpack): use platform runtime Int bounds for range singletons

### DIFF
--- a/pkg/encoding/msgpack/codec_test.go
+++ b/pkg/encoding/msgpack/codec_test.go
@@ -253,6 +253,11 @@ func TestMsgpackCodecEncode(t *testing.T) {
 	})
 
 	t.Run("range", func(t *testing.T) {
+		// The decoder bounds decoded integers by the native int range, so the
+		// singleton boundaries follow the runtime Int range of the platform.
+		maxRuntimeInt := int64(^uint(0) >> 1)
+		minRuntimeInt := -maxRuntimeInt - 1
+
 		tests := []struct {
 			name  string
 			want  []int64
@@ -264,8 +269,8 @@ func TestMsgpackCodecEncode(t *testing.T) {
 			{name: "negative ascending", start: -3, end: -1, want: []int64{-3, -2, -1}},
 			{name: "negative descending", start: -1, end: -3, want: []int64{-1, -2, -3}},
 			{name: "cross zero", start: -1, end: 1, want: []int64{-1, 0, 1}},
-			{name: "minimum singleton", start: math.MinInt64, end: math.MinInt64, want: []int64{math.MinInt64}},
-			{name: "maximum singleton", start: math.MaxInt64, end: math.MaxInt64, want: []int64{math.MaxInt64}},
+			{name: "minimum singleton", start: runtime.Int(minRuntimeInt), end: runtime.Int(minRuntimeInt), want: []int64{minRuntimeInt}},
+			{name: "maximum singleton", start: runtime.Int(maxRuntimeInt), end: runtime.Int(maxRuntimeInt), want: []int64{maxRuntimeInt}},
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
The range encode test asserted exact `Int` round-trips of `math.MinInt64` and `math.MaxInt64`. The decoder bounds decoded integers by the native int range, so on 32-bit platforms those singletons become a `Float` or are rejected, and `TestMsgpackCodecEncode/range/maximum_singleton` fails on `GOARCH=386`:

```
codec_test.go:290: decode failed: msgpack: integer 9223372036854775807 exceeds runtime range
```

The singleton boundaries now follow the platform runtime `Int` range, so the case exercises each platform's actual boundary. 64-bit expectations are unchanged, and 32-bit boundary behavior stays covered by the existing `int_overflow_float_on_32bit` and `unsigned_overflow_error` tests.

Verified with `go test ./pkg/encoding/msgpack/` on amd64 and `GOARCH=386` (both pass). Within `./pkg/... ./uapi/... .` the 386 and amd64 failure sets are now identical.

Not addressed here: the 32-bit encoder still emits full int64 values that its decoder cannot read back, so a `MaxInt64` range round-trip fails on encode/decode asymmetry rather than in the range logic. Happy to follow up if you want that bound made symmetric.
