### PR TITLE
Collection factories, iterable counting, and owned transformations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,7 +60,7 @@ jobs:
     name: Run main unit benchmark baseline
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
       - main-baseline-integration
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     permissions:
       contents: write
     concurrency:
@@ -182,7 +182,7 @@ jobs:
     name: Compare PR unit benchmarks
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write
@@ -321,7 +321,7 @@ jobs:
     name: Manual unit benchmark comparison
     if: github.event_name == 'workflow_dispatch' && inputs.run_unit
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write

--- a/docs/development/collection-library.md
+++ b/docs/development/collection-library.md
@@ -17,6 +17,8 @@ invalid counting inputs.
 falls back to `Iterable`. This validates both requirements in one dispatch for
 measured sources; `Measurable` alone is insufficient. It calls `Length` when available.
 It does not create an iterator or retry a failed length operation by scanning.
+Negative host lengths fail with `ErrInvalidOperation` without traversal; zero is
+valid. Cancellation during measurement is retained alongside an invalid-length error.
 Native ranges use this path, including propagation of range-length overflow.
 A host length can perform I/O or take nonconstant time.
 

--- a/docs/development/collection-library.md
+++ b/docs/development/collection-library.md
@@ -1,0 +1,82 @@
+# Collection library contracts
+
+The Collections group retains four global functions: unary `count`,
+`count_distinct`, and `reverse`, and binary `includes`. Their Go implementations
+live in `pkg/stdlib/collections`. FQL argument validation belongs here; collection
+construction and canonical equality remain runtime contracts.
+
+## Counting read-only sources
+
+`count` and `count_distinct` require only `runtime.Iterable` in addition to the
+`runtime.Value` input contract. Read-only host values do not need collection
+mutation, cloning, membership, equality, or ordering methods. Native ascending
+and descending ranges are supported. Strings and non-iterable scalars remain
+invalid counting inputs.
+
+After iterable validation, `count` calls `Measurable.Length` when available.
+It does not create an iterator or retry a failed length operation by scanning.
+Native ranges use this path, including propagation of range-length overflow.
+A host length can perform I/O or take nonconstant time.
+
+Without measurement, `count` traverses once through `runtime.ForEach`. Checked
+increments return `ErrRange` before exceeding `runtime.Int`. No partial count is
+returned after a failure. Scanning may consume a one-shot source, perform I/O,
+or fail to terminate on an unbounded source.
+
+`count_distinct` always traverses yielded values. Objects contribute values,
+not keys or key/value pairs. It uses `pkg/internal/valueset`: hashes select
+candidates, and canonical equality resolves collisions. Equivalent Int/Float
+values share a distinct entry, Duration equality remains strict, and host
+equality failures propagate. Stored references are borrowed, never cloned or closed.
+
+## Membership and traversal ownership
+
+`includes` dispatches to string handling first, then `runtime.Containable`, then
+an iterable scan. String needles retain textual conversion, so
+`includes("123", 123)` is true; the separate string `contains` remains strict.
+Object membership searches values. A matching key alone is insufficient.
+
+Fallback scans use `runtime.ForEach`, which closes only its acquired closable
+iterator exactly once on exhaustion, early match, or failure. Iterator creation
+failure acquires no cleanup obligation. Traversal/equality and close errors are
+joined, including a close failure after a match. Sources and yielded values
+remain borrowed. Delegated `Contains` owns its own internal resources.
+
+The counting and membership wrappers check cancellation before host dispatch,
+within traversal, and before successful completion. Equality/set operations are
+followed by cancellation checks, and cancellation during EOF or iterator cleanup
+cannot produce success. Hosts receive the caller's context and remain responsible
+while they retain control. Entry checks cannot interrupt arbitrary blocking host
+operations. Global iterator and equality semantics are unchanged.
+
+## Reversal and destination ownership
+
+String reversal reverses Unicode code points, not grapheme clusters. List
+reversal obtains length, calls `source.New(ctx)`, reads descending indexes, and
+checks every append. Negative host lengths fail before construction. It returns
+the same implementation family with the source's
+relevant configuration. Only the outer list is new; element references remain
+shallow and the source is unchanged. Non-list iterables are not materialized.
+
+Factories own construction failure, as specified by
+[Factory](runtime.md#collection-construction-and-migration). After successful
+creation, reversal owns the destination until success. Access, append, and
+cancellation failures close that incomplete destination when closable and join
+cleanup errors with the primary failure. Successful results transfer ownership
+through normal VM/result lifecycle handling. The borrowed source and element
+values are never explicitly closed.
+
+## Verification and compatibility
+
+Package tests use minimal read-only sources, configured lists/maps, deterministic
+cancellation hooks, and closable iterators. Tests assert exact cleanup counts,
+joined error identity, shallow references, and independent destinations. VM
+contracts run at None, Basic, and Full optimization; API analyzer tests verify
+capability types and arities. Benchmarks cover measured counting, distinct scans,
+membership dispatch, and native/custom reversal, with new iterable-only counting
+reported separately from previously supported paths.
+
+The Factory rename intentionally breaks Go implementers of List and Map; existing
+FQL names and arities are retained. Counting accepts additional read-only inputs,
+and global reverse now preserves custom list implementations. `arrays::reverse`
+and `is_empty` are outside this migration.

--- a/docs/development/collection-library.md
+++ b/docs/development/collection-library.md
@@ -13,7 +13,9 @@ mutation, cloning, membership, equality, or ordering methods. Native ascending
 and descending ranges are supported. Strings and non-iterable scalars remain
 invalid counting inputs.
 
-After iterable validation, `count` calls `Measurable.Length` when available.
+`count` first checks the combined `Iterable` and `Measurable` capability, then
+falls back to `Iterable`. This validates both requirements in one dispatch for
+measured sources; `Measurable` alone is insufficient. It calls `Length` when available.
 It does not create an iterator or retry a failed length operation by scanning.
 Native ranges use this path, including propagation of range-length overflow.
 A host length can perform I/O or take nonconstant time.
@@ -75,6 +77,15 @@ contracts run at None, Basic, and Full optimization; API analyzer tests verify
 capability types and arities. Benchmarks cover measured counting, distinct scans,
 membership dispatch, and native/custom reversal, with new iterable-only counting
 reported separately from previously supported paths.
+
+Context-sensitive benchmarks also cover empty, singleton, small, and larger
+inputs with Background, cancellable, deadline, and layered contexts. Reused
+contexts exclude setup and first `Done` access; fresh contexts include creation,
+the collection operation, and cancellation. Keep these measurements separate:
+first access to a cancellation channel can allocate. Loop checkpoints use
+`ctx.Err()` directly, preserving the caller's context and error identity without
+forcing channel creation. Context polling changes must demonstrate benefits
+across these cases, not only for Background or deeply wrapped contexts.
 
 The Factory rename intentionally breaks Go implementers of List and Map; existing
 FQL names and arities are retained. Counting accepts additional read-only inputs,

--- a/docs/development/modules.md
+++ b/docs/development/modules.md
@@ -96,6 +96,10 @@ boundary, preserve argument context in errors, and delegate shared semantics to
 runtime helpers. Reusable module contracts do not belong in stdlib, and
 stdlib-specific behavior does not belong in `pkg/module`.
 
+The Collections group registers global `count`, `count_distinct`, `includes`,
+and `reverse`. Their minimum input capabilities, cancellation boundaries, and
+ownership contracts are described in [Collection library contracts](collection-library.md).
+
 The function definitions registered by `stdlib.Full()` are also the source for
 the published Ferret Core API artifacts. Structured documentation requirements
 and generation checks are described in the

--- a/docs/development/object-library.md
+++ b/docs/development/object-library.md
@@ -87,6 +87,14 @@ produce independent destinations. `New` transfers ownership only on success;
 the factory owns failed-construction cleanup. See the runtime guide's
 [collection construction migration](runtime.md#collection-construction-and-migration).
 
+After successful factory construction, immutable merge owns its destination until
+successful return. Population or cancellation failures close that incomplete
+destination exactly once when it implements `io.Closer`, joining cleanup failures
+with the attributed primary error. Failed calls return `runtime.None`; successful
+destinations stay open and transfer through normal result lifecycle handling.
+Sources remain borrowed. This is resource cleanup, not transactional rollback;
+mutable merge never closes its caller-owned target.
+
 Mutable shallow merge and key filters use the same runtime operations directly
 on their target, without cloning it. Retained existing values are untouched.
 `runtime.Map` already includes `Set` and `RemoveKey`; readable values lacking

--- a/docs/development/object-library.md
+++ b/docs/development/object-library.md
@@ -21,7 +21,8 @@ non-string key fails the call with an argument-attributed type error.
 
 Both merge functions accept variadic maps or one `runtime.List` of maps.
 At least one argument is required; an empty list produces an empty object.
-The first source's `Empty` method creates the destination. Later sources win.
+The first source's `New` method creates the destination, preserving its
+implementation family and relevant configuration. Later sources win.
 Deep merge recurses only when both conflicting values implement `runtime.Map`;
 arrays, scalars, and `none` are replaced.
 
@@ -81,8 +82,10 @@ Key snapshots are fully traversed before removal, supporting live host key views
 Immutable results have independent containers. Values use `runtime.CloneOrCopy`:
 Cloneable values must honor their deep-clone contract; other values follow
 their shallow `Value.Copy` contract. The library cannot strengthen a host
-value's copy guarantees. Host implementations of `Empty` and `Clone` must
-produce independent destinations.
+value's copy guarantees. Host implementations of `New` and `Clone` must
+produce independent destinations. `New` transfers ownership only on success;
+the factory owns failed-construction cleanup. See the runtime guide's
+[collection construction migration](runtime.md#collection-construction-and-migration).
 
 Mutable shallow merge and key filters use the same runtime operations directly
 on their target, without cloning it. Retained existing values are untouched.

--- a/docs/development/runtime.md
+++ b/docs/development/runtime.md
@@ -287,6 +287,8 @@ execution diagnostic is returned unchanged.
 
 Diagnostic aggregates expose `Unwrap() []error`, and runtime errors unwrap to
 their underlying diagnostic, which in turn retains its cause.
+When cleanup failures are joined alongside an attributed argument error,
+argument diagnostics retain the joined causes without changing their presentation.
 
 Before hooks run in registration order. After and close hooks unwind in reverse
 order, with the error behavior defined by `pkg/module` and the engine's internal

--- a/docs/development/runtime.md
+++ b/docs/development/runtime.md
@@ -15,6 +15,37 @@ Consumers should use the runtime's shared operations rather than matching
 concrete built-in types. Host values may implement capabilities without being a
 built-in value, and consumers must preserve those contracts.
 
+## Collection construction and migration
+
+`runtime.Factory[T Collection]` exposes `New(context.Context) (T, error)`.
+`List` embeds `Factory[List]`, and `Map` embeds `Factory[Map]`. This is an
+intentional breaking Go API change from `Spawnable[T].Empty`: implementers must
+rename the method and callers must use `New`. There is no compatibility alias.
+The generic constraint limits this capability to runtime collections.
+
+`New` creates an empty, independently mutable collection in the receiver's
+implementation family. Preserve relevant configuration such as backend,
+encoding, limits, and placement policy. A shared service or backend is allowed;
+shared logical mutable contents are not. The source remains unchanged and no
+elements are copied. Native Array may reserve capacity without populating it;
+FastObject preserves its shape cache and dictionary threshold, and DataSet
+preserves its distinctness policy with fresh membership state.
+
+`Copy` makes a shallow copy containing the elements; `Clone` makes a deep copy;
+`Clear` removes elements from the existing collection. None replaces `New`.
+Construction may perform I/O or fail and must honor the caller's context when
+it may block. Native factories reject pre-canceled calls before allocating.
+Ownership transfers only on success. A failed factory releases its partially
+acquired resources and joins creation and cleanup failures without returning an
+owned result. After successful creation, the caller owns cleanup until it
+transfers the result. Wrappers must implement `New` when an inherited factory
+would discard their implementation family or configuration.
+
+Global collection functions and their iterator/result ownership are described
+in [Collection library contracts](collection-library.md).
+
+## Copying values
+
 Use `runtime.Copy(src)` when a caller needs a shallow copy preserving its static
 Go type, including capability interfaces such as `runtime.List`. The helper calls
 `Value.Copy` once and checks the result, returning an error wrapping

--- a/pkg/runtime/array.go
+++ b/pkg/runtime/array.go
@@ -373,8 +373,13 @@ func (t *Array) Clear(_ context.Context) error {
 	return nil
 }
 
-func (t *Array) Empty(_ context.Context) (List, error) {
-	return NewArray(0), nil
+// New creates an independent empty collection with the receiver's configuration.
+func (t *Array) New(ctx context.Context) (List, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	return NewArray(len(t.data)), nil
 }
 
 func (t *Array) Remove(ctx context.Context, value Value) error {

--- a/pkg/runtime/collections.go
+++ b/pkg/runtime/collections.go
@@ -85,12 +85,19 @@ type (
 	// KeyReadablePredicate is a function type that represents a condition to be evaluated against elements in a collection based on their key.
 	KeyReadablePredicate = func(ctx context.Context, value, key Value) (Boolean, error)
 
-	// Spawnable is an interface for creating new instances of a type.
-	// Generic interface for all types that can create new instances of themselves.
-	Spawnable[T any] interface {
-		// Empty creates a new instance of the type or returns an error if the operation fails.
-		// The new instance should be initialized with default values and ready for use.
-		Empty(ctx context.Context) (T, error)
+	// Factory constructs collections in the receiver's implementation family.
+	// It is a collection capability, not a general-purpose object factory.
+	Factory[T Collection] interface {
+		// New creates a new, empty, independently mutable collection, preserving
+		// relevant implementation configuration such as backend, encoding, limits,
+		// and placement policy. It neither copies elements nor changes the source.
+		// A shared backend is allowed, but logical mutable contents must be distinct.
+		// Unlike Copy and Clone, New contains no source elements; unlike Clear,
+		// it does not mutate the receiver. Creation may perform I/O and must honor
+		// ctx when it may block. Ownership transfers to the caller only on success.
+		// On failure the factory releases partially acquired resources, joining
+		// cleanup failures with the creation error, and returns no owned result.
+		New(ctx context.Context) (T, error)
 	}
 
 	// Collection represents a collection of values.
@@ -119,7 +126,7 @@ type (
 		IndexWritable
 		IndexRemovable
 		ValueRemovable
-		Spawnable[List]
+		Factory[List]
 
 		// Insert adds a value at the specified index in a collection or returns an error if the index is invalid or operation fails.
 		Insert(ctx context.Context, idx Int, value Value) error
@@ -152,7 +159,7 @@ type (
 		KeyWritable
 		KeyRemovable
 		ValueRemovable
-		Spawnable[Map]
+		Factory[Map]
 
 		// Merge merges another map into the current map, combining their key-value pairs or returns an error if merging fails.
 		Merge(ctx context.Context, other Map) error

--- a/pkg/runtime/conversion_error_list_test.go
+++ b/pkg/runtime/conversion_error_list_test.go
@@ -31,3 +31,15 @@ func (l *conversionErrorList) Iterate(ctx context.Context) (Iterator, error) {
 
 	return l.Array.Iterate(ctx)
 }
+
+func (l *conversionErrorList) New(ctx context.Context) (List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.Array = base.(*Array)
+
+	return &result, nil
+}

--- a/pkg/runtime/copy_host_test.go
+++ b/pkg/runtime/copy_host_test.go
@@ -1,6 +1,10 @@
 package runtime_test
 
-import "github.com/MontFerret/ferret/v2/pkg/runtime"
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
 
 type copyContractList struct {
 	runtime.List
@@ -12,4 +16,16 @@ func (list *copyContractList) Copy() runtime.Value {
 	list.calls++
 
 	return list.copied
+}
+
+func (list *copyContractList) New(ctx context.Context) (runtime.List, error) {
+	base, err := list.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *list
+	result.List = base
+
+	return &result, nil
 }

--- a/pkg/runtime/factory_test.go
+++ b/pkg/runtime/factory_test.go
@@ -1,0 +1,89 @@
+package runtime_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+var (
+	_ runtime.Factory[runtime.List] = (*runtime.Array)(nil)
+	_ runtime.Factory[runtime.Map]  = (*runtime.Object)(nil)
+	_ runtime.List                  = (*runtime.Array)(nil)
+	_ runtime.Map                   = (*runtime.Object)(nil)
+)
+
+func TestNativeCollectionFactories(t *testing.T) {
+	ctx := t.Context()
+	array := runtime.NewArrayWith(runtime.Int(7))
+	list, err := array.New(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := list.(*runtime.Array); !ok || list == array {
+		t.Fatalf("list family: %T", list)
+	}
+
+	if length, err := list.Length(ctx); err != nil || length != 0 {
+		t.Fatalf("new list is not empty: %d, %v", length, err)
+	}
+
+	if err := list.Append(ctx, runtime.Int(9)); err != nil {
+		t.Fatal(err)
+	}
+
+	if value, err := array.At(ctx, 0); err != nil || value != runtime.Int(7) {
+		t.Fatal("list source changed")
+	}
+
+	if err := array.SetAt(ctx, 0, runtime.Int(8)); err != nil {
+		t.Fatal(err)
+	}
+
+	if value, err := list.At(ctx, 0); err != nil || value != runtime.Int(9) {
+		t.Fatal("list destination aliases source")
+	}
+
+	object := runtime.NewObjectWith(map[string]runtime.Value{"a": runtime.Int(7)})
+	mapping, err := object.New(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := mapping.(*runtime.Object); !ok || mapping == object {
+		t.Fatalf("map family: %T", mapping)
+	}
+
+	if length, err := mapping.Length(ctx); err != nil || length != 0 {
+		t.Fatalf("new map is not empty: %d, %v", length, err)
+	}
+
+	if err := mapping.Set(ctx, runtime.String("a"), runtime.Int(9)); err != nil {
+		t.Fatal(err)
+	}
+
+	if value, err := object.Get(ctx, runtime.String("a")); err != nil || value != runtime.Int(7) {
+		t.Fatal("map source changed")
+	}
+
+	if err := object.Set(ctx, runtime.String("a"), runtime.Int(8)); err != nil {
+		t.Fatal(err)
+	}
+
+	if value, err := mapping.Get(ctx, runtime.String("a")); err != nil || value != runtime.Int(9) {
+		t.Fatal("map destination aliases source")
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if value, err := array.New(canceled); value != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("array cancellation: %v, %v", value, err)
+	}
+
+	if value, err := object.New(canceled); value != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("object cancellation: %v, %v", value, err)
+	}
+}

--- a/pkg/runtime/fallible_duration_list_test.go
+++ b/pkg/runtime/fallible_duration_list_test.go
@@ -35,3 +35,15 @@ func (l *fallibleDurationList) At(ctx context.Context, idx runtime.Int) (runtime
 
 	return l.Array.At(ctx, idx)
 }
+
+func (l *fallibleDurationList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.Array = base.(*runtime.Array)
+
+	return &result, nil
+}

--- a/pkg/runtime/object.go
+++ b/pkg/runtime/object.go
@@ -415,7 +415,12 @@ func (t *Object) Clear(_ context.Context) error {
 	return nil
 }
 
-func (t *Object) Empty(_ context.Context) (Map, error) {
+// New creates an independent empty collection with the receiver's configuration.
+func (t *Object) New(ctx context.Context) (Map, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return NewObject(), nil
 }
 

--- a/pkg/runtime/type_list_fixture_test.go
+++ b/pkg/runtime/type_list_fixture_test.go
@@ -1,0 +1,37 @@
+package runtime_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type typedList struct {
+	*runtime.Array
+}
+
+func (t typedList) Concat(ctx context.Context, other runtime.List) error {
+	return t.Array.Concat(ctx, other)
+}
+
+func (t typedList) Type() runtime.Type {
+	return typeTypedList
+}
+
+func (t typedList) New(ctx context.Context) (runtime.List, error) {
+	base, err := t.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := t
+	result.Array = base.(*runtime.Array)
+
+	return result, nil
+}
+
+var typeTypedList = runtime.NewType("test", "typedList", func(value runtime.Value) bool {
+	_, ok := value.(typedList)
+
+	return ok
+})

--- a/pkg/runtime/type_test.go
+++ b/pkg/runtime/type_test.go
@@ -1,7 +1,6 @@
 package runtime_test
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -27,24 +26,6 @@ func (typedOnly) Hash() uint64 {
 
 func (typedOnly) Copy() runtime.Value {
 	return typedOnly{}
-}
-
-type typedList struct {
-	*runtime.Array
-}
-
-func (t typedList) Concat(ctx context.Context, other runtime.List) error {
-	return t.Array.Concat(ctx, other)
-}
-
-var typeTypedList = runtime.NewType("test", "typedList", func(value runtime.Value) bool {
-	_, ok := value.(typedList)
-
-	return ok
-})
-
-func (t typedList) Type() runtime.Type {
-	return typeTypedList
 }
 
 func TestValidateType(t *testing.T) {

--- a/pkg/stdlib/arrays/copy_bench_test.go
+++ b/pkg/stdlib/arrays/copy_bench_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/MontFerret/ferret/v2/pkg/stdlib/arrays"
 )
 
-type copyBenchmarkList struct {
-	runtime.List
-}
-
 var copyBenchmarkResult runtime.Value
 
 func BenchmarkListCopyOperations(b *testing.B) {

--- a/pkg/stdlib/arrays/copy_benchmark_list_test.go
+++ b/pkg/stdlib/arrays/copy_benchmark_list_test.go
@@ -1,0 +1,23 @@
+package arrays_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type copyBenchmarkList struct {
+	runtime.List
+}
+
+func (source copyBenchmarkList) New(ctx context.Context) (runtime.List, error) {
+	base, err := source.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := source
+	result.List = base
+
+	return result, nil
+}

--- a/pkg/stdlib/arrays/host_values_test.go
+++ b/pkg/stdlib/arrays/host_values_test.go
@@ -149,3 +149,51 @@ func (probe *copyMutationProbe) RemoveAt(context.Context, runtime.Int) (runtime.
 
 	return runtime.None, nil
 }
+
+func (p *sliceProbe) New(ctx context.Context) (runtime.List, error) {
+	base, err := p.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *p
+	result.List = base
+
+	return &result, nil
+}
+
+func (l *failingList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.Array = base.(*runtime.Array)
+
+	return &result, nil
+}
+
+func (l *lengthFailingList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.Array = base.(*runtime.Array)
+
+	return &result, nil
+}
+
+func (list *copyFailureList) New(ctx context.Context) (runtime.List, error) {
+	base, err := list.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *list
+	result.List = base
+
+	return &result, nil
+}

--- a/pkg/stdlib/arrays/legacy_pop.go
+++ b/pkg/stdlib/arrays/legacy_pop.go
@@ -22,7 +22,7 @@ func legacyPop(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 	}
 
 	if size == 0 {
-		return arr.Empty(ctx)
+		return arr.New(ctx)
 	}
 
 	return arr.Slice(ctx, 0, size-1)

--- a/pkg/stdlib/arrays/mutable_contract_test.go
+++ b/pkg/stdlib/arrays/mutable_contract_test.go
@@ -334,7 +334,7 @@ func mutableOperationArgs(name string, target runtime.Value) []runtime.Value {
 
 func assertNoMutableCopies(t *testing.T, target *mutableHostList) {
 	t.Helper()
-	if target.calls["Copy"]+target.calls["Clone"]+target.calls["Empty"] != 0 {
+	if target.calls["Copy"]+target.calls["Clone"]+target.calls["New"] != 0 {
 		t.Fatalf("mutable operation copied its target: %v", target.calls)
 	}
 }

--- a/pkg/stdlib/arrays/mutable_host_values_test.go
+++ b/pkg/stdlib/arrays/mutable_host_values_test.go
@@ -61,8 +61,8 @@ func (l *mutableHostList) Clone(context.Context) (runtime.Cloneable, error) {
 	return nil, l.failure
 }
 
-func (l *mutableHostList) Empty(context.Context) (runtime.List, error) {
-	l.calls["Empty"]++
+func (l *mutableHostList) New(context.Context) (runtime.List, error) {
+	l.calls["New"]++
 
 	return nil, l.failure
 }

--- a/pkg/stdlib/arrays/removal_host_values_test.go
+++ b/pkg/stdlib/arrays/removal_host_values_test.go
@@ -53,3 +53,15 @@ func (l *removalFilterList) Filter(ctx context.Context, predicate runtime.IndexR
 
 	return l.List.Filter(ctx, predicate)
 }
+
+func (l *removalFilterList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.List = base
+
+	return &result, nil
+}

--- a/pkg/stdlib/collections/collection_benchmark_test.go
+++ b/pkg/stdlib/collections/collection_benchmark_test.go
@@ -1,0 +1,81 @@
+package collections_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+)
+
+func BenchmarkCollections(b *testing.B) {
+	ctx := context.Background()
+	array := runtime.NewArray(1024)
+	for i := range 1024 {
+		if err := array.Append(ctx, runtime.Int(i%128)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	host := &benchmarkList{Array: array, backend: "memory"}
+	stream := &benchmarkIterable{values: array}
+	for _, tc := range []struct {
+		input runtime.Value
+		call  func(context.Context, runtime.Value) (runtime.Value, error)
+		name  string
+	}{
+		{name: "CountNative", input: array, call: collections.Count},
+		{name: "CountHost", input: host, call: collections.Count},
+		{name: "DistinctNative", input: array, call: collections.CountDistinct},
+		{name: "DistinctHost", input: host, call: collections.CountDistinct},
+		{name: "ReverseNative", input: array, call: collections.Reverse},
+		{name: "ReverseHost", input: host, call: collections.Reverse},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := tc.call(ctx, tc.input); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		input  runtime.Value
+		needle runtime.Value
+		name   string
+	}{
+		{name: "IncludesContainable", input: host, needle: runtime.Int(-1)},
+		{name: "IncludesScan", input: stream, needle: runtime.Int(-1)},
+		{name: "IncludesEarly", input: stream, needle: runtime.Int(0)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := collections.Includes(ctx, tc.input, tc.needle); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// These inputs were previously rejected, so they have no successful old baseline.
+func BenchmarkCollectionIterableCounting(b *testing.B) {
+	array := runtime.NewArray(1024)
+	for i := range 1024 {
+		if err := array.Append(b.Context(), runtime.Int(i%128)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	stream := &benchmarkIterable{values: array}
+	for name, call := range map[string]func(context.Context, runtime.Value) (runtime.Value, error){"Count": collections.Count, "Distinct": collections.CountDistinct} {
+		b.Run(name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := call(context.Background(), stream); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/stdlib/collections/collection_benchmark_value_test.go
+++ b/pkg/stdlib/collections/collection_benchmark_value_test.go
@@ -1,0 +1,38 @@
+package collections_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	benchmarkList struct {
+		*runtime.Array
+		backend string
+	}
+
+	benchmarkIterable struct {
+		values *runtime.Array
+	}
+)
+
+func (l *benchmarkList) New(ctx context.Context) (runtime.List, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	size, err := l.Length(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &benchmarkList{Array: runtime.NewArray64(size), backend: l.backend}, nil
+}
+
+func (s *benchmarkIterable) String() string      { return "benchmark iterable" }
+func (s *benchmarkIterable) Hash() uint64        { return 1 }
+func (s *benchmarkIterable) Copy() runtime.Value { return s }
+func (s *benchmarkIterable) Iterate(ctx context.Context) (runtime.Iterator, error) {
+	return s.values.Iterate(ctx)
+}

--- a/pkg/stdlib/collections/context_benchmark_test.go
+++ b/pkg/stdlib/collections/context_benchmark_test.go
@@ -1,0 +1,103 @@
+package collections_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+)
+
+// Reused contexts exclude setup and first Done access. Fresh contexts include
+// creation, the collection call, and cancellation, including lazy channel costs.
+func BenchmarkCollectionContexts(b *testing.B) {
+	for _, size := range []int{0, 1, 16, 1024} {
+		array := runtime.NewArray(size)
+		for i := range size {
+			if err := array.Append(context.Background(), runtime.Int(i%128)); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		host := &benchmarkList{Array: array, backend: "memory"}
+		stream := &benchmarkIterable{values: array}
+		cases := []struct {
+			input runtime.Value
+			call  func(context.Context, runtime.Value) (runtime.Value, error)
+			name  string
+		}{
+			{name: "CountNative", input: array, call: collections.Count},
+			{name: "CountHost", input: host, call: collections.Count},
+			{name: "CountScan", input: stream, call: collections.Count},
+			{name: "DistinctNative", input: array, call: collections.CountDistinct},
+			{name: "DistinctHost", input: host, call: collections.CountDistinct},
+			{name: "DistinctScan", input: stream, call: collections.CountDistinct},
+			{name: "ReverseNative", input: array, call: collections.Reverse},
+			{name: "ReverseHost", input: host, call: collections.Reverse},
+			{name: "IncludesContainable", input: host, call: benchmarkCollectionMissing},
+			{name: "IncludesScan", input: stream, call: benchmarkCollectionMissing},
+			{name: "IncludesEarly", input: stream, call: benchmarkCollectionFirst},
+		}
+
+		for _, kind := range []string{"Background", "Cancellable", "Deadline", "Layered"} {
+			for _, lifetime := range []string{"Reused", "Fresh"} {
+				for _, tc := range cases {
+					b.Run(fmt.Sprintf("Size=%d/%s/%s/%s", size, kind, lifetime, tc.name), func(b *testing.B) {
+						if lifetime == "Fresh" {
+							for b.Loop() {
+								ctx, cancel := collectionBenchmarkContext(kind)
+								_, err := tc.call(ctx, tc.input)
+								cancel()
+								if err != nil {
+									b.Fatal(err)
+								}
+							}
+
+							return
+						}
+
+						ctx, cancel := collectionBenchmarkContext(kind)
+						defer cancel()
+						_ = ctx.Done()
+						for b.Loop() {
+							if _, err := tc.call(ctx, tc.input); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func collectionBenchmarkContext(kind string) (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	switch kind {
+	case "Cancellable":
+		return context.WithCancel(ctx)
+	case "Deadline":
+		return context.WithDeadline(ctx, time.Now().Add(time.Hour))
+	case "Layered":
+		type key int
+
+		ctx, cancel := context.WithCancel(ctx)
+		for i := range 4 {
+			ctx = context.WithValue(ctx, key(i), i)
+		}
+
+		return ctx, cancel
+	default:
+		return ctx, func() {}
+	}
+}
+
+func benchmarkCollectionMissing(ctx context.Context, source runtime.Value) (runtime.Value, error) {
+	return collections.Includes(ctx, source, runtime.Int(-1))
+}
+
+func benchmarkCollectionFirst(ctx context.Context, source runtime.Value) (runtime.Value, error) {
+	return collections.Includes(ctx, source, runtime.Int(0))
+}

--- a/pkg/stdlib/collections/context_contract_test.go
+++ b/pkg/stdlib/collections/context_contract_test.go
@@ -189,7 +189,7 @@ func TestReverseLayeredCancellationBoundaries(t *testing.T) {
 }
 
 func collectionTestContext(kind string) (*doneCountingContext, context.CancelFunc) {
-	var ctx context.Context = context.Background()
+	ctx := context.Background()
 	cancel := func() {}
 	switch kind {
 	case "Open", "Layered", "Closed":

--- a/pkg/stdlib/collections/context_contract_test.go
+++ b/pkg/stdlib/collections/context_contract_test.go
@@ -1,0 +1,213 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+)
+
+func TestCollectionContextStates(t *testing.T) {
+	for _, kind := range []string{"Nil", "Open", "Closed", "Deadline", "Layered"} {
+		for _, operation := range []string{"count", "distinct", "includes", "reverse"} {
+			t.Run(kind+"/"+operation, func(t *testing.T) {
+				ctx, cancel := collectionTestContext(kind)
+				defer cancel()
+				values := []runtime.Value{runtime.Int(1), runtime.Int(2), runtime.Int(2)}
+				source := &scanSource{expected: ctx, values: values}
+				list := &configuredList{Array: runtime.NewArrayWith(values...), expected: ctx, calls: make(map[string]int)}
+				var got, want runtime.Value
+				var err error
+				switch operation {
+				case "count":
+					got, err = collections.Count(ctx, source)
+					want = runtime.Int(3)
+				case "distinct":
+					got, err = collections.CountDistinct(ctx, source)
+					want = runtime.Int(2)
+				case "includes":
+					got, err = collections.Includes(ctx, source, runtime.Int(2))
+					want = runtime.True
+				case "reverse":
+					got, err = collections.Reverse(ctx, list)
+					want = list.created
+				}
+
+				if expected := ctx.Err(); expected != nil {
+					if !errors.Is(err, expected) || source.iterations != 0 || len(list.calls) != 0 || ctx.doneCalls != 0 {
+						t.Fatalf("pre-canceled work: %v, %v, %+v, %+v", got, err, source, list)
+					}
+
+					return
+				}
+
+				if err != nil || got != want || ctx.doneCalls > 1 {
+					t.Fatalf("got %v, %v; want %v; Done calls %d", got, err, want, ctx.doneCalls)
+				}
+
+				if operation == "reverse" {
+					first, err := list.created.At(ctx, 0)
+					if err != nil || first != runtime.Int(2) || list.created.closes != 0 || list.closes != 0 {
+						t.Fatal("reversal order or ownership changed")
+					}
+
+					if err := list.created.Close(); err != nil {
+						t.Fatal(err)
+					}
+				} else if source.closes != 1 || source.sourceCloses != 0 {
+					t.Fatal("scan ownership changed")
+				}
+			})
+		}
+	}
+}
+
+func TestCollectionFastPathsDoNotAcquireDone(t *testing.T) {
+	for _, operation := range []string{"count", "contains", "includes-string", "reverse-string", "reverse-empty", "measurable-only"} {
+		t.Run(operation, func(t *testing.T) {
+			ctx, cancel := collectionTestContext("Open")
+			defer cancel()
+			var err error
+			switch operation {
+			case "count":
+				_, err = collections.Count(ctx, &measuredSource{scanSource: &scanSource{expected: ctx}, length: 2})
+			case "contains":
+				_, err = collections.Includes(ctx, &containableSource{scanSource: &scanSource{expected: ctx}, contains: true}, runtime.Int(2))
+			case "includes-string":
+				_, err = collections.Includes(ctx, runtime.String("123"), runtime.Int(123))
+			case "reverse-string":
+				_, err = collections.Reverse(ctx, runtime.String("abc"))
+			case "reverse-empty":
+				_, err = collections.Reverse(ctx, runtime.NewArray(0))
+			case "measurable-only":
+				source := &measurableOnly{}
+				got, failure := collections.Count(ctx, source)
+				if got != runtime.ZeroInt || !errors.Is(failure, runtime.ErrInvalidType) || !strings.Contains(failure.Error(), "position 1") || source.lengthCalls != 0 {
+					t.Fatalf("measurable-only dispatch: %v, %v, %+v", got, failure, source)
+				}
+			}
+
+			if err != nil || ctx.doneCalls != 0 {
+				t.Fatalf("fast path: %v, Done calls %d", err, ctx.doneCalls)
+			}
+		})
+	}
+}
+
+func TestLayeredScanCancellationPreservesCauses(t *testing.T) {
+	primary, cleanup := errors.New("host operation"), errors.New("iterator cleanup")
+	for _, operation := range []string{"count", "distinct", "includes"} {
+		for _, stage := range []string{"create", "next", "equality", "eof", "close"} {
+			if operation == "count" && stage == "equality" {
+				continue
+			}
+
+			t.Run(operation+"/"+stage, func(t *testing.T) {
+				ctx, cancel := collectionTestContext("Layered")
+				defer cancel()
+				first, second := &scanValue{}, &scanValue{}
+				source := &scanSource{expected: ctx, values: []runtime.Value{first, second}, closeErr: cleanup}
+				wantCloses := 1
+				wantPrimary := true
+				switch stage {
+				case "create":
+					source.onIterate, source.iterateErr = cancel, primary
+					wantCloses = 0
+				case "next":
+					source.onNext = func(int) { cancel() }
+					source.nextErr = primary
+				case "equality":
+					first.onEqual, first.equalErr = cancel, primary
+				case "eof":
+					source.values = nil
+					source.onNext = func(int) { cancel() }
+					wantPrimary = false
+				case "close":
+					source.onClose = cancel
+					wantPrimary = false
+				}
+
+				var got runtime.Value
+				var err error
+				switch operation {
+				case "count":
+					got, err = collections.Count(ctx, source)
+				case "distinct":
+					got, err = collections.CountDistinct(ctx, source)
+				case "includes":
+					got, err = collections.Includes(ctx, source, first)
+				}
+
+				if !errors.Is(err, context.Canceled) || wantPrimary && !errors.Is(err, primary) || wantCloses == 1 && !errors.Is(err, cleanup) {
+					t.Fatalf("lost failure: %v, %v", got, err)
+				}
+
+				if got != runtime.ZeroInt && got != runtime.False || source.closes != wantCloses || source.sourceCloses != 0 || first.closes+second.closes != 0 {
+					t.Fatalf("partial result or ownership changed: %v, %+v", got, source)
+				}
+			})
+		}
+	}
+}
+
+func TestReverseLayeredCancellationBoundaries(t *testing.T) {
+	cleanup := errors.New("destination cleanup")
+	for _, stage := range []string{"Length", "New", "At", "Append"} {
+		t.Run(stage, func(t *testing.T) {
+			ctx, cancel := collectionTestContext("Layered")
+			defer cancel()
+			value := &scanValue{}
+			source := &configuredList{Array: runtime.NewArrayWith(value), expected: ctx, calls: make(map[string]int), closeErr: cleanup}
+			source.after = func(operation string) {
+				if operation == stage {
+					cancel()
+				}
+			}
+
+			got, err := collections.Reverse(ctx, source)
+			if got != runtime.None || !errors.Is(err, context.Canceled) || source.closes != 0 || value.closes+value.copies+value.clones != 0 {
+				t.Fatalf("cancellation: %v, %v", got, err)
+			}
+
+			if stage == "Length" {
+				if source.created != nil || source.calls["New"] != 0 {
+					t.Fatal("constructed after cancellation")
+				}
+			} else if source.created == nil || source.created.closes != 1 || !errors.Is(err, cleanup) {
+				t.Fatal("incomplete destination cleanup lost")
+			}
+
+			if stage == "New" && source.calls["At"] != 0 || stage == "At" && source.created.calls["Append"] != 0 {
+				t.Fatal("host operation after cancellation")
+			}
+		})
+	}
+}
+
+func collectionTestContext(kind string) (*doneCountingContext, context.CancelFunc) {
+	var ctx context.Context = context.Background()
+	cancel := func() {}
+	switch kind {
+	case "Open", "Layered", "Closed":
+		ctx, cancel = context.WithCancel(ctx)
+		if kind == "Closed" {
+			cancel()
+		}
+	case "Deadline":
+		ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	}
+
+	if kind == "Layered" {
+		type key int
+
+		for i := range 4 {
+			ctx = context.WithValue(ctx, key(i), i)
+		}
+	}
+
+	return &doneCountingContext{Context: ctx}, cancel
+}

--- a/pkg/stdlib/collections/context_fixture_test.go
+++ b/pkg/stdlib/collections/context_fixture_test.go
@@ -1,0 +1,15 @@
+package collections_test
+
+import "context"
+
+// Host fixtures use the original context so this observes only wrapper polling.
+type doneCountingContext struct {
+	context.Context
+	doneCalls int
+}
+
+func (c *doneCountingContext) Done() <-chan struct{} {
+	c.doneCalls++
+
+	return c.Context.Done()
+}

--- a/pkg/stdlib/collections/count.go
+++ b/pkg/stdlib/collections/count.go
@@ -2,19 +2,65 @@ package collections
 
 import (
 	"context"
+	"errors"
+	"math"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
-// count computes the number of distinct elements in the given collection and returns the count as an integer.
-// @param collection {Collection} Collection whose elements are counted.
-// @return {Int} Number of elements in the collection.
+// Count returns the number of values in an iterable, including map values.
+// A measurable source supplies its length without traversal; computing that length
+// may still perform I/O. Otherwise one traversal may consume a one-shot source,
+// perform I/O, or never finish for an unbounded source. The acquired iterator is
+// closed; the source and its values remain borrowed. Traversal, cancellation,
+// overflow, and iterator close failures are returned without a partial count.
+// @param collection {Iterable} Source whose yielded values are counted.
+// @return {Int} Number of yielded values, or the source's measured length.
 func Count(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
-	collection, err := runtime.CastArg[runtime.Collection](arg, 0)
+	if err := ctx.Err(); err != nil {
+		return runtime.ZeroInt, err
+	}
+
+	collection, ok := arg.(runtime.Iterable)
+	if !ok {
+		return runtime.ZeroInt, runtime.ArgError(runtime.TypeErrorOf(arg, runtime.TypeIterable), 0)
+	}
+
+	var (
+		count runtime.Int
+		err   error
+	)
+
+	if measurable, ok := collection.(runtime.Measurable); ok {
+		count, err = measurable.Length(ctx)
+	} else {
+		err = runtime.ForEach(ctx, collection, func(c context.Context, _, _ runtime.Value) (runtime.Boolean, error) {
+			if err := c.Err(); err != nil {
+				return false, err
+			}
+
+			var err error
+			count, err = incrementCount(count)
+
+			return err == nil, err
+		})
+	}
+
+	if canceled := ctx.Err(); canceled != nil && !errors.Is(err, canceled) {
+		err = errors.Join(err, canceled)
+	}
 
 	if err != nil {
 		return runtime.ZeroInt, err
 	}
 
-	return collection.Length(ctx)
+	return count, nil
+}
+
+func incrementCount(count runtime.Int) (runtime.Int, error) {
+	if count == math.MaxInt64 {
+		return runtime.ZeroInt, runtime.Error(runtime.ErrRange, "count exceeds runtime.Int capacity")
+	}
+
+	return count + 1, nil
 }

--- a/pkg/stdlib/collections/count.go
+++ b/pkg/stdlib/collections/count.go
@@ -21,19 +21,15 @@ func Count(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 		return runtime.ZeroInt, err
 	}
 
-	collection, ok := arg.(runtime.Iterable)
-	if !ok {
-		return runtime.ZeroInt, runtime.ArgError(runtime.TypeErrorOf(arg, runtime.TypeIterable), 0)
-	}
-
 	var (
 		count runtime.Int
 		err   error
 	)
 
-	if measurable, ok := collection.(runtime.Measurable); ok {
-		count, err = measurable.Length(ctx)
-	} else {
+	switch collection := arg.(type) {
+	case measuredIterable:
+		count, err = collection.Length(ctx)
+	case runtime.Iterable:
 		err = runtime.ForEach(ctx, collection, func(c context.Context, _, _ runtime.Value) (runtime.Boolean, error) {
 			if err := c.Err(); err != nil {
 				return false, err
@@ -44,6 +40,8 @@ func Count(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 
 			return err == nil, err
 		})
+	default:
+		return runtime.ZeroInt, runtime.ArgError(runtime.TypeErrorOf(arg, runtime.TypeIterable), 0)
 	}
 
 	if canceled := ctx.Err(); canceled != nil && !errors.Is(err, canceled) {
@@ -55,6 +53,11 @@ func Count(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 	}
 
 	return count, nil
+}
+
+type measuredIterable interface {
+	runtime.Iterable
+	runtime.Measurable
 }
 
 func incrementCount(count runtime.Int) (runtime.Int, error) {

--- a/pkg/stdlib/collections/count.go
+++ b/pkg/stdlib/collections/count.go
@@ -10,7 +10,8 @@ import (
 
 // Count returns the number of values in an iterable, including map values.
 // A measurable source supplies its length without traversal; computing that length
-// may still perform I/O. Otherwise one traversal may consume a one-shot source,
+// may still perform I/O. Negative measured lengths are rejected without traversal.
+// Otherwise one traversal may consume a one-shot source,
 // perform I/O, or never finish for an unbounded source. The acquired iterator is
 // closed; the source and its values remain borrowed. Traversal, cancellation,
 // overflow, and iterator close failures are returned without a partial count.
@@ -29,6 +30,9 @@ func Count(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 	switch collection := arg.(type) {
 	case measuredIterable:
 		count, err = collection.Length(ctx)
+		if err == nil && count < 0 {
+			err = runtime.Error(runtime.ErrInvalidOperation, "negative iterable length")
+		}
 	case runtime.Iterable:
 		err = runtime.ForEach(ctx, collection, func(c context.Context, _, _ runtime.Value) (runtime.Boolean, error) {
 			if err := c.Err(); err != nil {

--- a/pkg/stdlib/collections/count_distinct.go
+++ b/pkg/stdlib/collections/count_distinct.go
@@ -2,30 +2,46 @@ package collections
 
 import (
 	"context"
+	"errors"
 
 	"github.com/MontFerret/ferret/v2/pkg/internal/valueset"
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
-// count_distinct computes the number of distinct elements in the given collection and returns the count as an integer.
-// @param collection {Collection} Collection whose distinct elements are counted.
-// @return {Int} Number of distinct elements in the collection.
+// CountDistinct counts distinct yielded values using canonical runtime equality.
+// Maps contribute values, not keys. One traversal may consume a one-shot source,
+// perform I/O, or never finish for an unbounded source. The acquired iterator is
+// closed; the source and yielded values are neither cloned nor closed. Iteration,
+// equality, cancellation, and close failures are returned without a partial count.
+// @param collection {Iterable} Source whose distinct yielded values are counted.
+// @return {Int} Number of distinct yielded values.
 func CountDistinct(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
-	collection, err := runtime.CastArg[runtime.Collection](arg, 0)
-
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return runtime.ZeroInt, err
+	}
+
+	collection, ok := arg.(runtime.Iterable)
+	if !ok {
+		return runtime.ZeroInt, runtime.ArgError(runtime.TypeErrorOf(arg, runtime.TypeIterable), 0)
 	}
 
 	seen := valueset.New(0)
 
-	err = runtime.ForEach(ctx, collection, func(c context.Context, value, idx runtime.Value) (runtime.Boolean, error) {
+	err := runtime.ForEach(ctx, collection, func(c context.Context, value, idx runtime.Value) (runtime.Boolean, error) {
+		if err := c.Err(); err != nil {
+			return false, err
+		}
+
 		if _, err := seen.Add(c, value); err != nil {
 			return false, err
 		}
 
-		return true, nil
+		return true, c.Err()
 	})
+
+	if canceled := ctx.Err(); canceled != nil && !errors.Is(err, canceled) {
+		err = errors.Join(err, canceled)
+	}
 
 	if err != nil {
 		return runtime.ZeroInt, err

--- a/pkg/stdlib/collections/count_overflow_test.go
+++ b/pkg/stdlib/collections/count_overflow_test.go
@@ -1,0 +1,21 @@
+package collections
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+func TestIncrementCountBoundary(t *testing.T) {
+	got, err := incrementCount(math.MaxInt64 - 1)
+	if err != nil || got != math.MaxInt64 {
+		t.Fatalf("last valid count: %v, %v", got, err)
+	}
+
+	got, err = incrementCount(got)
+	if got != runtime.ZeroInt || !errors.Is(err, runtime.ErrRange) {
+		t.Fatalf("overflow: %v, %v", got, err)
+	}
+}

--- a/pkg/stdlib/collections/include.go
+++ b/pkg/stdlib/collections/include.go
@@ -2,15 +2,26 @@ package collections
 
 import (
 	"context"
+	"errors"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
-// includes checks whether a container includes a given value.
-// @param haystack {String | Any[] | hashMap | Iterable} The value container.
+// Includes checks membership, preferring a host's Contains capability over a scan.
+// Strings convert the needle to text. Iterable scans compare yielded values,
+// including map values, using canonical equality and stop at the first match.
+// Only the acquired iterator is closed; traversal, equality, cancellation, and
+// close failures are preserved, including a close failure after a match.
+// Host capabilities receive the caller's context and must observe cancellation
+// while they retain control; an entry check cannot interrupt a blocking host.
+// @param haystack {String | Containable | Iterable} The value container.
 // @param needle {Any} The target value to assert.
 // @return {Boolean} A boolean value that indicates whether a container contains a given value.
 func Includes(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, error) {
+	if err := ctx.Err(); err != nil {
+		return runtime.False, err
+	}
+
 	var err error
 	var result runtime.Boolean
 	haystack := arg1
@@ -22,15 +33,17 @@ func Includes(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, err
 	case runtime.Containable:
 		result, err = v.Contains(ctx, needle)
 	case runtime.Iterable:
-		iter, err := v.Iterate(ctx)
+		err = runtime.ForEach(ctx, v, func(c context.Context, value runtime.Value, key runtime.Value) (runtime.Boolean, error) {
+			if err := c.Err(); err != nil {
+				return false, err
+			}
 
-		if err != nil {
-			return runtime.False, err
-		}
-
-		err = runtime.ForEachIter(ctx, iter, func(c context.Context, value runtime.Value, key runtime.Value) (runtime.Boolean, error) {
 			equal, err := runtime.EqualValues(c, needle, value)
 			if err != nil {
+				return false, err
+			}
+
+			if err := c.Err(); err != nil {
 				return false, err
 			}
 
@@ -42,10 +55,6 @@ func Includes(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, err
 
 			return true, nil
 		})
-
-		if err != nil {
-			return runtime.False, err
-		}
 	default:
 		return runtime.None, runtime.TypeErrorOf(haystack,
 			runtime.TypeString,
@@ -56,5 +65,13 @@ func Includes(ctx context.Context, arg1, arg2 runtime.Value) (runtime.Value, err
 		)
 	}
 
-	return result, err
+	if canceled := ctx.Err(); canceled != nil && !errors.Is(err, canceled) {
+		err = errors.Join(err, canceled)
+	}
+
+	if err != nil {
+		return runtime.False, err
+	}
+
+	return result, nil
 }

--- a/pkg/stdlib/collections/reverse.go
+++ b/pkg/stdlib/collections/reverse.go
@@ -2,13 +2,20 @@ package collections
 
 import (
 	"context"
+	"errors"
+	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
-// reverse returns the reverse of a given string or array value.
-// @param value {String | Any[]} The string or array to reverse.
-// @return {String | Any[]} A reversed version of a given value.
+// Reverse reverses Unicode code points in a string or indexed elements in a list.
+// Lists construct an independent outer list through New, preserving implementation
+// family and backend configuration. Elements remain shallow borrowed references.
+// Failed or canceled construction is handled by the factory; subsequent failures
+// close the incomplete destination and preserve cleanup errors. Success transfers
+// destination ownership to the caller. The source and its elements are not closed.
+// @param value {String | List} The string or indexed list to reverse.
+// @return {String | List} A reversed string or new list of the source's implementation family.
 func Reverse(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 	switch col := arg.(type) {
 	case runtime.String:
@@ -22,26 +29,67 @@ func Reverse(ctx context.Context, arg runtime.Value) (runtime.Value, error) {
 
 		return runtime.NewString(string(runes)), nil
 	case runtime.List:
-		size, err := col.Length(ctx)
+		return reverseList(ctx, col)
+	default:
+		return runtime.None, runtime.TypeErrorOf(arg, runtime.TypeList, runtime.TypeString)
+	}
+}
 
+func reverseList(ctx context.Context, col runtime.List) (_ runtime.Value, err error) {
+	if err := ctx.Err(); err != nil {
+		return runtime.None, err
+	}
+
+	size, err := col.Length(ctx)
+	if err != nil {
+		return runtime.None, err
+	}
+
+	if size < 0 {
+		return runtime.None, runtime.Error(runtime.ErrInvalidOperation, "negative list length")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return runtime.None, err
+	}
+
+	result, err := col.New(ctx)
+	if err != nil {
+		return runtime.None, err
+	}
+
+	defer func() {
+		if err != nil {
+			if closer, ok := result.(io.Closer); ok {
+				if closeErr := closer.Close(); closeErr != nil {
+					err = errors.Join(err, closeErr)
+				}
+			}
+		}
+	}()
+
+	for i := size; i > 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return runtime.None, err
+		}
+
+		item, err := col.At(ctx, i-1)
 		if err != nil {
 			return runtime.None, err
 		}
 
-		result := runtime.NewArray(int(size))
-
-		for i := size - 1; i >= 0; i-- {
-			item, err := col.At(ctx, i)
-
-			if err != nil {
-				return runtime.None, err
-			}
-
-			_ = result.Append(ctx, item)
+		if err := ctx.Err(); err != nil {
+			return runtime.None, err
 		}
 
-		return result, nil
-	default:
-		return runtime.None, runtime.TypeErrorOf(arg, runtime.TypeList, runtime.TypeString)
+		if err := result.Append(ctx, item); err != nil {
+			return runtime.None, err
+		}
 	}
+
+	if err := ctx.Err(); err != nil {
+		return runtime.None, err
+	}
+
+	return result, nil
 }

--- a/pkg/stdlib/collections/reverse_contract_test.go
+++ b/pkg/stdlib/collections/reverse_contract_test.go
@@ -1,0 +1,182 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+)
+
+func TestReversePreservesListImplementationAndOwnership(t *testing.T) {
+	for _, size := range []int{0, 1, 3} {
+		ctx := t.Context()
+		resource := &scanValue{}
+		values := []runtime.Value{resource, runtime.NewObject(), runtime.Int(3)}[:size]
+		source := &configuredList{Array: runtime.NewArrayWith(values...), backend: &listBackend{encoding: "binary", limit: 100}, expected: ctx, calls: make(map[string]int)}
+		out, err := collections.Reverse(ctx, source)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		destination, ok := out.(*configuredList)
+		if !ok || destination == source || destination != source.created || destination.backend != source.backend {
+			t.Fatalf("factory identity/configuration lost: %T", out)
+		}
+
+		length, err := destination.Length(ctx)
+		if err != nil || length != runtime.Int(size) {
+			t.Fatalf("length: %d, %v", length, err)
+		}
+
+		for i, value := range values {
+			original, err := source.At(ctx, runtime.Int(i))
+			if err != nil || original != value {
+				t.Fatal("source changed")
+			}
+
+			reversed, err := destination.At(ctx, runtime.Int(size-i-1))
+			if err != nil || reversed != value {
+				t.Fatal("element identity/order changed")
+			}
+		}
+
+		if err := destination.Append(ctx, runtime.True); err != nil {
+			t.Fatal(err)
+		}
+
+		length, err = source.Length(ctx)
+		if err != nil || length != runtime.Int(size) {
+			t.Fatal("destination aliases source storage")
+		}
+
+		if source.calls["New"] != 1 || source.closes != 0 || destination.closes != 0 || resource.closes+resource.copies+resource.clones != 0 {
+			t.Fatal("incorrect ownership transfer")
+		}
+
+		if err := destination.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if destination.closes != 1 || source.closes != 0 || resource.closes != 0 {
+			t.Fatal("caller cleanup changed borrowed ownership")
+		}
+	}
+}
+
+func TestReverseClosesPopulatedDestination(t *testing.T) {
+	primary, cleanup := errors.New("operation"), errors.New("close")
+	for _, operation := range []string{"At", "Append"} {
+		for _, failAt := range []int{1, 2, 3} {
+			t.Run(fmt.Sprintf("%s/%d", operation, failAt), func(t *testing.T) {
+				resource := &scanValue{}
+				source := &configuredList{
+					Array:    runtime.NewArrayWith(runtime.Int(1), runtime.Int(2), resource),
+					expected: t.Context(), calls: make(map[string]int),
+					failures: map[string]error{operation: primary},
+					failAt:   map[string]int{operation: failAt}, closeErr: cleanup,
+				}
+				out, err := collections.Reverse(t.Context(), source)
+				if out != runtime.None || !errors.Is(err, primary) || !errors.Is(err, cleanup) {
+					t.Fatalf("lost failure: %v, %v", out, err)
+				}
+
+				if source.created == nil || source.created.closes != 1 || source.closes != 0 || resource.closes != 0 {
+					t.Fatal("incorrect partial-result ownership")
+				}
+
+				length, err := source.created.Array.Length(t.Context())
+				if err != nil || length != runtime.Int(failAt-1) {
+					t.Fatalf("unexpected partial result: %d, %v", length, err)
+				}
+			})
+		}
+	}
+}
+
+func TestReverseRejectsNegativeHostLengthBeforeConstruction(t *testing.T) {
+	for _, size := range []runtime.Int{-1, math.MinInt64} {
+		source := &configuredList{Array: runtime.NewArray(0), expected: t.Context(), calls: make(map[string]int), length: &size}
+		result, err := collections.Reverse(t.Context(), source)
+		if result != runtime.None || !errors.Is(err, runtime.ErrInvalidOperation) || source.calls["New"] != 0 || source.closes != 0 {
+			t.Fatalf("negative length: %v, %v", result, err)
+		}
+	}
+}
+
+func TestReverseFailureOwnership(t *testing.T) {
+	primary, cleanup := errors.New("operation"), errors.New("cleanup")
+	for _, stage := range []string{"Length", "New", "At", "Append", "pre-cancel", "cancel-Length", "cancel-New", "cancel-At", "cancel-Append"} {
+		for _, closeFails := range []bool{false, true} {
+			t.Run(stage+map[bool]string{false: "", true: "+cleanup"}[closeFails], func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				value := &scanValue{}
+				source := &configuredList{Array: runtime.NewArrayWith(value), backend: &listBackend{}, expected: ctx, calls: make(map[string]int), failures: make(map[string]error)}
+				want := primary
+				constructed := stage == "At" || stage == "Append" || stage == "cancel-New" || stage == "cancel-At" || stage == "cancel-Append"
+				if closeFails {
+					source.closeErr, source.newCleanupErr = cleanup, cleanup
+				}
+
+				if stage == "pre-cancel" {
+					cancel()
+					want = context.Canceled
+				} else if len(stage) > 7 && stage[:7] == "cancel-" {
+					want = context.Canceled
+					source.after = func(name string) {
+						if name == stage[7:] {
+							cancel()
+						}
+					}
+				} else {
+					source.failures[stage] = primary
+				}
+
+				out, err := collections.Reverse(ctx, source)
+				if out != runtime.None || !errors.Is(err, want) {
+					t.Fatalf("got %v, %v; want %v", out, err, want)
+				}
+
+				if closeFails && (constructed || stage == "New") && !errors.Is(err, cleanup) {
+					t.Fatalf("cleanup error lost: %v", err)
+				}
+
+				if constructed {
+					if source.created == nil || source.created.closes != 1 {
+						t.Fatal("incomplete destination not closed exactly once")
+					}
+				} else if source.created != nil {
+					t.Fatal("unexpected destination")
+				}
+
+				if source.closes != 0 || value.closes+value.clones+value.copies != 0 {
+					t.Fatal("borrowed source/element consumed")
+				}
+
+				if stage == "New" && source.newRollbacks != 1 {
+					t.Fatal("factory did not own failed construction")
+				}
+
+				if stage == "pre-cancel" && len(source.calls) != 0 {
+					t.Fatal("pre-canceled call performed host work")
+				}
+
+				if stage == "cancel-Length" && source.calls["New"] != 0 {
+					t.Fatal("constructed after cancellation")
+				}
+
+				if stage == "cancel-New" && source.calls["At"] != 0 {
+					t.Fatal("read after cancellation")
+				}
+
+				if stage == "cancel-At" && source.created.calls["Append"] != 0 {
+					t.Fatal("appended after cancellation")
+				}
+			})
+		}
+	}
+}

--- a/pkg/stdlib/collections/reverse_host_test.go
+++ b/pkg/stdlib/collections/reverse_host_test.go
@@ -1,0 +1,103 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	listBackend struct {
+		encoding string
+		limit    int
+	}
+
+	configuredList struct {
+		expected      context.Context
+		closeErr      error
+		newCleanupErr error
+		*runtime.Array
+		backend      *listBackend
+		length       *runtime.Int
+		created      *configuredList
+		failures     map[string]error
+		failAt       map[string]int
+		after        func(string)
+		calls        map[string]int
+		newRollbacks int
+		closes       int
+	}
+)
+
+var (
+	_ runtime.List                  = (*configuredList)(nil)
+	_ runtime.Factory[runtime.List] = (*configuredList)(nil)
+)
+
+func (l *configuredList) Length(ctx context.Context) (runtime.Int, error) {
+	if err := l.operation(ctx, "Length"); err != nil {
+		return 0, err
+	}
+
+	if l.length != nil {
+		return *l.length, nil
+	}
+
+	return l.Array.Length(ctx)
+}
+
+func (l *configuredList) New(ctx context.Context) (runtime.List, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := l.operation(ctx, "New"); err != nil {
+		l.newRollbacks++
+
+		return nil, errors.Join(err, l.newCleanupErr)
+	}
+
+	l.created = &configuredList{Array: runtime.NewArray(0), backend: l.backend, expected: l.expected, failures: l.failures, failAt: l.failAt, after: l.after, closeErr: l.closeErr, calls: make(map[string]int)}
+
+	return l.created, nil
+}
+
+func (l *configuredList) At(ctx context.Context, index runtime.Int) (runtime.Value, error) {
+	if err := l.operation(ctx, "At"); err != nil {
+		return runtime.None, err
+	}
+
+	return l.Array.At(ctx, index)
+}
+
+func (l *configuredList) Append(ctx context.Context, value runtime.Value) error {
+	if err := l.operation(ctx, "Append"); err != nil {
+		return err
+	}
+
+	return l.Array.Append(ctx, value)
+}
+
+func (l *configuredList) Close() error {
+	l.closes++
+
+	return l.closeErr
+}
+
+func (l *configuredList) operation(ctx context.Context, name string) error {
+	l.calls[name]++
+	if ctx != l.expected {
+		return errors.New("list context changed")
+	}
+
+	if l.after != nil {
+		l.after(name)
+	}
+
+	if l.calls[name] < l.failAt[name] {
+		return nil
+	}
+
+	return l.failures[name]
+}

--- a/pkg/stdlib/collections/scan_contract_test.go
+++ b/pkg/stdlib/collections/scan_contract_test.go
@@ -3,7 +3,9 @@ package collections_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -68,6 +70,42 @@ func TestCountMeasurementNeverTraverses(t *testing.T) {
 				t.Fatalf("unexpected host work: %+v", source)
 			}
 		})
+	}
+}
+
+func TestCountRejectsNegativeMeasurements(t *testing.T) {
+	for _, length := range []runtime.Int{-1, math.MinInt64, 0, 42} {
+		for _, cancelDuringLength := range []bool{false, true} {
+			t.Run(fmt.Sprintf("length=%d/cancel=%v", length, cancelDuringLength), func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				source := &measuredSource{scanSource: &scanSource{expected: ctx}, length: length}
+				if cancelDuringLength {
+					source.onLength = cancel
+				}
+
+				result, err := collections.Count(ctx, source)
+				if source.lengthCalls != 1 || source.iterations != 0 || source.closes != 0 || source.sourceCloses != 0 {
+					t.Fatal("measurement traversed or closed a borrowed source")
+				}
+
+				if errors.Is(err, runtime.ErrInvalidOperation) != (length < 0) || errors.Is(err, context.Canceled) != cancelDuringLength {
+					t.Fatalf("error identities lost: %v", err)
+				}
+
+				if length < 0 && !strings.Contains(err.Error(), "negative iterable length") {
+					t.Fatalf("wrong contract error: %v", err)
+				}
+
+				if length < 0 || cancelDuringLength {
+					if result != runtime.ZeroInt || err == nil {
+						t.Fatalf("invalid measurement succeeded: %v, %v", result, err)
+					}
+				} else if result != length || err != nil {
+					t.Fatalf("valid measurement failed: %v, %v", result, err)
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/stdlib/collections/scan_contract_test.go
+++ b/pkg/stdlib/collections/scan_contract_test.go
@@ -1,0 +1,279 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/collections"
+)
+
+func TestCountingIterableCapabilities(t *testing.T) {
+	for name, call := range map[string]func(context.Context, runtime.Value) (runtime.Value, error){
+		"count": collections.Count, "distinct": collections.CountDistinct,
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, source := range []runtime.Value{runtime.NewRange(1, 3), runtime.NewRange(3, 1), &scanSource{values: []runtime.Value{runtime.Int(1), runtime.Int(2), runtime.Int(3)}}} {
+				got, err := call(t.Context(), source)
+				if err != nil || got != runtime.Int(3) {
+					t.Fatalf("%T: got %v, %v", source, got, err)
+				}
+			}
+
+			for _, source := range []runtime.Value{runtime.String(""), runtime.String("abc"), runtime.Int(1), runtime.True, runtime.None, nil} {
+				got, err := call(t.Context(), source)
+				if got != runtime.ZeroInt || !errors.Is(err, runtime.ErrInvalidType) {
+					t.Fatalf("invalid %T: got %v, %v", source, got, err)
+				}
+			}
+		})
+	}
+
+	if _, err := collections.Count(t.Context(), runtime.NewRange(math.MinInt64, math.MaxInt64)); !errors.Is(err, runtime.ErrRange) {
+		t.Fatalf("range overflow: %v", err)
+	}
+}
+
+func TestCountMeasurementNeverTraverses(t *testing.T) {
+	failure := errors.New("length failed")
+	for _, stage := range []string{"success", "failure", "cancel", "pre-cancel"} {
+		t.Run(stage, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			source := &measuredSource{scanSource: &scanSource{expected: ctx}, length: 42}
+			var want error
+			switch stage {
+			case "failure":
+				source.lengthErr, want = failure, failure
+			case "cancel":
+				source.onLength, want = cancel, context.Canceled
+			case "pre-cancel":
+				cancel()
+				want = context.Canceled
+			}
+
+			got, err := collections.Count(ctx, source)
+			if !errors.Is(err, want) || (want == nil && got != runtime.Int(42)) || (want != nil && got != runtime.ZeroInt) {
+				t.Fatalf("got %v, %v; want error %v", got, err, want)
+			}
+
+			calls := 1
+			if stage == "pre-cancel" {
+				calls = 0
+			}
+
+			if source.lengthCalls != calls || source.iterations != 0 || source.closes != 0 || source.sourceCloses != 0 {
+				t.Fatalf("unexpected host work: %+v", source)
+			}
+		})
+	}
+}
+
+func TestOwnedScans(t *testing.T) {
+	primary, cleanup := errors.New("traversal"), errors.New("close")
+	for name, call := range map[string]func(context.Context, runtime.Value) (runtime.Value, error){
+		"count":    collections.Count,
+		"distinct": collections.CountDistinct,
+		"includes": func(ctx context.Context, source runtime.Value) (runtime.Value, error) {
+			return collections.Includes(ctx, source, runtime.Int(2))
+		},
+	} {
+		for _, stage := range []string{"empty", "success", "create", "next", "next+close", "close", "pre-cancel", "cancel", "cancel+close", "cancel-eof", "cancel-close"} {
+			t.Run(name+"/"+stage, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				source := &scanSource{values: []runtime.Value{runtime.Int(1), runtime.Int(2), runtime.Int(2)}, expected: ctx, failAt: 1}
+				wantCloses, wantIterations := 1, 1
+				var wantPrimary, wantClose error
+				switch stage {
+				case "empty":
+					source.values = nil
+				case "create":
+					source.iterateErr, wantPrimary, wantCloses = primary, primary, 0
+				case "next":
+					source.nextErr, wantPrimary = primary, primary
+				case "next+close":
+					source.nextErr, source.closeErr, wantPrimary, wantClose = primary, cleanup, primary, cleanup
+				case "close":
+					source.closeErr, wantClose = cleanup, cleanup
+				case "pre-cancel":
+					cancel()
+					wantPrimary, wantCloses, wantIterations = context.Canceled, 0, 0
+				case "cancel", "cancel+close":
+					source.onNext = func(index int) {
+						if index == 1 {
+							cancel()
+						}
+					}
+
+					wantPrimary = context.Canceled
+					if stage == "cancel+close" {
+						source.closeErr, wantClose = cleanup, cleanup
+					}
+				case "cancel-eof":
+					source.values = nil
+					source.onNext = func(int) { cancel() }
+					wantPrimary = context.Canceled
+				case "cancel-close":
+					source.onClose, source.closeErr, wantPrimary, wantClose = cancel, cleanup, context.Canceled, cleanup
+				}
+
+				got, err := call(ctx, source)
+				if (wantPrimary != nil && !errors.Is(err, wantPrimary)) || (wantClose != nil && !errors.Is(err, wantClose)) {
+					t.Fatalf("lost failure: %v; want %v, %v", err, wantPrimary, wantClose)
+				}
+
+				if wantPrimary == nil && wantClose == nil {
+					want := runtime.Value(runtime.Int(3))
+					if name == "distinct" {
+						want = runtime.Int(2)
+					}
+
+					if name == "includes" {
+						want = runtime.True
+					}
+
+					if stage == "empty" {
+						want = runtime.ZeroInt
+						if name == "includes" {
+							want = runtime.False
+						}
+					}
+
+					if err != nil || got != want {
+						t.Fatalf("got %v, %v; want %v", got, err, want)
+					}
+				} else if got != runtime.ZeroInt && got != runtime.False {
+					t.Fatalf("partial result: %v", got)
+				}
+
+				if source.closes != wantCloses || source.iterations != wantIterations || source.sourceCloses != 0 {
+					t.Fatalf("ownership: iterations %d, closes %d, source closes %d", source.iterations, source.closes, source.sourceCloses)
+				}
+
+				if (stage == "cancel" || stage == "cancel+close" || (name == "includes" && stage == "success")) && source.nexts != 2 {
+					t.Fatalf("did not stop promptly: %d next calls", source.nexts)
+				}
+			})
+		}
+	}
+}
+
+func TestIncludesDelegatesContains(t *testing.T) {
+	failure := errors.New("membership failed")
+	for _, stage := range []string{"success", "false", "failure", "cancel", "pre-cancel"} {
+		t.Run(stage, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			source := &containableSource{scanSource: &scanSource{expected: ctx}, contains: true}
+			var want error
+			switch stage {
+			case "false":
+				source.contains = false
+			case "failure":
+				source.containsErr, want = failure, failure
+			case "cancel":
+				source.onContains, want = cancel, context.Canceled
+			case "pre-cancel":
+				cancel()
+				want = context.Canceled
+			}
+
+			got, err := collections.Includes(ctx, source, runtime.Int(2))
+			if !errors.Is(err, want) || (want == nil && got != source.contains) {
+				t.Fatalf("got %v, %v", got, err)
+			}
+
+			calls := 1
+			if stage == "pre-cancel" {
+				calls = 0
+			}
+
+			if source.containsCalls != calls || source.iterations != 0 || source.sourceCloses != 0 || source.closes != 0 {
+				t.Fatalf("incorrect dispatch: %+v", source)
+			}
+		})
+	}
+}
+
+func TestScanEqualityAndBorrowedValues(t *testing.T) {
+	primary, cleanup := errors.New("equality"), errors.New("close")
+	for _, operation := range []string{"count", "distinct", "includes"} {
+		for _, stage := range []string{"success", "equality", "cancel-equality"} {
+			if operation == "count" && stage != "success" {
+				continue
+			}
+
+			t.Run(operation+"/"+stage, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				first, second := &scanValue{}, &scanValue{}
+				source := &scanSource{values: []runtime.Value{first, second}, expected: ctx}
+				var want error
+				if stage == "equality" {
+					first.equalErr, want, source.closeErr = primary, primary, cleanup
+				}
+
+				if stage == "cancel-equality" {
+					first.onEqual, want, source.closeErr = cancel, context.Canceled, cleanup
+				}
+
+				var got runtime.Value
+				var err error
+				switch operation {
+				case "count":
+					got, err = collections.Count(ctx, source)
+				case "distinct":
+					got, err = collections.CountDistinct(ctx, source)
+				case "includes":
+					got, err = collections.Includes(ctx, source, first)
+				}
+
+				if want == nil {
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if operation == "count" && got != runtime.Int(2) || operation == "distinct" && got != runtime.Int(1) || operation == "includes" && got != runtime.True {
+						t.Fatalf("got %v", got)
+					}
+				} else if !errors.Is(err, want) || !errors.Is(err, cleanup) {
+					t.Fatalf("lost errors: %v", err)
+				}
+
+				if source.closes != 1 || source.sourceCloses != 0 || first.closes+second.closes+first.copies+second.copies+first.clones+second.clones != 0 {
+					t.Fatal("borrowed values were owned or iterator leaked")
+				}
+			})
+		}
+	}
+}
+
+func TestMapValuesAndStringCoercion(t *testing.T) {
+	ctx := t.Context()
+	object := runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.Int(7), "other": runtime.Float(7)})
+	got, err := collections.CountDistinct(ctx, object)
+	if err != nil || got != runtime.Int(1) {
+		t.Fatalf("distinct map values: %v, %v", got, err)
+	}
+
+	for _, tc := range []struct{ source, needle, want runtime.Value }{
+		{object, runtime.String("key"), runtime.False}, {object, runtime.Int(7), runtime.True},
+		{runtime.String("123"), runtime.Int(123), runtime.True},
+	} {
+		got, err := collections.Includes(ctx, tc.source, tc.needle)
+		if err != nil || got != tc.want {
+			t.Fatalf("membership: %v, %v", got, err)
+		}
+	}
+}
+
+func TestIncludesClosesAfterNonemptyExhaustion(t *testing.T) {
+	source := &scanSource{values: []runtime.Value{runtime.Int(1), runtime.Int(2)}}
+	got, err := collections.Includes(t.Context(), source, runtime.Int(3))
+	if err != nil || got != runtime.False || source.iterations != 1 || source.nexts != 3 || source.closes != 1 || source.sourceCloses != 0 {
+		t.Fatalf("exhaustion: %v, %v, %+v", got, err, source)
+	}
+}

--- a/pkg/stdlib/collections/scan_fixture_test.go
+++ b/pkg/stdlib/collections/scan_fixture_test.go
@@ -15,6 +15,7 @@ type (
 		iterateErr   error
 		nextErr      error
 		closeErr     error
+		onIterate    func()
 		onNext       func(int)
 		onClose      func()
 		values       []runtime.Value
@@ -35,6 +36,10 @@ type (
 		*scanSource
 		onLength    func()
 		length      runtime.Int
+		lengthCalls int
+	}
+
+	measurableOnly struct {
 		lengthCalls int
 	}
 
@@ -63,6 +68,10 @@ func (s *scanSource) Iterate(ctx context.Context) (runtime.Iterator, error) {
 	s.iterations++
 	if s.expected != nil && ctx != s.expected {
 		return nil, errors.New("iterator context changed")
+	}
+
+	if s.onIterate != nil {
+		s.onIterate()
 	}
 
 	if s.iterateErr != nil {
@@ -124,6 +133,16 @@ func (s *measuredSource) Length(ctx context.Context) (runtime.Int, error) {
 	}
 
 	return s.length, s.lengthErr
+}
+
+func (s *measurableOnly) String() string      { return "measurable only" }
+func (s *measurableOnly) Hash() uint64        { return 1 }
+func (s *measurableOnly) Copy() runtime.Value { return s }
+
+func (s *measurableOnly) Length(context.Context) (runtime.Int, error) {
+	s.lengthCalls++
+
+	return 42, nil
 }
 
 func (s *containableSource) Contains(ctx context.Context, _ runtime.Value) (runtime.Boolean, error) {

--- a/pkg/stdlib/collections/scan_fixture_test.go
+++ b/pkg/stdlib/collections/scan_fixture_test.go
@@ -1,0 +1,169 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	// This source deliberately has no measurement, collection, or equality methods.
+	scanSource struct {
+		expected     context.Context
+		iterateErr   error
+		nextErr      error
+		closeErr     error
+		onNext       func(int)
+		onClose      func()
+		values       []runtime.Value
+		failAt       int
+		iterations   int
+		nexts        int
+		closes       int
+		sourceCloses int
+	}
+
+	scanIterator struct {
+		source *scanSource
+		index  int
+	}
+
+	measuredSource struct {
+		lengthErr error
+		*scanSource
+		onLength    func()
+		length      runtime.Int
+		lengthCalls int
+	}
+
+	containableSource struct {
+		containsErr error
+		*scanSource
+		onContains    func()
+		containsCalls int
+		contains      runtime.Boolean
+	}
+
+	scanValue struct {
+		equalErr error
+		onEqual  func()
+		closes   int
+		copies   int
+		clones   int
+	}
+)
+
+func (s *scanSource) String() string      { return "read-only stream" }
+func (s *scanSource) Hash() uint64        { return 1 }
+func (s *scanSource) Copy() runtime.Value { return s }
+
+func (s *scanSource) Iterate(ctx context.Context) (runtime.Iterator, error) {
+	s.iterations++
+	if s.expected != nil && ctx != s.expected {
+		return nil, errors.New("iterator context changed")
+	}
+
+	if s.iterateErr != nil {
+		return nil, s.iterateErr
+	}
+
+	return &scanIterator{source: s}, nil
+}
+
+func (s *scanSource) Close() error {
+	s.sourceCloses++
+
+	return nil
+}
+
+// Next intentionally ignores cancellation to exercise the caller's safepoints.
+func (i *scanIterator) Next(ctx context.Context) (runtime.Value, runtime.Value, error) {
+	s := i.source
+	s.nexts++
+	if s.expected != nil && ctx != s.expected {
+		return runtime.None, runtime.None, errors.New("next context changed")
+	}
+
+	if s.onNext != nil {
+		s.onNext(i.index)
+	}
+
+	if s.nextErr != nil && i.index == s.failAt {
+		return runtime.None, runtime.None, s.nextErr
+	}
+
+	if i.index == len(s.values) {
+		return runtime.None, runtime.None, io.EOF
+	}
+
+	value := s.values[i.index]
+	i.index++
+
+	return value, runtime.Int(i.index - 1), nil
+}
+
+func (i *scanIterator) Close() error {
+	i.source.closes++
+	if i.source.onClose != nil {
+		i.source.onClose()
+	}
+
+	return i.source.closeErr
+}
+
+func (s *measuredSource) Length(ctx context.Context) (runtime.Int, error) {
+	s.lengthCalls++
+	if s.expected != nil && ctx != s.expected {
+		return 0, errors.New("length context changed")
+	}
+
+	if s.onLength != nil {
+		s.onLength()
+	}
+
+	return s.length, s.lengthErr
+}
+
+func (s *containableSource) Contains(ctx context.Context, _ runtime.Value) (runtime.Boolean, error) {
+	s.containsCalls++
+	if s.expected != nil && ctx != s.expected {
+		return false, errors.New("contains context changed")
+	}
+
+	if s.onContains != nil {
+		s.onContains()
+	}
+
+	return s.contains, s.containsErr
+}
+
+func (v *scanValue) String() string { return "scan value" }
+func (v *scanValue) Hash() uint64   { return 7 }
+
+func (v *scanValue) Copy() runtime.Value {
+	v.copies++
+
+	return v
+}
+
+func (v *scanValue) Clone(context.Context) (runtime.Cloneable, error) {
+	v.clones++
+
+	return v, nil
+}
+
+func (v *scanValue) Close() error {
+	v.closes++
+
+	return nil
+}
+
+func (v *scanValue) Equal(context.Context, runtime.Value) (bool, error) {
+	if v.onEqual != nil {
+		v.onEqual()
+	}
+
+	return true, v.equalErr
+}

--- a/pkg/stdlib/math/percentile_host_test.go
+++ b/pkg/stdlib/math/percentile_host_test.go
@@ -36,3 +36,15 @@ func (value *percentileCopySortable) SortDesc(context.Context) error {
 
 	return nil
 }
+
+func (list *percentileCopyList) New(ctx context.Context) (runtime.List, error) {
+	base, err := list.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *list
+	result.List = base
+
+	return &result, nil
+}

--- a/pkg/stdlib/objects/factory_contract_test.go
+++ b/pkg/stdlib/objects/factory_contract_test.go
@@ -64,6 +64,18 @@ func TestImmutableMergeUsesFirstMapFactory(t *testing.T) {
 				t.Fatal("merge changed source value")
 			}
 
+			if destination.closes != 0 || first.closes != 0 || second.closes != 0 {
+				t.Fatal("successful merge closed a result or borrowed source")
+			}
+
+			if err := destination.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := empty.(*configuredMap).Close(); err != nil {
+				t.Fatal(err)
+			}
+
 			primary, cleanup := errors.New("factory failed"), errors.New("factory rollback failed")
 			first.newErr = errors.Join(primary, cleanup)
 			result, err = merge(ctx, first)

--- a/pkg/stdlib/objects/factory_contract_test.go
+++ b/pkg/stdlib/objects/factory_contract_test.go
@@ -1,0 +1,90 @@
+package objects_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
+)
+
+func TestImmutableMergeUsesFirstMapFactory(t *testing.T) {
+	for name, merge := range map[string]func(context.Context, ...runtime.Value) (runtime.Value, error){"shallow": objects.Merge, "deep": objects.MergeDeep} {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			nested := runtime.NewArrayWith(runtime.Int(1))
+			first := &configuredMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"nested": nested, "a": runtime.Int(1)}), backend: "remote/utf8/limit=100"}
+			second := &configuredMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"a": runtime.Int(2)}), backend: "different"}
+			empty, err := first.New(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if size, err := empty.Length(ctx); err != nil || size != 0 {
+				t.Fatal("factory copied elements")
+			}
+
+			if empty.(*configuredMap).backend != first.backend {
+				t.Fatal("factory lost configuration")
+			}
+
+			if err := empty.Set(ctx, runtime.String("a"), runtime.Int(9)); err != nil {
+				t.Fatal(err)
+			}
+
+			if value, err := first.Get(ctx, runtime.String("a")); err != nil || value != runtime.Int(1) {
+				t.Fatal("factory aliases source")
+			}
+
+			result, err := merge(ctx, first, second)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			destination, ok := result.(*configuredMap)
+			if !ok || destination == first || destination.backend != first.backend || first.creations != 2 || second.creations != 0 {
+				t.Fatalf("wrong destination: %T", result)
+			}
+
+			if value, err := destination.Get(ctx, runtime.String("a")); err != nil || value != runtime.Int(2) {
+				t.Fatal("merge precedence changed")
+			}
+
+			value, err := destination.Get(ctx, runtime.String("nested"))
+			if err != nil || value == nested {
+				t.Fatal("merge did not clone incoming list")
+			}
+
+			if err := value.(runtime.List).Append(ctx, runtime.Int(3)); err != nil {
+				t.Fatal(err)
+			}
+
+			if size, err := nested.Length(ctx); err != nil || size != 1 {
+				t.Fatal("merge changed source value")
+			}
+
+			primary, cleanup := errors.New("factory failed"), errors.New("factory rollback failed")
+			first.newErr = errors.Join(primary, cleanup)
+			result, err = merge(ctx, first)
+			if result != runtime.None || !errors.Is(err, primary) || !errors.Is(err, cleanup) {
+				t.Fatalf("factory errors lost: %v, %v", result, err)
+			}
+
+			canceled, cancel := context.WithCancel(ctx)
+			cancel()
+			before := first.creations
+			if result, err := first.New(canceled); result != nil || !errors.Is(err, context.Canceled) {
+				t.Fatalf("factory cancellation: %v, %v", result, err)
+			}
+
+			if result, err := merge(canceled, first); result != runtime.None || !errors.Is(err, context.Canceled) {
+				t.Fatalf("merge cancellation: %v, %v", result, err)
+			}
+
+			if before != first.creations {
+				t.Fatal("pre-canceled construction performed host work")
+			}
+		})
+	}
+}

--- a/pkg/stdlib/objects/factory_host_test.go
+++ b/pkg/stdlib/objects/factory_host_test.go
@@ -2,15 +2,23 @@ package objects_test
 
 import (
 	"context"
+	"errors"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 type configuredMap struct {
-	newErr error
+	newErr   error
+	closeErr error
 	*runtime.Object
+	created   *configuredMap
+	onNew     func(*configuredMap)
+	onSet     func(context.Context, runtime.Value, runtime.Value) error
+	onLookup  func(context.Context, runtime.Value) (runtime.Value, bool, error)
+	onForEach func(context.Context, runtime.KeyReadablePredicate) error
 	backend   string
 	creations int
+	closes    int
 }
 
 var (
@@ -24,9 +32,44 @@ func (m *configuredMap) New(ctx context.Context) (runtime.Map, error) {
 	}
 
 	m.creations++
-	if m.newErr != nil {
-		return nil, m.newErr
+	m.created = &configuredMap{Object: runtime.NewObject(), backend: m.backend}
+	if m.onNew != nil {
+		m.onNew(m.created)
 	}
 
-	return &configuredMap{Object: runtime.NewObject(), backend: m.backend}, nil
+	if m.newErr != nil {
+		return nil, errors.Join(m.newErr, m.created.Close())
+	}
+
+	return m.created, nil
+}
+
+func (m *configuredMap) Set(ctx context.Context, key, value runtime.Value) error {
+	if m.onSet != nil {
+		return m.onSet(ctx, key, value)
+	}
+
+	return m.Object.Set(ctx, key, value)
+}
+
+func (m *configuredMap) Lookup(ctx context.Context, key runtime.Value) (runtime.Value, bool, error) {
+	if m.onLookup != nil {
+		return m.onLookup(ctx, key)
+	}
+
+	return m.Object.Lookup(ctx, key)
+}
+
+func (m *configuredMap) ForEach(ctx context.Context, predicate runtime.KeyReadablePredicate) error {
+	if m.onForEach != nil {
+		return m.onForEach(ctx, predicate)
+	}
+
+	return m.Object.ForEach(ctx, predicate)
+}
+
+func (m *configuredMap) Close() error {
+	m.closes++
+
+	return m.closeErr
 }

--- a/pkg/stdlib/objects/factory_host_test.go
+++ b/pkg/stdlib/objects/factory_host_test.go
@@ -1,0 +1,32 @@
+package objects_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type configuredMap struct {
+	newErr error
+	*runtime.Object
+	backend   string
+	creations int
+}
+
+var (
+	_ runtime.Map                  = (*configuredMap)(nil)
+	_ runtime.Factory[runtime.Map] = (*configuredMap)(nil)
+)
+
+func (m *configuredMap) New(ctx context.Context) (runtime.Map, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	m.creations++
+	if m.newErr != nil {
+		return nil, m.newErr
+	}
+
+	return &configuredMap{Object: runtime.NewObject(), backend: m.backend}, nil
+}

--- a/pkg/stdlib/objects/host_values_test.go
+++ b/pkg/stdlib/objects/host_values_test.go
@@ -12,14 +12,14 @@ type (
 		runtime.Map
 		keys        runtime.List
 		values      runtime.List
-		empty       runtime.Map
+		created     runtime.Map
 		cloned      runtime.Cloneable
 		keysErr     error
 		valuesErr   error
 		lookupErr   error
 		containsErr error
 		walkErr     error
-		emptyErr    error
+		newErr      error
 		cloneErr    error
 		setErr      error
 		removeErr   error
@@ -129,16 +129,27 @@ func (m *hostMap) ForEach(ctx context.Context, fn runtime.KeyReadablePredicate) 
 	return m.Map.ForEach(ctx, fn)
 }
 
-func (m *hostMap) Empty(ctx context.Context) (runtime.Map, error) {
-	if m.emptyErr != nil {
-		return nil, m.emptyErr
+func (m *hostMap) New(ctx context.Context) (runtime.Map, error) {
+	if m.newErr != nil {
+		return nil, m.newErr
 	}
 
-	if m.empty != nil {
-		return m.empty, nil
+	if m.created != nil {
+		return m.created, nil
 	}
 
-	return m.Map.Empty(ctx)
+	base, err := m.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *m
+	result.Map = base
+	result.keys = nil
+	result.values = nil
+	result.walk = nil
+
+	return &result, nil
 }
 
 func (m *hostMap) Clone(ctx context.Context) (runtime.Cloneable, error) {
@@ -284,4 +295,16 @@ func (m *hostMap) Equal(ctx context.Context, value runtime.Value) (bool, error) 
 	}
 
 	return m.Map.Equal(ctx, value)
+}
+
+func (l *hostList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.List = base
+
+	return &result, nil
 }

--- a/pkg/stdlib/objects/merge.go
+++ b/pkg/stdlib/objects/merge.go
@@ -37,7 +37,7 @@ func mergeObjects(ctx context.Context, args []runtime.Value, mergeInto func(cont
 		return runtime.NewObject(), nil
 	}
 
-	dst, err := sources[0].Empty(ctx)
+	dst, err := sources[0].New(ctx)
 	if err != nil {
 		return runtime.None, mergeArgumentError(err, 0, listForm, 0)
 	}

--- a/pkg/stdlib/objects/merge.go
+++ b/pkg/stdlib/objects/merge.go
@@ -2,11 +2,16 @@ package objects
 
 import (
 	"context"
+	"errors"
+	"io"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
 )
 
 // Merge copies maps into an independent destination; later values replace earlier values.
+// Successful factory construction transfers destination ownership to this call.
+// Population failure closes a closable destination and joins cleanup errors;
+// success transfers the result to the caller. Source maps remain borrowed.
 // @param values {Map|Map[], repeated} Variadic maps, or one list of maps.
 // @return {Map} Shallow merge with cloned or copied values.
 func Merge(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {
@@ -23,13 +28,17 @@ func MergeMutable(ctx context.Context, args ...runtime.Value) (runtime.Value, er
 	return mergeMutableObjects(ctx, args, runtime.MergeMapsInto)
 }
 
-func mergeObjects(ctx context.Context, args []runtime.Value, mergeInto func(context.Context, runtime.Map, ...runtime.Map) error) (runtime.Value, error) {
+func mergeObjects(ctx context.Context, args []runtime.Value, mergeInto func(context.Context, runtime.Map, ...runtime.Map) error) (_ runtime.Value, err error) {
 	if err := runtime.ValidateArgs(args, 1, runtime.MaxArgs); err != nil {
 		return runtime.None, err
 	}
 
 	sources, listForm, err := normalizeMergeArgs(ctx, args, 0)
 	if err != nil {
+		return runtime.None, err
+	}
+
+	if err := ctx.Err(); err != nil {
 		return runtime.None, err
 	}
 
@@ -42,8 +51,27 @@ func mergeObjects(ctx context.Context, args []runtime.Value, mergeInto func(cont
 		return runtime.None, mergeArgumentError(err, 0, listForm, 0)
 	}
 
+	defer func() {
+		if err != nil {
+			if closer, ok := dst.(io.Closer); ok {
+				if closeErr := closer.Close(); closeErr != nil {
+					err = errors.Join(err, closeErr)
+				}
+			}
+		}
+	}()
+
+	if err := ctx.Err(); err != nil {
+		return runtime.None, mergeArgumentError(err, 0, listForm, 0)
+	}
+
 	for index, src := range sources {
-		if err := mergeInto(ctx, dst, src); err != nil {
+		err := mergeInto(ctx, dst, src)
+		if canceled := ctx.Err(); canceled != nil && !errors.Is(err, canceled) {
+			err = errors.Join(err, canceled)
+		}
+
+		if err != nil {
 			return runtime.None, mergeArgumentError(err, index, listForm, 0)
 		}
 	}

--- a/pkg/stdlib/objects/merge_deep.go
+++ b/pkg/stdlib/objects/merge_deep.go
@@ -8,6 +8,9 @@ import (
 
 // MergeDeep copies maps into an independent destination, merging nested maps recursively.
 // Arrays, scalars, and none are replaced by later values.
+// After successful factory construction, population failure closes a closable
+// destination and joins cleanup errors. Successful results transfer to the caller;
+// source maps remain borrowed. Failed construction is the factory's responsibility.
 // @param values {Map|Map[], repeated} Variadic maps, or one list of maps.
 // @return {Map} Deep merge with cloned or copied values.
 func MergeDeep(ctx context.Context, args ...runtime.Value) (runtime.Value, error) {

--- a/pkg/stdlib/objects/merge_ownership_benchmark_test.go
+++ b/pkg/stdlib/objects/merge_ownership_benchmark_test.go
@@ -1,0 +1,42 @@
+package objects_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
+)
+
+func BenchmarkConfiguredMapMerge(b *testing.B) {
+	ctx := context.Background()
+	for _, size := range []int{0, 1, 16, 1024} {
+		for name, merge := range map[string]runtime.Function{"shallow": objects.Merge, "deep": objects.MergeDeep} {
+			b.Run(fmt.Sprintf("%s/size=%d", name, size), func(b *testing.B) {
+				values := make(map[string]runtime.Value, size)
+				for i := range size {
+					values[fmt.Sprint(i)] = runtime.Int(i)
+				}
+
+				if size > 0 {
+					values["0"] = runtime.NewObjectWith(map[string]runtime.Value{"value": runtime.Int(1)})
+				}
+
+				left := &configuredMap{Object: runtime.NewObjectWith(values), backend: "configured"}
+				right := &configuredMap{Object: runtime.NewObjectWith(values), backend: "other"}
+				b.ReportAllocs()
+				for b.Loop() {
+					result, err := merge(ctx, left, right)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					if err := result.(*configuredMap).Close(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/pkg/stdlib/objects/merge_ownership_test.go
+++ b/pkg/stdlib/objects/merge_ownership_test.go
@@ -1,0 +1,211 @@
+package objects_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/stdlib/objects"
+)
+
+func TestImmutableMergeDestinationOwnership(t *testing.T) {
+	for name, merge := range map[string]runtime.Function{"shallow": objects.Merge, "deep": objects.MergeDeep} {
+		for _, listForm := range []bool{false, true} {
+			for _, cleanupFails := range []bool{false, true} {
+				for _, stage := range []string{"success", "set", "traversal", "clone", "lookup", "nested", "factory", "pre-cancel", "new-cancel", "set-cancel", "traversal-cancel", "failure-cancel"} {
+					if (stage == "lookup" || stage == "nested") && name != "deep" {
+						continue
+					}
+
+					t.Run(fmt.Sprintf("%s/list=%v/cleanup=%v/%s", name, listForm, cleanupFails, stage), func(t *testing.T) {
+						ctx, cancel := context.WithCancel(t.Context())
+						defer cancel()
+						primary, cleanup := errors.New("population failed"), errors.New("destination close failed")
+						first := &configuredMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"existing": runtime.Int(1)}), backend: "configured storage"}
+						second := &configuredMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.Int(2)}), backend: "other storage"}
+						first.onNew = func(dst *configuredMap) {
+							if cleanupFails {
+								dst.closeErr = cleanup
+							}
+
+							if stage == "new-cancel" {
+								cancel()
+							}
+
+							if stage == "lookup" || stage == "nested" {
+								dst.onLookup = func(c context.Context, _ runtime.Value) (runtime.Value, bool, error) {
+									if c != ctx {
+										t.Fatal("lookup context changed")
+									}
+
+									if stage == "lookup" {
+										return runtime.None, false, primary
+									}
+
+									return &hostMap{Map: runtime.NewObject(), setErr: primary}, true, nil
+								}
+							}
+
+							dst.onSet = func(c context.Context, key, value runtime.Value) error {
+								if c != ctx {
+									t.Fatal("mutation context changed")
+								}
+
+								if key == runtime.String("key") {
+									if stage == "set" || stage == "failure-cancel" {
+										if stage == "failure-cancel" {
+											cancel()
+										}
+
+										return primary
+									}
+								}
+
+								err := dst.Object.Set(c, key, value)
+								if key == runtime.String("key") && stage == "set-cancel" {
+									cancel()
+								}
+
+								return err
+							}
+						}
+
+						switch stage {
+						case "factory":
+							first.newErr = primary
+						case "pre-cancel":
+							cancel()
+						case "clone":
+							second.Object = runtime.NewObjectWith(map[string]runtime.Value{"key": &cloneValue{Value: runtime.Int(2), clones: new(int), cloneErr: primary}})
+						case "lookup", "nested":
+							second.Object = runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.NewObjectWith(map[string]runtime.Value{"nested": runtime.Int(2)})})
+						case "traversal", "traversal-cancel":
+							second.onForEach = func(c context.Context, predicate runtime.KeyReadablePredicate) error {
+								if err := second.Object.ForEach(c, predicate); err != nil {
+									return err
+								}
+
+								if stage == "traversal-cancel" {
+									cancel()
+
+									return nil
+								}
+
+								return primary
+							}
+						}
+
+						before := second.String()
+						args := []runtime.Value{first, second}
+						if listForm {
+							args = []runtime.Value{runtime.NewArrayWith(args...)}
+						}
+
+						result, err := merge(ctx, args...)
+						if first.closes != 0 || second.closes != 0 || second.creations != 0 || first.String() != `{"existing":1}` || second.String() != before {
+							t.Fatal("borrowed sources changed or closed")
+						}
+
+						if stage == "pre-cancel" {
+							if result != runtime.None || !errors.Is(err, context.Canceled) || first.created != nil {
+								t.Fatalf("pre-cancel: %v, %v", result, err)
+							}
+
+							return
+						}
+
+						dst := first.created
+						if dst == nil || first.creations != 1 || dst.backend != first.backend {
+							t.Fatal("factory result or configuration lost")
+						}
+
+						if stage == "new-cancel" && dst.String() != "{}" {
+							t.Fatal("population continued after construction canceled")
+						}
+
+						if stage == "success" {
+							if err != nil || result != dst || dst.closes != 0 {
+								t.Fatalf("successful ownership transfer: %v, %v, closes=%d", result, err, dst.closes)
+							}
+
+							assertObjectValue(t, dst, runtime.NewObjectWith(map[string]runtime.Value{"existing": runtime.Int(1), "key": runtime.Int(2)}))
+
+							closeErr := dst.Close()
+							if dst.closes != 1 || errors.Is(closeErr, cleanup) != cleanupFails {
+								t.Fatal("caller cleanup changed")
+							}
+
+							return
+						}
+
+						wantPrimary := !strings.HasSuffix(stage, "-cancel") || stage == "failure-cancel"
+						wantCancel := strings.HasSuffix(stage, "-cancel")
+						if result != runtime.None || err == nil || dst.closes != 1 || errors.Is(err, primary) != wantPrimary || errors.Is(err, context.Canceled) != wantCancel || errors.Is(err, cleanup) != cleanupFails {
+							t.Fatalf("failure ownership: %v, %v, closes=%d", result, err, dst.closes)
+						}
+
+						index := 1
+						if stage == "factory" || stage == "new-cancel" {
+							index = 0
+						}
+
+						attribution := fmt.Sprintf("position %d", index+1)
+						if listForm {
+							attribution = fmt.Sprintf("item %d", index)
+							if !strings.Contains(err.Error(), "position 1") {
+								t.Fatal("list argument attribution lost")
+							}
+						}
+
+						if !strings.Contains(err.Error(), attribution) {
+							t.Fatalf("source attribution lost: %v", err)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestMutableMergeBorrowsClosableTarget(t *testing.T) {
+	for name, merge := range map[string]runtime.Function{"shallow": objects.MergeMutable, "deep": objects.MergeDeepMutable} {
+		for _, stage := range []string{"success", "failure", "cancel"} {
+			t.Run(name+"/"+stage, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				primary := errors.New("mutation failed")
+				if stage == "cancel" {
+					primary = context.Canceled
+				}
+
+				target := &configuredMap{Object: runtime.NewObject()}
+				source := &configuredMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.Int(1)})}
+				if stage != "success" {
+					target.onSet = func(ctx context.Context, key, value runtime.Value) error {
+						if err := target.Object.Set(ctx, key, value); err != nil {
+							return err
+						}
+
+						if stage == "cancel" {
+							cancel()
+						}
+
+						return primary
+					}
+				}
+
+				result, err := merge(ctx, target, source)
+				if target.closes != 0 || source.closes != 0 || target.creations != 0 || source.creations != 0 || target.String() != `{"key":1}` {
+					t.Fatal("borrowed target ownership or partial mutation changed")
+				}
+
+				if stage != "success" && (result != runtime.None || !errors.Is(err, primary)) || stage == "success" && (result != target || err != nil) {
+					t.Fatalf("result=%v, err=%v", result, err)
+				}
+			})
+		}
+	}
+}

--- a/pkg/stdlib/objects/mutable_contract_test.go
+++ b/pkg/stdlib/objects/mutable_contract_test.go
@@ -103,7 +103,7 @@ func TestMutableMergesNoSourceDoesNotCopyOrWrite(t *testing.T) {
 			unexpected := errors.New("unexpected copy or mutation")
 			nested := runtime.NewObjectWith(map[string]runtime.Value{"a": runtime.Int(1)})
 			target := &hostMap{Map: runtime.NewObjectWith(map[string]runtime.Value{"nested": nested}),
-				cloneErr: unexpected, emptyErr: unexpected, setErr: unexpected, setCalls: &writes}
+				cloneErr: unexpected, newErr: unexpected, setErr: unexpected, setCalls: &writes}
 			args := []runtime.Value{target}
 			switch form {
 			case "empty list":
@@ -130,7 +130,7 @@ func TestMutableShallowOperationsRetainExistingValues(t *testing.T) {
 	for name, apply := range map[string]runtime.Function{"merge": objects.MergeMutable, "keep": objects.KeepKeysMutable, "omit": objects.OmitKeysMutable} {
 		nested := runtime.NewObject()
 		target := &hostMap{Map: runtime.NewObjectWith(map[string]runtime.Value{"nested": nested, "remove": runtime.True}),
-			cloneErr: errors.New("target must not be cloned"), emptyErr: errors.New("target must not be replaced")}
+			cloneErr: errors.New("target must not be cloned"), newErr: errors.New("target must not be replaced")}
 		var argument runtime.Value = runtime.String("remove")
 		if name == "merge" {
 			argument = runtime.NewObjectWith(map[string]runtime.Value{"added": runtime.True})

--- a/pkg/stdlib/objects/transform_contract_test.go
+++ b/pkg/stdlib/objects/transform_contract_test.go
@@ -249,7 +249,7 @@ func TestObjectHostErrors(t *testing.T) {
 			return objects.Zip(ctx, keys, &hostList{List: vals, accessErr: sentinel})
 		}, "position 2"},
 		{"zip clone", func() (runtime.Value, error) { return objects.Zip(ctx, keys, runtime.NewArrayWith(badValue)) }, "position 2"},
-		{"merge empty", func() (runtime.Value, error) { return objects.Merge(ctx, &hostMap{Map: basic, emptyErr: sentinel}) }, "position 1"},
+		{"merge construction", func() (runtime.Value, error) { return objects.Merge(ctx, &hostMap{Map: basic, newErr: sentinel}) }, "position 1"},
 		{"merge source", func() (runtime.Value, error) {
 			return objects.Merge(ctx, basic, &hostMap{Map: basic, walkErr: sentinel})
 		}, "position 2"},
@@ -257,10 +257,10 @@ func TestObjectHostErrors(t *testing.T) {
 			return objects.MergeDeep(ctx, runtime.NewArrayWith(basic, &hostMap{Map: basic, walkErr: sentinel}))
 		}, "position 1"},
 		{"merge destination", func() (runtime.Value, error) {
-			return objects.Merge(ctx, &hostMap{Map: basic, empty: &hostMap{Map: runtime.NewObject(), setErr: sentinel}})
+			return objects.Merge(ctx, &hostMap{Map: basic, created: &hostMap{Map: runtime.NewObject(), setErr: sentinel}})
 		}, "position 1"},
 		{"deep lookup", func() (runtime.Value, error) {
-			return objects.MergeDeep(ctx, &hostMap{Map: runtime.NewObjectWith(map[string]runtime.Value{"a": basic}), empty: &hostMap{Map: runtime.NewObject(), lookupErr: sentinel}})
+			return objects.MergeDeep(ctx, &hostMap{Map: runtime.NewObjectWith(map[string]runtime.Value{"a": basic}), created: &hostMap{Map: runtime.NewObject(), lookupErr: sentinel}})
 		}, "position 1"},
 		{"merge list", func() (runtime.Value, error) {
 			return objects.MergeDeep(ctx, &hostList{List: runtime.NewArrayWith(basic), walkErr: sentinel})

--- a/pkg/stdlib/strings/join_list_test.go
+++ b/pkg/stdlib/strings/join_list_test.go
@@ -27,3 +27,15 @@ func (l *joinTestList) ForEach(ctx context.Context, fn runtime.IndexReadablePred
 
 	return l.failure
 }
+
+func (l *joinTestList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.List = base
+
+	return &result, nil
+}

--- a/pkg/stdlib/testing/collection_fixture_test.go
+++ b/pkg/stdlib/testing/collection_fixture_test.go
@@ -16,3 +16,15 @@ func (m *countingMap) ContainsKey(ctx context.Context, key runtime.Value) (runti
 
 	return m.Object.ContainsKey(ctx, key)
 }
+
+func (m *countingMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := m.Object.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *m
+	result.Object = base.(*runtime.Object)
+
+	return &result, nil
+}

--- a/pkg/stdlib/testing/equality_fixture_test.go
+++ b/pkg/stdlib/testing/equality_fixture_test.go
@@ -100,3 +100,53 @@ func (v *diagnosticEqualityProbe) Equal(context.Context, runtime.Value) (bool, e
 
 	return false, v.err
 }
+
+func (s *snapshotList) New(ctx context.Context) (runtime.List, error) {
+	base, err := s.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *s
+	result.List = base
+	result.snapshot = base.(*runtime.Array)
+
+	return &result, nil
+}
+
+func (s *snapshotMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := s.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *s
+	result.Map = base
+	result.snapshot = base.(*runtime.Object)
+
+	return &result, nil
+}
+
+func (l *unsafeList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.List = base
+
+	return &result, nil
+}
+
+func (m *unsafeMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := m.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *m
+	result.Map = base
+
+	return &result, nil
+}

--- a/pkg/vm/internal/data/dataset.go
+++ b/pkg/vm/internal/data/dataset.go
@@ -149,8 +149,12 @@ func (ds *DataSet) SortDesc(ctx context.Context) error {
 	return ds.values.SortDesc(ctx)
 }
 
-func (ds *DataSet) Empty(_ context.Context) (runtime.List, error) {
-	// TODO: Or should we return an underlying list instead?
+// New creates an independent empty collection with the receiver's configuration.
+func (ds *DataSet) New(ctx context.Context) (runtime.List, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return NewDataSet(ds.uniqueness != nil), nil
 }
 

--- a/pkg/vm/internal/data/factory_test.go
+++ b/pkg/vm/internal/data/factory_test.go
@@ -1,0 +1,99 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+var (
+	_ runtime.Factory[runtime.List] = (*DataSet)(nil)
+	_ runtime.Factory[runtime.Map]  = (*FastObject)(nil)
+)
+
+func TestDataSetNewPreservesIndependentDistinctPolicy(t *testing.T) {
+	for _, distinct := range []bool{false, true} {
+		source := NewDataSet(distinct)
+		if err := source.Append(t.Context(), runtime.Int(1)); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := source.New(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		destination, ok := result.(*DataSet)
+		if !ok || destination == source || (destination.uniqueness != nil) != distinct {
+			t.Fatal("DataSet policy/family changed")
+		}
+
+		if size, err := result.Length(t.Context()); size != 0 || err != nil {
+			t.Fatal("new dataset is not empty")
+		}
+
+		for range 2 {
+			if err := result.Append(t.Context(), runtime.Int(1)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		want := runtime.Int(2)
+		if distinct {
+			want = 1
+		}
+
+		if size, err := result.Length(t.Context()); size != want || err != nil {
+			t.Fatalf("distinct state shared or policy lost: %d, %v", size, err)
+		}
+
+		if size, err := source.Length(t.Context()); size != 1 || err != nil {
+			t.Fatal("source changed")
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		if result, err := source.New(ctx); result != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancellation: %v, %v", result, err)
+		}
+	}
+}
+
+func TestFastObjectNewPreservesConfiguration(t *testing.T) {
+	for _, threshold := range []int{0, 1, 10} {
+		source := NewFastObject(NewShapeCache(8), threshold)
+		if err := source.Set(t.Context(), runtime.String("a"), runtime.Int(7)); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := source.New(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		destination, ok := result.(*FastObject)
+		if !ok || destination == source || destination.cache != source.cache || destination.dictThreshold != threshold {
+			t.Fatal("configuration/family changed")
+		}
+
+		if size, err := result.Length(t.Context()); size != 0 || err != nil {
+			t.Fatal("new map is not empty")
+		}
+
+		if err := result.Set(t.Context(), runtime.String("a"), runtime.Int(9)); err != nil {
+			t.Fatal(err)
+		}
+
+		if value, err := source.Get(t.Context(), runtime.String("a")); value != runtime.Int(7) || err != nil {
+			t.Fatal("source changed")
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		if result, err := source.New(ctx); result != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancellation: %v, %v", result, err)
+		}
+	}
+}

--- a/pkg/vm/internal/data/failing_at_list_test.go
+++ b/pkg/vm/internal/data/failing_at_list_test.go
@@ -14,3 +14,15 @@ type failingAtList struct {
 func (l *failingAtList) At(context.Context, runtime.Int) (runtime.Value, error) {
 	return runtime.None, l.err
 }
+
+func (l *failingAtList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.List = base
+
+	return &result, nil
+}

--- a/pkg/vm/internal/data/fast_object_runtime.go
+++ b/pkg/vm/internal/data/fast_object_runtime.go
@@ -402,7 +402,12 @@ func (t *FastObject) Iterate(_ context.Context) (runtime.Iterator, error) {
 	return &fastObjectIterator{entries: entries, slots: t.slots}, nil
 }
 
-func (t *FastObject) Empty(_ context.Context) (runtime.Map, error) {
+// New creates an independent empty collection with the receiver's configuration.
+func (t *FastObject) New(ctx context.Context) (runtime.Map, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return NewFastObject(t.cache, t.dictThreshold), nil
 }
 

--- a/pkg/vm/internal/diagnostics/runtime_error.go
+++ b/pkg/vm/internal/diagnostics/runtime_error.go
@@ -281,6 +281,11 @@ func ToRuntimeError(program *bytecode.Program, pc int, callStack []frame.TraceEn
 		spec.Cause = cause
 	}
 
+	if _, joined := err.(interface{ Unwrap() []error }); hasArg && joined {
+		// Retain cleanup siblings without changing ordinary diagnostics' normalized causes.
+		spec.Cause = err
+	}
+
 	return newRuntimeErrorWithSpec(program, callStack, spec)
 }
 

--- a/pkg/vm/internal/diagnostics/runtime_error_tree_test.go
+++ b/pkg/vm/internal/diagnostics/runtime_error_tree_test.go
@@ -1,11 +1,13 @@
 package diagnostics
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/diagnostics"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
@@ -31,6 +33,30 @@ func TestRuntimeAggregateUnwrapPreservesEveryCause(t *testing.T) {
 
 	if !errors.Is(set, first) {
 		t.Fatal("unwrap granted mutation of the aggregate")
+	}
+}
+
+func TestArgumentDiagnosticPreservesJoinedCleanup(t *testing.T) {
+	cleanup := errors.New("destination cleanup failed")
+	for _, primary := range []error{errors.New("host failed"), runtime.ErrInvalidType, context.Canceled} {
+		for _, listForm := range []bool{false, true} {
+			cause := primary
+			if listForm {
+				cause = fmt.Errorf("item 1: %w", cause)
+			}
+
+			attributed := runtime.ArgError(cause, 0)
+			before := ToRuntimeError(nil, 0, nil, attributed)
+			joined := errors.Join(attributed, cleanup)
+			result := ToRuntimeError(nil, 0, nil, joined)
+			if !errors.Is(result, primary) || !errors.Is(result, cleanup) || !errors.Is(result, attributed) {
+				t.Fatalf("argument diagnostic lost causes: %v", result)
+			}
+
+			if result.Message != before.Message || result.Note != before.Note || result.Kind != before.Kind {
+				t.Fatal("cleanup changed argument diagnostic presentation")
+			}
+		}
 	}
 }
 

--- a/test/benchmarks/spread_benchmark_list_test.go
+++ b/test/benchmarks/spread_benchmark_list_test.go
@@ -14,3 +14,16 @@ type benchmarkSnapshotList struct {
 func (b *benchmarkSnapshotList) Snapshot(context.Context) (*runtime.Array, error) {
 	return b.snapshot, nil
 }
+
+func (b *benchmarkSnapshotList) New(ctx context.Context) (runtime.List, error) {
+	base, err := b.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *b
+	result.List = base
+	result.snapshot = base.(*runtime.Array)
+
+	return &result, nil
+}

--- a/test/benchmarks/spread_benchmark_map_test.go
+++ b/test/benchmarks/spread_benchmark_map_test.go
@@ -1,7 +1,23 @@
 package benchmarks_test
 
-import "github.com/MontFerret/ferret/v2/pkg/runtime"
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
 
 type benchmarkMap struct {
 	runtime.Map
+}
+
+func (source benchmarkMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := source.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := source
+	result.Map = base
+
+	return result, nil
 }

--- a/test/benchmarks/spread_benchmark_snapshot_object_test.go
+++ b/test/benchmarks/spread_benchmark_snapshot_object_test.go
@@ -14,3 +14,16 @@ type benchmarkSnapshotObject struct {
 func (b *benchmarkSnapshotObject) Snapshot(context.Context) (*runtime.Object, error) {
 	return b.snapshot, nil
 }
+
+func (b *benchmarkSnapshotObject) New(ctx context.Context) (runtime.Map, error) {
+	base, err := b.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *b
+	result.Map = base
+	result.snapshot = base.(*runtime.Object)
+
+	return &result, nil
+}

--- a/test/integration/vm/array_copy_host_test.go
+++ b/test/integration/vm/array_copy_host_test.go
@@ -1,6 +1,10 @@
 package vm_test
 
-import "github.com/MontFerret/ferret/v2/pkg/runtime"
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
 
 type invalidArrayCopy struct {
 	runtime.List
@@ -8,4 +12,16 @@ type invalidArrayCopy struct {
 
 func (list *invalidArrayCopy) Copy() runtime.Value {
 	return runtime.True
+}
+
+func (list *invalidArrayCopy) New(ctx context.Context) (runtime.List, error) {
+	base, err := list.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *list
+	result.List = base
+
+	return &result, nil
 }

--- a/test/integration/vm/collection_iterable_test.go
+++ b/test/integration/vm/collection_iterable_test.go
@@ -1,0 +1,43 @@
+package vm_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	collectionIterable struct {
+		values *runtime.Array
+	}
+	ownedCollectionList struct {
+		*runtime.Array
+		created *ownedCollectionList
+		backend string
+		closes  int
+	}
+)
+
+func (s *collectionIterable) String() string      { return "read-only collection source" }
+func (s *collectionIterable) Hash() uint64        { return 1 }
+func (s *collectionIterable) Copy() runtime.Value { return s }
+func (s *collectionIterable) Iterate(ctx context.Context) (runtime.Iterator, error) {
+	return s.values.Iterate(ctx)
+}
+
+func (l *ownedCollectionList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	l.created = &ownedCollectionList{Array: base.(*runtime.Array), backend: l.backend}
+
+	return l.created, nil
+}
+
+func (l *ownedCollectionList) Close() error {
+	l.closes++
+
+	return nil
+}

--- a/test/integration/vm/collection_map_test.go
+++ b/test/integration/vm/collection_map_test.go
@@ -1,0 +1,62 @@
+package vm_test
+
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type (
+	ownedCollectionMap struct {
+		writeErr error
+		closeErr error
+		*runtime.Object
+		created *ownedCollectionMap
+		backend string
+		closes  int
+	}
+
+	measuredCollectionIterable struct {
+		*collectionIterable
+		length       runtime.Int
+		measurements int
+		iterations   int
+	}
+)
+
+func (m *ownedCollectionMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := m.Object.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.created = &ownedCollectionMap{Object: base.(*runtime.Object), backend: m.backend, writeErr: m.writeErr, closeErr: m.closeErr}
+
+	return m.created, nil
+}
+
+func (m *ownedCollectionMap) Set(ctx context.Context, key, value runtime.Value) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+
+	return m.Object.Set(ctx, key, value)
+}
+
+func (m *ownedCollectionMap) Close() error {
+	m.closes++
+
+	return m.closeErr
+}
+
+func (m *measuredCollectionIterable) Length(context.Context) (runtime.Int, error) {
+	m.measurements++
+
+	return m.length, nil
+}
+
+func (m *measuredCollectionIterable) Iterate(ctx context.Context) (runtime.Iterator, error) {
+	m.iterations++
+
+	return m.collectionIterable.Iterate(ctx)
+}

--- a/test/integration/vm/fallible_duration_list_test.go
+++ b/test/integration/vm/fallible_duration_list_test.go
@@ -35,3 +35,15 @@ func (l *fallibleDurationList) At(ctx context.Context, idx runtime.Int) (runtime
 
 	return l.Array.At(ctx, idx)
 }
+
+func (l *fallibleDurationList) New(ctx context.Context) (runtime.List, error) {
+	base, err := l.Array.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *l
+	result.Array = base.(*runtime.Array)
+
+	return &result, nil
+}

--- a/test/integration/vm/generic_map_test.go
+++ b/test/integration/vm/generic_map_test.go
@@ -1,6 +1,10 @@
 package vm_test
 
-import "github.com/MontFerret/ferret/v2/pkg/runtime"
+import (
+	"context"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
 
 type genericMap struct {
 	runtime.Map
@@ -8,4 +12,16 @@ type genericMap struct {
 
 func (genericMap) Type() runtime.Type {
 	return runtime.TypeMap
+}
+
+func (source genericMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := source.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := source
+	result.Map = base
+
+	return result, nil
 }

--- a/test/integration/vm/object_pattern_error_map_test.go
+++ b/test/integration/vm/object_pattern_error_map_test.go
@@ -1,0 +1,28 @@
+package vm_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+)
+
+type errorMap struct {
+	*runtime.Object
+}
+
+func (m *errorMap) ContainsKey(ctx context.Context, key runtime.Value) (runtime.Boolean, error) {
+	return runtime.False, errors.New("boom")
+}
+
+func (m *errorMap) New(ctx context.Context) (runtime.Map, error) {
+	base, err := m.Object.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *m
+	result.Object = base.(*runtime.Object)
+
+	return &result, nil
+}

--- a/test/integration/vm/spread_snapshot_list_test.go
+++ b/test/integration/vm/spread_snapshot_list_test.go
@@ -29,3 +29,16 @@ func (s *spreadSnapshotList) Iterate(ctx context.Context) (runtime.Iterator, err
 
 	return s.List.Iterate(ctx)
 }
+
+func (s *spreadSnapshotList) New(ctx context.Context) (runtime.List, error) {
+	base, err := s.List.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *s
+	result.List = base
+	result.snapshot = base.(*runtime.Array)
+
+	return &result, nil
+}

--- a/test/integration/vm/spread_snapshot_object_test.go
+++ b/test/integration/vm/spread_snapshot_object_test.go
@@ -29,3 +29,16 @@ func (s *spreadSnapshotObject) ForEach(ctx context.Context, predicate runtime.Ke
 
 	return s.Map.ForEach(ctx, predicate)
 }
+
+func (s *spreadSnapshotObject) New(ctx context.Context) (runtime.Map, error) {
+	base, err := s.Map.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := *s
+	result.Map = base
+	result.snapshot = base.(*runtime.Object)
+
+	return &result, nil
+}

--- a/test/integration/vm/vm_collection_contract_test.go
+++ b/test/integration/vm/vm_collection_contract_test.go
@@ -1,0 +1,62 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/MontFerret/ferret/v2/pkg/compiler"
+	"github.com/MontFerret/ferret/v2/pkg/runtime"
+	"github.com/MontFerret/ferret/v2/pkg/vm"
+	"github.com/MontFerret/ferret/v2/test/spec"
+	. "github.com/MontFerret/ferret/v2/test/spec/exec"
+)
+
+func TestCollectionContracts(t *testing.T) {
+	cases := []spec.Spec{
+		S(`return {ascending: count(1..3), descending: count(3..1), distinct: count_distinct({first: 7, second: 7.0}), present: includes("123", 123), reversed: reverse([1,2,3])} == {ascending: 3, descending: 3, distinct: 1, present: true, reversed: [3,2,1]}`, true),
+		S(`return count(1..3) == 3 and count(3..1) == 3`, true),
+		S(`return count_distinct(1..3) == 3 and count_distinct(3..1) == 3`, true),
+		S(`return count(@source) == 3 and count_distinct(@source) == 2`, true),
+		S(`return includes(@source, 2) and not includes(@source, 3)`, true),
+		S(`return count({a: 1, b: 1.0}) == 2 and count_distinct({a: 1, b: 1.0}) == 1`, true),
+		S(`return includes({key: 7}, 7) and not includes({key: 7}, "key")`, true),
+		S(`return includes("123", 123)`, true),
+		S(`return reverse("a狐犬") == "犬狐a" and reverse([1,2,3]) == [3,2,1]`, true),
+		S(`return count([]) == 0 and count_distinct({}) == 0 and reverse([]) == []`, true),
+		S(`let source = [1,2,3] let result = reverse(source) return source == [1,2,3] and result == [3,2,1]`, true),
+	}
+
+	for _, call := range []string{`count("abc")`, `count_distinct("abc")`, `count(1)`, `count_distinct(true)`, `reverse(1..3)`, `includes(1, 1)`} {
+		cases = append(cases, S("return "+call+` on error return "caught"`, "caught", call))
+	}
+
+	for _, call := range []string{"count()", "count([], [])", "count_distinct()", "count_distinct([], [])", "includes([])", "includes([], 1, 2)", "reverse()", "reverse([], [])"} {
+		cases = append(cases, spec.NewSpec("return "+call, call).Expect().ExecError(ShouldBeRuntimeError, &ExpectedRuntimeError{Message: "invalid number of arguments"}))
+	}
+
+	for _, level := range []compiler.OptimizationLevel{compiler.None, compiler.Basic, compiler.Full} {
+		c, err := compiler.New(compiler.WithOptimizationLevel(level))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		source := &collectionIterable{values: runtime.NewArrayWith(runtime.Int(1), runtime.Int(2), runtime.Float(2))}
+		RunSpecsWith(t, level.String(), c, cases, vm.WithParam("source", source))
+	}
+}
+
+func TestReverseHostResultLifecycle(t *testing.T) {
+	for _, level := range []compiler.OptimizationLevel{compiler.None, compiler.Basic, compiler.Full} {
+		c, err := compiler.New(compiler.WithOptimizationLevel(level))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		source := &ownedCollectionList{Array: runtime.NewArrayWith(runtime.Int(1), runtime.Int(2), runtime.Int(3)), backend: "host storage"}
+		RunSpecsWith(t, level.String(), c, []spec.Spec{
+			S(`return reverse(@source)`, []any{float64(3), float64(2), float64(1)}),
+		}, vm.WithParam("source", source))
+		if source.closes != 0 || source.created == nil || source.created.backend != source.backend || source.created.closes != 1 {
+			t.Fatalf("result ownership: source closes %d, destination %+v", source.closes, source.created)
+		}
+	}
+}

--- a/test/integration/vm/vm_collection_contract_test.go
+++ b/test/integration/vm/vm_collection_contract_test.go
@@ -1,6 +1,9 @@
 package vm_test
 
 import (
+	"errors"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/compiler"
@@ -41,6 +44,73 @@ func TestCollectionContracts(t *testing.T) {
 
 		source := &collectionIterable{values: runtime.NewArrayWith(runtime.Int(1), runtime.Int(2), runtime.Float(2))}
 		RunSpecsWith(t, level.String(), c, cases, vm.WithParam("source", source))
+	}
+}
+
+func TestMeasuredCollectionCountContracts(t *testing.T) {
+	for _, level := range []compiler.OptimizationLevel{compiler.None, compiler.Basic, compiler.Full} {
+		for _, length := range []runtime.Int{-1, math.MinInt64, 0, 42} {
+			t.Run(fmt.Sprintf("%s/length=%d", level, length), func(t *testing.T) {
+				c, err := compiler.New(compiler.WithOptimizationLevel(level))
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				source := &measuredCollectionIterable{collectionIterable: &collectionIterable{values: runtime.NewArray(0)}, length: length}
+				test := S(`return count(@source)`, float64(length))
+				if length < 0 {
+					test = spec.NewSpec(`return count(@source)`).Expect().ExecError(func(t *testing.T, actual any, _ ...any) {
+						t.Helper()
+
+						err, ok := actual.(error)
+						if !ok || !errors.Is(err, runtime.ErrInvalidOperation) {
+							t.Fatalf("negative measurement error lost: %v", actual)
+						}
+					})
+				}
+
+				RunSpecsWith(t, level.String(), c, []spec.Spec{test}, vm.WithParam("source", source))
+				if source.measurements != 1 || source.iterations != 0 {
+					t.Fatalf("unexpected host work: %+v", source)
+				}
+			})
+		}
+	}
+}
+
+func TestImmutableMergeHostResultLifecycle(t *testing.T) {
+	for _, level := range []compiler.OptimizationLevel{compiler.None, compiler.Basic, compiler.Full} {
+		for _, function := range []string{"object::merge", "object::merge_deep"} {
+			for _, fail := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/fail=%v", level, function, fail), func(t *testing.T) {
+					c, err := compiler.New(compiler.WithOptimizationLevel(level))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					primary, cleanup := errors.New("host population failed"), errors.New("host cleanup failed")
+					source := &ownedCollectionMap{Object: runtime.NewObjectWith(map[string]runtime.Value{"key": runtime.Int(1)}), backend: "host storage"}
+					query := "return " + function + "(@source)"
+					test := S(query, map[string]any{"key": float64(1)})
+					if fail {
+						source.writeErr, source.closeErr = primary, cleanup
+						test = spec.NewSpec(query).Expect().ExecError(func(t *testing.T, actual any, _ ...any) {
+							t.Helper()
+
+							err, ok := actual.(error)
+							if !ok || !errors.Is(err, primary) || !errors.Is(err, cleanup) {
+								t.Fatalf("host error identities lost: %v (primary=%v, cleanup=%v)", actual, errors.Is(err, primary), errors.Is(err, cleanup))
+							}
+						})
+					}
+
+					RunSpecsWith(t, level.String(), c, []spec.Spec{test}, vm.WithParam("source", source))
+					if source.closes != 0 || source.created == nil || source.created.closes != 1 || source.created.backend != source.backend || source.String() != `{"key":1}` {
+						t.Fatalf("result ownership: source closes %d, destination %+v", source.closes, source.created)
+					}
+				})
+			}
+		}
 	}
 }
 

--- a/test/integration/vm/vm_match_object_pattern_error_test.go
+++ b/test/integration/vm/vm_match_object_pattern_error_test.go
@@ -1,8 +1,6 @@
 package vm_test
 
 import (
-	"context"
-	"errors"
 	"testing"
 
 	"github.com/MontFerret/ferret/v2/pkg/runtime"
@@ -10,14 +8,6 @@ import (
 	"github.com/MontFerret/ferret/v2/test/spec"
 	. "github.com/MontFerret/ferret/v2/test/spec/exec"
 )
-
-type errorMap struct {
-	*runtime.Object
-}
-
-func (m *errorMap) ContainsKey(ctx context.Context, key runtime.Value) (runtime.Boolean, error) {
-	return runtime.False, errors.New("boom")
-}
 
 func TestMatchObjectPatternContainsKeyError(t *testing.T) {
 	RunSpecs(t, []spec.Spec{

--- a/tools/apiref/internal/analyzer/collections_test.go
+++ b/tools/apiref/internal/analyzer/collections_test.go
@@ -1,0 +1,85 @@
+package analyzer_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MontFerret/specs/pkg/api"
+)
+
+func assertCollectionMetadata(t *testing.T, reference *api.Reference) {
+	t.Helper()
+
+	want := map[string][]string{
+		"count":          {"Iterable"},
+		"count_distinct": {"Iterable"},
+		"includes":       {"String", "Containable", "Iterable"},
+		"reverse":        {"String", "List"},
+	}
+
+	for _, namespace := range reference.Namespaces {
+		if namespace.Name != "" {
+			continue
+		}
+
+		for _, function := range namespace.Functions {
+			expected, ok := want[function.Name]
+			if !ok {
+				continue
+			}
+
+			if len(function.Signatures) != 1 {
+				t.Fatalf("%s overloads: %v", function.Name, function.Signatures)
+			}
+
+			signature := function.Signatures[0]
+			arity := 1
+			if function.Name == "includes" {
+				arity = 2
+			}
+
+			if len(signature.Parameters) != arity || signature.Variadic {
+				t.Fatalf("%s arity changed", function.Name)
+			}
+
+			parameter := signature.Parameters[0].Type
+			actual := []string{parameter.Name}
+			if parameter.Kind == api.TypeKindUnion {
+				actual = nil
+				for _, member := range parameter.Types {
+					actual = append(actual, member.Name)
+				}
+			}
+
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("%s accepts %v; want %v", function.Name, actual, expected)
+			}
+
+			if function.Name == "reverse" {
+				actual = nil
+				for _, member := range signature.Return.Type.Types {
+					actual = append(actual, member.Name)
+				}
+
+				if !reflect.DeepEqual(actual, expected) {
+					t.Fatalf("reverse return type: %v", actual)
+				}
+			} else {
+				result := "Int"
+				if function.Name == "includes" {
+					result = "Boolean"
+				}
+
+				if signature.Return.Type.Name != result {
+					t.Fatalf("%s return type changed", function.Name)
+				}
+			}
+
+			delete(want, function.Name)
+		}
+	}
+
+	if len(want) != 0 {
+		t.Fatalf("missing functions: %v", want)
+	}
+}

--- a/tools/apiref/internal/analyzer/real_test.go
+++ b/tools/apiref/internal/analyzer/real_test.go
@@ -69,6 +69,7 @@ func TestGenerateMatchesFullRuntimeRegistryAndIsDeterministic(t *testing.T) {
 	assertMutableObjectMetadata(t, first.Reference, first.Catalog)
 	assertObjectCompatibilityMetadata(t, first.Reference, first.Catalog)
 	assertArrayMetadata(t, first.Reference, first.Catalog)
+	assertCollectionMetadata(t, first.Reference)
 }
 
 func assertMutableObjectMetadata(t *testing.T, reference *api.Reference, catalog *apicatalog.Catalog) {


### PR DESCRIPTION
Collection construction now uses `runtime.Factory[T Collection].New(context.Context) (T, error)`. This intentionally breaks the Go `Spawnable[T].Empty` contract without a compatibility alias: List/Map implementers and callers must migrate to `New`. Factories return independent empty collections preserving implementation family and relevant configuration. Ownership transfers only on success; factories release failed construction and preserve construction plus cleanup errors.

`count` and `count_distinct` accept read-only iterables, including ranges and map values. Measurable counting remains authoritative and never falls back after a length error. Canonical equality, string-needle coercion, FQL names, and arities are preserved. Fallback `includes` uses `runtime.ForEach` for exclusive iterator ownership. Global list reversal constructs through the source factory, preserves shallow references and custom implementations, checks destination writes, and closes failed results.

Immutable shallow/deep object merge now closes its incomplete closable destination after successful construction if population or cancellation fails, preserving attributed primary and cleanup errors. Successful results transfer normally; sources and mutable targets remain borrowed. Negative measured counts fail with `ErrInvalidOperation` and zero result without traversal, retaining concurrent cancellation. A necessary VM diagnostic fix preserves cleanup errors joined beside attributed errors while keeping ordinary normalized causes and diagnostic presentation unchanged.

Validation completed:
- Focused runtime, collections, objects, and VM diagnostic tests, including regressions that failed against the baseline.
- Host measurement and merge-result lifecycle coverage through FQL under None, Basic, and Full optimization.
- Full `make test` (unit/race, integration/race, security), `make fmt`, `make lint`, `make compile`, and final diff/self-review.
- Lint with repository-pinned tools under Go 1.25.14; corrected the exact redundant-context declaration reported by the PR-triggered Static Analysis failure.
- The complete [PR-triggered build workflow](https://github.com/MontFerret/ferret/actions/runs/34647163427) passed, including Go 1.25/1.26/1.27 builds, race tests, and security tests.
- The PR-triggered [Static Analysis check](https://github.com/MontFerret/ferret/actions/runs/34647163427/job/103420597810) passed on final commit `0c5add74`.
- `GOWORK=off go -C tools/apiref test ./internal/analyzer` and temporary API Reference/Catalog generation.
- Contributor documentation and sibling website host-value/collection/object-migration documentation updated; website `mage build` passed. Existing website edits are preserved; website changes remain in the local sibling checkout for separate commit/publication. Generated public references await normal release publication; release pins are unchanged.

Focused performance comparison against `61ad13c8`: Go 1.26.5, Apple M2 Max, darwin/arm64; baseline binaries saved before production edits; eight alternating baseline/current rounds, `-pgo=off`, `-benchmem`, `-benchtime=100ms`, analyzed with `benchstat`.

| Case | Before | After | Result |
| --- | ---: | ---: | --- |
| Native measured count, 1,024 values | 12.62 ns | 13.28 ns | +5.31%, p=0.028 |
| Host measured count, 1,024 values | 13.56 ns | 13.72 ns | No significant difference |
| Native shallow merge | 793.6 ns | 809.4 ns | No significant difference |
| Native deep merge | 746.4 ns | 765.4 ns | No significant difference |

All eight configured closable-map merge cases (0, 1, 16, 1,024 entries; shallow/deep) had no significant timing change. Allocation counts were identical across all 44 cases, and bytes/op showed no significant change. Small reused-context counts add roughly 0.3–0.5 ns; fresh-Background variants add roughly 1.5–1.9 ns (11–21%). Fresh cancellable-context differences were insignificant. Compiler assembly confirms the added error/numeric-sign checks and error construction only on the invalid path; no iterator/channel allocation was added.

The [previous hosted benchmark comparison](https://github.com/MontFerret/ferret/actions/runs/34632506484) timed out after 20 minutes in unrelated array benchmarks and never completed comparison. Benchmark workflow repair remains separate by agreement; the completed focused comparisons above are the performance evidence for this follow-up.
